### PR TITLE
Update photo button

### DIFF
--- a/src/views/MyProfile/index.js
+++ b/src/views/MyProfile/index.js
@@ -16,6 +16,9 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import ButtonBase from '@material-ui/core/ButtonBase';
+import GridList from '@material-ui/core/GridList';
+import GridListTile from '@material-ui/core/GridListTile';
+import GridListTileBar from '@material-ui/core/GridListTileBar';
 
 import user from './../../services/user';
 import { gordonColors } from '../../theme';
@@ -24,10 +27,10 @@ import LinksDialog from './Components/LinksDialog';
 import GordonLoader from './../../components/Loader';
 import { socialMediaInfo } from '../../socialMedia';
 
+import './profileButton.css';
 import Cropper from 'react-cropper';
 import 'cropperjs/dist/cropper.css';
 import Switch from '@material-ui/core/Switch';
-import { createMuiTheme } from '@material-ui/core';
 
 const CROP_DIM = 200; // pixels
 
@@ -256,41 +259,6 @@ export default class Profile extends Component {
         background: gordonColors.primary.cyan,
         color: 'white',
       },
-
-      image: {
-        position: 'relative',
-        opacity: 1,
-        backgroundColor: 'black',
-        height: 200,
-        width: 200,
-      },
-      imageText: {
-        position: 'absolute',
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        color: 'white',
-        opacity: 1,
-        padding: '20px',
-      },
-      imageBackdrop: {
-        position: 'absolute',
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-        backgroundColor: 'black',
-        opacity: 0,
-        height: 200,
-        width: 200,
-        '&:hover': {
-          opacity: 1,
-        },
-      },
     };
 
     const photoUploader = {
@@ -496,171 +464,175 @@ export default class Profile extends Component {
           <Grid item xs={12} lg={10}>
             <Card id="print">
               <CardContent>
-                <Grid container justify="center" spacing="16">
-                  <Grid item xs={6} sm={6} md={6} lg={4}>
+                <Grid container alignItems="center" align="center" justify="center" spacing="16">
+                  <Grid item xs={12} sm={6} md={6} lg={4}>
                     <ButtonBase
                       onClick={this.handlePhotoOpen}
                       focusRipple
                       alt=""
-                      style={style.image}
+                      className="profile-image"
                     >
                       <img src={`data:image/jpg;base64,${this.state.image}`} alt="Profile Photo" />
-                      <span style={style.imageBackdrop} />
-                      <Typography component="span" variant="subheading" style={style.imageText}>
-                        Update Photo
-                      </Typography>
+                      <span className="imageBackdrop" />
+                      <GridListTileBar className="tile-bar" title="Update Photo" />
                     </ButtonBase>
                   </Grid>
-
-                  <Grid item xs={6} sm={6} md={6} lg={4}>
-                    <CardHeader
-                      title={this.state.profile.fullName}
-                      subheader={this.state.profile.Class}
-                    />
-                    <Grid container spacing="16">
-                      {facebookButton}
-                      {twitterButton}
-                      {linkedInButton}
-                      {instagramButton}
-                      {editButton}
-                    </Grid>
-                    <Dialog
-                      open={this.state.photoOpen}
-                      keepMounted
-                      onClose={this.handleClose}
-                      aria-labelledby="alert-dialog-slide-title"
-                      aria-describedby="alert-dialog-slide-description"
-                      maxWidth="false"
-                    >
-                      <DialogTitle id="simple-dialog-title">Update Profile Picture</DialogTitle>
-                      <DialogContent>
-                        <DialogContentText>
-                          Drag &amp; Drop Picture, or Click to Browse Files
-                        </DialogContentText>
-                        <DialogContentText>
-                          <br />
-                        </DialogContentText>
-                        {!preview && (
-                          <Dropzone
-                            onDropAccepted={this.onDropAccepted.bind(this)}
-                            onDropRejected={this.onDropRejected.bind(this)}
-                            accept="image/jpeg,image/jpg,image/png"
-                            style={photoUploader}
-                          >
+                  <Grid item xs={12} sm={6} md={6} lg={4}>
+                    <Grid container align="center" alignItems="center">
+                      <Grid item xs={12}>
+                        <CardHeader
+                          title={this.state.profile.fullName}
+                          subheader={this.state.profile.Class}
+                        />
+                      </Grid>
+                      <Grid container spacing="16" align="center" justify="center">
+                        {facebookButton}
+                        {twitterButton}
+                        {linkedInButton}
+                        {instagramButton}
+                        {editButton}
+                      </Grid>
+                      <Dialog
+                        open={this.state.photoOpen}
+                        keepMounted
+                        onClose={this.handleClose}
+                        aria-labelledby="alert-dialog-slide-title"
+                        aria-describedby="alert-dialog-slide-description"
+                        maxWidth="false"
+                      >
+                        <DialogTitle id="simple-dialog-title">Update Profile Picture</DialogTitle>
+                        <DialogContent>
+                          <DialogContentText>
+                            Drag &amp; Drop Picture, or Click to Browse Files
+                          </DialogContentText>
+                          <DialogContentText>
+                            <br />
+                          </DialogContentText>
+                          {!preview && (
+                            <Dropzone
+                              onDropAccepted={this.onDropAccepted.bind(this)}
+                              onDropRejected={this.onDropRejected.bind(this)}
+                              accept="image/jpeg,image/jpg,image/png"
+                              style={photoUploader}
+                            >
+                              <Grid container justify="center" spacing="16">
+                                <img
+                                  src={require('./image.png')}
+                                  alt=""
+                                  style={{ 'max-width': '100%' }}
+                                />
+                              </Grid>
+                            </Dropzone>
+                          )}
+                          {preview && (
                             <Grid container justify="center" spacing="16">
-                              <img
-                                src={require('./image.png')}
-                                alt=""
-                                style={{ 'max-width': '100%' }}
+                              <Cropper
+                                ref="cropper"
+                                src={preview}
+                                style={{
+                                  'max-width': this.maxCropPreviewWidth(),
+                                  'max-height':
+                                    this.maxCropPreviewWidth() / this.state.cropperData.aspectRatio,
+                                }}
+                                autoCropArea={1}
+                                viewMode={3}
+                                aspectRatio={1}
+                                highlight={false}
+                                background={false}
+                                zoom={this.onCropperZoom.bind(this)}
+                                zoomable={false}
+                                dragMode={'none'}
+                                minCropBoxWidth={this.state.cropperData.cropBoxDim}
+                                minCropBoxHeight={this.state.cropperData.cropBoxDim}
                               />
                             </Grid>
-                          </Dropzone>
-                        )}
-                        {preview && (
-                          <Grid container justify="center" spacing="16">
-                            <Cropper
-                              ref="cropper"
-                              src={preview}
-                              style={{
-                                'max-width': this.maxCropPreviewWidth(),
-                                'max-height':
-                                  this.maxCropPreviewWidth() / this.state.cropperData.aspectRatio,
-                              }}
-                              autoCropArea={1}
-                              viewMode={3}
-                              aspectRatio={1}
-                              highlight={false}
-                              background={false}
-                              zoom={this.onCropperZoom.bind(this)}
-                              zoomable={false}
-                              dragMode={'none'}
-                              minCropBoxWidth={this.state.cropperData.cropBoxDim}
-                              minCropBoxHeight={this.state.cropperData.cropBoxDim}
-                            />
-                          </Grid>
-                        )}
-                        {preview && <br />}
-                        {preview && (
-                          <Grid container justify="center" spacing="16">
-                            <Grid item>
-                              <Button
-                                onClick={() => this.setState({ preview: null })}
-                                raised
-                                style={style.button}
-                              >
-                                Choose Another Image
-                              </Button>
+                          )}
+                          {preview && <br />}
+                          {preview && (
+                            <Grid container justify="center" spacing="16">
+                              <Grid item>
+                                <Button
+                                  onClick={() => this.setState({ preview: null })}
+                                  raised
+                                  style={style.button}
+                                >
+                                  Choose Another Image
+                                </Button>
+                              </Grid>
                             </Grid>
-                          </Grid>
-                        )}
-                      </DialogContent>
-                      <DialogActions>
-                        <Grid container spacing={8} justify="flex-end">
-                          <Grid item>
-                            <Tooltip
-                              id="tooltip-hide"
-                              title={
-                                this.state.isImagePublic
-                                  ? 'Only faculty and police will see your photo'
-                                  : 'Make photo visible to other students'
-                              }
-                            >
-                              <Button
-                                onClick={this.toggleImagePrivacy.bind(this)}
-                                raised
-                                style={style.button}
-                              >
-                                {this.state.isImagePublic ? 'Hide' : 'Show'}
-                              </Button>
-                            </Tooltip>
-                          </Grid>
-                          <Grid item>
-                            <Tooltip id="tooltip-reset" title="Restore your original ID photo">
-                              <Button
-                                onClick={this.handleResetImage}
-                                raised
-                                style={{ background: 'tomato', color: 'white' }}
-                              >
-                                Reset
-                              </Button>
-                            </Tooltip>
-                          </Grid>
-                          <Grid item>
-                            <Button onClick={this.handleCloseCancel} raised style={style.button}>
-                              Cancel
-                            </Button>
-                          </Grid>
-                          <Grid item>
-                            <Tooltip id="tooltip-submit" title="Crop to current region and submit">
-                              <Button
-                                onClick={this.handleCloseSubmit}
-                                raised
-                                disabled={!this.state.preview}
-                                style={
-                                  this.state.preview
-                                    ? style.button
-                                    : { background: 'darkgray', color: 'white' }
+                          )}
+                        </DialogContent>
+                        <DialogActions>
+                          <Grid container spacing={8} justify="flex-end">
+                            <Grid item>
+                              <Tooltip
+                                id="tooltip-hide"
+                                title={
+                                  this.state.isImagePublic
+                                    ? 'Only faculty and police will see your photo'
+                                    : 'Make photo visible to other students'
                                 }
                               >
-                                Submit
+                                <Button
+                                  onClick={this.toggleImagePrivacy.bind(this)}
+                                  raised
+                                  style={style.button}
+                                >
+                                  {this.state.isImagePublic ? 'Hide' : 'Show'}
+                                </Button>
+                              </Tooltip>
+                            </Grid>
+                            <Grid item>
+                              <Tooltip id="tooltip-reset" title="Restore your original ID photo">
+                                <Button
+                                  onClick={this.handleResetImage}
+                                  raised
+                                  style={{ background: 'tomato', color: 'white' }}
+                                >
+                                  Reset
+                                </Button>
+                              </Tooltip>
+                            </Grid>
+                            <Grid item>
+                              <Button onClick={this.handleCloseCancel} raised style={style.button}>
+                                Cancel
                               </Button>
-                            </Tooltip>
+                            </Grid>
+                            <Grid item>
+                              <Tooltip
+                                id="tooltip-submit"
+                                title="Crop to current region and submit"
+                              >
+                                <Button
+                                  onClick={this.handleCloseSubmit}
+                                  raised
+                                  disabled={!this.state.preview}
+                                  style={
+                                    this.state.preview
+                                      ? style.button
+                                      : { background: 'darkgray', color: 'white' }
+                                  }
+                                >
+                                  Submit
+                                </Button>
+                              </Tooltip>
+                            </Grid>
                           </Grid>
-                        </Grid>
-                      </DialogActions>
-                    </Dialog>
-                    <Dialog
-                      open={this.state.socialLinksOpen}
-                      keepMounted
-                      onClose={this.handleSocialLinksClose}
-                      aria-labelledby="alert-dialog-slide-title"
-                      aria-describedby="alert-dialog-slide-description"
-                    >
-                      <DialogTitle id="simple-dialog-title">
-                        Edit your social media links
-                      </DialogTitle>
-                      <DialogContent>{linksDialog}</DialogContent>
-                    </Dialog>
+                        </DialogActions>
+                      </Dialog>
+                      <Dialog
+                        open={this.state.socialLinksOpen}
+                        keepMounted
+                        onClose={this.handleSocialLinksClose}
+                        aria-labelledby="alert-dialog-slide-title"
+                        aria-describedby="alert-dialog-slide-description"
+                      >
+                        <DialogTitle id="simple-dialog-title">
+                          Edit your social media links
+                        </DialogTitle>
+                        <DialogContent>{linksDialog}</DialogContent>
+                      </Dialog>
+                    </Grid>
                   </Grid>
                 </Grid>
               </CardContent>

--- a/src/views/MyProfile/index.js
+++ b/src/views/MyProfile/index.js
@@ -16,8 +16,6 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import ButtonBase from '@material-ui/core/ButtonBase';
-import GridList from '@material-ui/core/GridList';
-import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';
 
 import user from './../../services/user';
@@ -472,7 +470,7 @@ export default class Profile extends Component {
                       alt=""
                       className="profile-image"
                     >
-                      <img src={`data:image/jpg;base64,${this.state.image}`} alt="Profile Photo" />
+                      <img src={`data:image/jpg;base64,${this.state.image}`} alt="Profile" />
                       <span className="imageBackdrop" />
                       <GridListTileBar className="tile-bar" title="Update Photo" />
                     </ButtonBase>

--- a/src/views/MyProfile/index.js
+++ b/src/views/MyProfile/index.js
@@ -15,6 +15,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import ButtonBase from '@material-ui/core/ButtonBase';
 
 import user from './../../services/user';
 import { gordonColors } from '../../theme';
@@ -26,6 +27,7 @@ import { socialMediaInfo } from '../../socialMedia';
 import Cropper from 'react-cropper';
 import 'cropperjs/dist/cropper.css';
 import Switch from '@material-ui/core/Switch';
+import { createMuiTheme } from '@material-ui/core';
 
 const CROP_DIM = 200; // pixels
 
@@ -254,6 +256,41 @@ export default class Profile extends Component {
         background: gordonColors.primary.cyan,
         color: 'white',
       },
+
+      image: {
+        position: 'relative',
+        opacity: 1,
+        backgroundColor: 'black',
+        height: 200,
+        width: 200,
+      },
+      imageText: {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'white',
+        opacity: 1,
+        padding: '20px',
+      },
+      imageBackdrop: {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        backgroundColor: 'black',
+        opacity: 0,
+        height: 200,
+        width: 200,
+        '&:hover': {
+          opacity: 1,
+        },
+      },
     };
 
     const photoUploader = {
@@ -461,11 +498,18 @@ export default class Profile extends Component {
               <CardContent>
                 <Grid container justify="center" spacing="16">
                   <Grid item xs={6} sm={6} md={6} lg={4}>
-                    <img
-                      src={`data:image/jpg;base64,${this.state.image}`}
+                    <ButtonBase
+                      onClick={this.handlePhotoOpen}
+                      focusRipple
                       alt=""
-                      style={style.img}
-                    />
+                      style={style.image}
+                    >
+                      <img src={`data:image/jpg;base64,${this.state.image}`} alt="Profile Photo" />
+                      <span style={style.imageBackdrop} />
+                      <Typography component="span" variant="subheading" style={style.imageText}>
+                        Update Photo
+                      </Typography>
+                    </ButtonBase>
                   </Grid>
 
                   <Grid item xs={6} sm={6} md={6} lg={4}>
@@ -480,9 +524,6 @@ export default class Profile extends Component {
                       {instagramButton}
                       {editButton}
                     </Grid>
-                    <Button onClick={this.handlePhotoOpen} raised style={style.button}>
-                      Update Photo
-                    </Button>
                     <Dialog
                       open={this.state.photoOpen}
                       keepMounted

--- a/src/views/MyProfile/profileButton.scss
+++ b/src/views/MyProfile/profileButton.scss
@@ -1,0 +1,62 @@
+@import '../../vars';
+
+@media (min-width: $break-xs) {
+  .contact-grid {
+    align-content: center;
+    justify-content: center;
+  }
+}
+
+@media (min-width: $break-sm) {
+  .profile-image {
+    position: 'relative';
+    opacity: 1;
+    background-color: 'black';
+    height: 200;
+    width: 200;
+    .tile-bar {
+      opacity: 0; // make tile bar only visible on hover
+    }
+    &:hover {
+      .tile-bar {
+        transition: all 0.3s;
+        opacity: 1;
+        background: transparentize(
+          $neutral-dark-gray,
+          0.3
+        ); // Make titles more readable over image background
+        height: 64px; // Make space for a two-line title
+        text-align: center;
+      }
+    }
+    &:not(:hover) {
+      .tile-bar {
+        transition: all 0.3s;
+        opacity: 0;
+        background: transparentize(
+          $neutral-dark-gray,
+          0.3
+        ); // Make titles more readable over image background
+        height: 64px; // Make space for a two-line title
+        text-align: center;
+      }
+    }
+  }
+}
+@media (min-width: $break-sm) {
+  .profile-image {
+    position: 'relative';
+    opacity: 1;
+    background-color: 'black';
+    height: 200;
+    width: 200;
+  }
+  .tile-bar {
+    opacity: 1;
+    background: transparentize($neutral-dark-gray, 0.3);
+    // Make titles more readable over image background
+    height: 64px;
+    // Make space for a two-line title
+    text-align: center;
+  }
+}


### PR DESCRIPTION
The update photo button is now built into the profile image itself. Hovering over the image reveals an "update photo" label (thanks Stephen for the css help!!) On mobile (xs) this label is always visible, as there's no hover option without a mouse. 

With mouse hover:
![image](https://user-images.githubusercontent.com/7535545/42184854-ed49f9ac-7e14-11e8-9d98-ed3050815ceb.png)

No hover:
![image](https://user-images.githubusercontent.com/7535545/42184867-fc109d9c-7e14-11e8-91df-89b4424bc42e.png)

Mobile:
![image](https://user-images.githubusercontent.com/7535545/42184983-4815c19a-7e15-11e8-825b-8fc3e7e94516.png)

