### PR TITLE
removed carousel from card, removed status, enabled keyboard

### DIFF
--- a/src/views/Home/components/Carousel/index.js
+++ b/src/views/Home/components/Carousel/index.js
@@ -1,4 +1,3 @@
-import Card, { CardContent } from 'material-ui/Card';
 import React, { Component } from 'react';
 import { Carousel } from 'react-responsive-carousel';
 
@@ -47,6 +46,8 @@ export default class GordonCarousel extends Component {
           infiniteLoop
           transitionTime={1000}
           interval={10000}
+          showStatus={false}
+          useKeyboardArrows={true}
         >
           {this.state.carouselContent.map(slide => (
             <div>
@@ -56,10 +57,6 @@ export default class GordonCarousel extends Component {
         </Carousel>
       );
     }
-    return (
-      <Card>
-        <CardContent>{content}</CardContent>
-      </Card>
-    );
+    return <div>{content}</div>;
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7535545/41796476-b4effed6-7634-11e8-8370-cd3c593af0e7.png)

I made some minor tweaks to the home carousel. I removed it from the card, and removed the 1/2 status from the top right (it was kind of redundant as there are circle indicators in the bottom center). I also enabled using the left/right keys to step through the carousel slides.