### PR TITLE
Set up internal redirect to eliminate useless 404 (7)

### DIFF
--- a/iisConfig/copyIISConfig.js
+++ b/iisConfig/copyIISConfig.js
@@ -1,0 +1,9 @@
+const fs = require('fs-extra');
+
+const webConfigPath = './build/web.config';
+
+if (fs.existsSync(webConfigPath)) {
+    fs.unlinkSync(webConfigPath);
+}
+
+fs.copySync('./iisConfig/web.config', webConfigPath);

--- a/iisConfig/web.config
+++ b/iisConfig/web.config
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <rewrite>
+      <rules>
+        <rule name="React Routes" stopProcessing="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="/" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "lint": "npm-run-all --parallel --aggregate-output --silent lint-js lint-scss",
     "lint-js": "eslint --ext .js src",
     "lint-scss": "stylelint 'src/**/*.scss'",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "postbuild": "node iisConfig/copyIISConfig.js"
   },
   "lint-staged": {
     "{**/*.md,src/**/*.{js,scss}}": [


### PR DESCRIPTION
- Requires installation of URL Rewrite module in IIS Manager

The module has already been installed, so it should be good to go from here on out. There's really no easy way to add screenshots or test this locally, unless you open IIS manager, start the website, test the solution, and trust that it is actually running a production build like we said it was... (͡ ͡° ͜ つ ͡͡°)