### PR TITLE
Replace CL&W credit chart title with description of current term

### DIFF
--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -23,6 +23,7 @@ export default class CLWCreditsDaysLeft extends Component {
       chapelCredits: {},
       error: null,
       loading: true,
+      currSessionDescription: '',
     };
   }
 
@@ -35,9 +36,12 @@ export default class CLWCreditsDaysLeft extends Component {
     try {
       const daysLeftPromise = session.getDaysLeft();
       const chapelCreditsPromise = user.getChapelCredits();
+      const currSessionPromise = session.getCurrent();
       const daysLeft = await daysLeftPromise;
       const chapelCredits = await chapelCreditsPromise;
-      this.setState({ loading: false, daysLeft, chapelCredits });
+      const currSession = await currSessionPromise;
+      const currSessionDescription = currSession.SessionDescription;
+      this.setState({ loading: false, daysLeft, chapelCredits, currSessionDescription });
     } catch (error) {
       this.setState({ error });
     }
@@ -136,7 +140,7 @@ export default class CLWCreditsDaysLeft extends Component {
       <Card>
         <CardContent>
           <Typography variant="headline" style={{ textAlign: 'center', paddingTop: 5 }}>
-            Christian Life & Worship Credits
+            {this.state.currSessionDescription}
           </Typography>
           {content}
         </CardContent>


### PR DESCRIPTION
...as suggested by Dr. Tuck.

**Note**: If run using the release server (360Api), the title is "Summer 2018" as expected, but if run using the development/train server (360ApiTrain), the title is "Spring 17-18 Academic Year". This is identical to the behavior of the charts on [360.gordon.edu](https://360.gordon.edu) vs. [360train.gordon.edu](https://360train.gordon.edu) and is not an issue with the front-end code.