### PR TITLE
Remove white box from search bar

### DIFF
--- a/src/components/Header/components/PeopleSearch/people-search.scss
+++ b/src/components/Header/components/PeopleSearch/people-search.scss
@@ -15,21 +15,19 @@
     color: inherit;
   }
 
-  .people-search-inkbar {
-    &::after {
-      background-color: $neutral-white;
-    }
-  }
-
   .people-search-underline {
+    &::after {
+      border-bottom-color: $neutral-white;
+    }
+
     &::before {
-      background-color: $neutral-white;
+      border-bottom-color: $neutral-white;
     }
 
     &:hover {
       &:not(.people-search-disabled) {
         &::before {
-          background-color: $neutral-white;
+          border-bottom-color: $neutral-white;
         }
       }
     }


### PR DESCRIPTION
Looks better than it did, but the old way of setting the underline color on hover no longer works. The code is still in the SCSS file, but it has no effect.

From the little bit of Google searching I did, it looks like setting that attribute no longer works through CSS but can only be done using a Material-UI Theme override. I'm not sure about this though.