### PR TITLE
Mask breaking changes (reverse attempt at 404 fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "lint": "npm-run-all --parallel --aggregate-output --silent lint-js lint-scss",
     "lint-js": "eslint --ext .js src",
     "lint-scss": "stylelint 'src/**/*.scss'",
-    "precommit": "lint-staged",
-    "postbuild": "node iisConfig/copyIISConfig.js"
+    "precommit": "lint-staged"
   },
   "lint-staged": {
     "{**/*.md,src/**/*.{js,scss}}": [


### PR DESCRIPTION
Changes that worked just fine locally broke the staging server.

As of the time this pull request was opened, the site was working fine, but should it ever break on rebuild (if you try to load 360newtrain and it shows a blank white screen), merge this pull request and it _should_ be remedied.

It's not a hack, it's a workaround