### PR TITLE
Center search bar over events list

### DIFF
--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -13,6 +13,12 @@ import gordonEvent from './../../services/event';
 import EventItem from './components/EventItem';
 import GordonLoader from '../../components/Loader';
 
+const styles = {
+  searchBar: {
+    margin: '0 auto',
+  },
+};
+
 export default class Events extends Component {
   constructor(props) {
     super(props);
@@ -76,23 +82,26 @@ export default class Events extends Component {
     return (
       <section>
         <Grid container justify="center">
-          <Grid container alignItems="baseline" justify="center">
-            <Grid item xs={8} md={10} lg={5}>
-              <TextField
-                id="search"
-                label="Search"
-                value={this.state.search}
-                onChange={this.search('search')}
-                margin="none"
-                fullWidth
-              />
-            </Grid>
-            <Grid item xs={4} md={2} lg={3}>
-              <Button raised color="primary" onClick={this.handleExpandClick}>
-                Filters
-              </Button>
+          <Grid item xs={12} md={12} lg={8}>
+            <Grid container alignItems="baseline" style={styles.searchBar}>
+              <Grid item xs={8} sm={9} md={10} lg={10}>
+                <TextField
+                  id="search"
+                  label="Search"
+                  value={this.state.search}
+                  onChange={this.search('search')}
+                  margin="none"
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={4} sm={3} md={2} lg={2}>
+                <Button raised color="primary" onClick={this.handleExpandClick}>
+                  Filters
+                </Button>
+              </Grid>
             </Grid>
           </Grid>
+
           <Grid item xs={11} md={12} lg={8}>
             <Collapse in={this.state.open} timeout="auto" unmountOnExit>
               <FormGroup row>


### PR DESCRIPTION
I changed the positioning of the search bar on the events page. Now, there is a small margin from the left edge of the events list so that the search bar position seems a bit more natural. It also no longer sticks to the left side of the page when being viewed on a mobile device.

Before - Desktop:
![search_bar_uncentered_desktop](https://user-images.githubusercontent.com/5964594/41480339-288b69c8-709c-11e8-834c-476e4e54e299.PNG)

After - Desktop:
![search_bar_centered_desktop](https://user-images.githubusercontent.com/5964594/41480349-30cc07fa-709c-11e8-904a-30fcd8766f3d.PNG)

Before - Mobile:
![search_bar_uncentered_mobile](https://user-images.githubusercontent.com/5964594/41480358-36c75db2-709c-11e8-83dd-c1ae8fbf139b.PNG)

After - Mobile:
![search_bar_centered_mobile](https://user-images.githubusercontent.com/5964594/41480362-3c578f4a-709c-11e8-8684-8ec27b5b8952.PNG)
