### PR TITLE
Added report bug to help page

### DIFF
--- a/src/views/About/index.js
+++ b/src/views/About/index.js
@@ -1,6 +1,7 @@
 import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
 import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
 
 import { gordonColors } from '../../theme';
 import './about.css';
@@ -106,9 +107,11 @@ export default class About extends Component {
                 your guidance and encouragement to try new things.
               </Typography>
             </div>
-            <Typography variant="caption" gutterBottom>
-              Found a bug?
-              <a href="mailto:cts@gordon.edu?Subject=Gordon 360 Bug"> Report to CTS</a>
+            <Typography variant="subheading" gutterBottom>
+              <br /> Found a bug?
+              <a href="mailto:cts@gordon.edu?Subject=Gordon 360 Bug">
+                <Button style={{ color: gordonColors.primary.cyan }}>Report to CTS</Button>
+              </a>
             </Typography>
           </Grid>
         </Grid>

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -134,6 +134,91 @@ export default class Events extends Component {
       );
     }
 
+    let filter;
+    if (this.state.loading === true) {
+    } else {
+      filter = (
+        <Collapse in={this.state.open} timeout="auto" unmountOnExit>
+          <FormGroup row>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={this.state.academics}
+                  onChange={this.filterEvents('academics')}
+                />
+              }
+              label="Academics"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={this.state.admissions}
+                  onChange={this.filterEvents('admissions')}
+                />
+              }
+              label="Admissions"
+            />
+            <FormControlLabel
+              control={<Checkbox checked={this.state.art} onChange={this.filterEvents('art')} />}
+              label="Arts"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox checked={this.state.sports} onChange={this.filterEvents('sports')} />
+              }
+              label="Athletics"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox checked={this.state.calendar} onChange={this.filterEvents('calendar')} />
+              }
+              label="Calendar Events"
+            />
+            <FormControlLabel
+              control={<Checkbox checked={this.state.cec} onChange={this.filterEvents('cec')} />}
+              label="CEC"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={this.state.chapelOffice}
+                  onChange={this.filterEvents('chapelOffice')}
+                />
+              }
+              label="Chapel Office"
+            />
+
+            <FormControlLabel
+              control={<Checkbox checked={this.state.fair} onChange={this.filterEvents('fair')} />}
+              label="Fair or Expos"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={this.state.studentLife}
+                  onChange={this.filterEvents('studentLife')}
+                />
+              }
+              label="Student Life"
+            />
+          </FormGroup>
+          <Divider light />
+          <FormGroup row>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={this.state.chapelCredits}
+                  onChange={this.filterEvents('chapelCredits')}
+                  aria-label="chapelCredits"
+                />
+              }
+              label="CL&W"
+            />
+          </FormGroup>
+        </Collapse>
+      );
+    }
+
     return (
       <section>
         <Grid container justify="center">
@@ -164,93 +249,7 @@ export default class Events extends Component {
           </Grid>
 
           <Grid item xs={12} md={12} lg={8}>
-            <Collapse in={this.state.open} timeout="auto" unmountOnExit>
-              <FormGroup row>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={this.state.academics}
-                      onChange={this.filterEvents('academics')}
-                    />
-                  }
-                  label="Academics"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={this.state.admissions}
-                      onChange={this.filterEvents('admissions')}
-                    />
-                  }
-                  label="Admissions"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox checked={this.state.art} onChange={this.filterEvents('art')} />
-                  }
-                  label="Arts"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox checked={this.state.sports} onChange={this.filterEvents('sports')} />
-                  }
-                  label="Athletics"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={this.state.calendar}
-                      onChange={this.filterEvents('calendar')}
-                    />
-                  }
-                  label="Calendar Events"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox checked={this.state.cec} onChange={this.filterEvents('cec')} />
-                  }
-                  label="CEC"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={this.state.chapelOffice}
-                      onChange={this.filterEvents('chapelOffice')}
-                    />
-                  }
-                  label="Chapel Office"
-                />
-
-                <FormControlLabel
-                  control={
-                    <Checkbox checked={this.state.fair} onChange={this.filterEvents('fair')} />
-                  }
-                  label="Fair or Expos"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={this.state.studentLife}
-                      onChange={this.filterEvents('studentLife')}
-                    />
-                  }
-                  label="Student Life"
-                />
-              </FormGroup>
-              <Divider light />
-              <FormGroup row>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={this.state.chapelCredits}
-                      onChange={this.filterEvents('chapelCredits')}
-                      aria-label="chapelCredits"
-                    />
-                  }
-                  label="CL&W"
-                />
-              </FormGroup>
-            </Collapse>
+            {filter}
             {content}
           </Grid>
         </Grid>

--- a/src/views/Help/index.js
+++ b/src/views/Help/index.js
@@ -1,6 +1,7 @@
 import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
 import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
 
 import { gordonColors } from '../../theme';
 import './help.css';
@@ -191,6 +192,12 @@ export default class Help extends Component {
                 Sorry, but alumni cannot join new groups. You could still subscribe to groups to
                 receive emails!
               </li>
+            </Typography>
+            <Typography variant="subheading" gutterBottom>
+              <br /> Found a bug?
+              <a href="mailto:cts@gordon.edu?Subject=Gordon 360 Bug">
+                <Button style={{ color: gordonColors.primary.cyan }}>Report to CTS</Button>
+              </a>
             </Typography>
           </Grid>
         </Grid>


### PR DESCRIPTION
Based on feedback from our user testing.
Users went to the help page first to find the report bug feature, and for some reason it was only on the about page. I made the link an uncontained button instead of just a linked text, to be consistent with the rest of the website.

![image](https://user-images.githubusercontent.com/7535545/42694234-ac229290-867f-11e8-8515-3a0d66fbcdd4.png)
