### PR TITLE
Update Help and About Buttons

### DIFF
--- a/src/components/Header/components/GlobalMenu/index.js
+++ b/src/components/Header/components/GlobalMenu/index.js
@@ -51,12 +51,12 @@ export default class GordonGlobalMenu extends Component {
           onRequestClose={this.onClose}
         >
           <MenuItem onClick={this.onSignOut}>Sign out</MenuItem>
-          <MenuItem onClick={this.onClose}>
-            <Link to="/help">Help</Link>
-          </MenuItem>
-          <MenuItem onClick={this.onClose}>
-            <Link to="/about">About</Link>
-          </MenuItem>
+          <Link to="/help">
+            <MenuItem onClick={this.onClose}>Help</MenuItem>
+          </Link>
+          <Link to="/about">
+            <MenuItem onClick={this.onClose}>About</MenuItem>
+          </Link>
         </Menu>
       </span>
     );

--- a/src/views/Home/components/DaysLeft/index.js
+++ b/src/views/Home/components/DaysLeft/index.js
@@ -41,7 +41,7 @@ export default class DaysLeft extends Component {
     if (this.state.loading === true) {
       content = <GordonLoader />;
     } else {
-      const daysleft = this.state.daysLeft[0] < 0 ? 0 : this.state.daysLeft;
+      const daysleft = this.state.daysLeft[0];
       const pastDays = this.state.daysLeft[1] - daysleft;
       const data = {
         datasets: [{ data: [pastDays, daysleft], backgroundColor: [gordonColors.primary.blue] }],

--- a/src/views/Home/components/DaysLeft/index.js
+++ b/src/views/Home/components/DaysLeft/index.js
@@ -41,7 +41,7 @@ export default class DaysLeft extends Component {
     if (this.state.loading === true) {
       content = <GordonLoader />;
     } else {
-      const daysleft = this.state.daysLeft[0];
+      const daysleft = this.state.daysLeft[0] < 0 ? 0 : this.state.daysLeft;
       const pastDays = this.state.daysLeft[1] - daysleft;
       const data = {
         datasets: [{ data: [pastDays, daysleft], backgroundColor: [gordonColors.primary.blue] }],


### PR DESCRIPTION
Menu Items for 'Help' and 'About' only navigated to those pages if the text was directly clicked, not the actual button. I changed it so that the whole button is a link instead of just the text.