### PR TITLE
Fix hiccup in public profile image display logic

### DIFF
--- a/src/views/Profile/index.js
+++ b/src/views/Profile/index.js
@@ -232,23 +232,23 @@ export default class Profile extends Component {
                   <Grid container alignItems="center" align="center" justify="center" spacing="16">
                     <Grid container alignItems="center" spacing="16">
                       <Grid item xs={12} sm={12} md={12} lg={12}>
-                        {this.state.profile.preferred_photo !== 0 && (
+                        {this.state.prefImage && (
                           <img
                             className="rounded-corners"
                             src={`data:image/jpg;base64,${this.state.prefImage}`}
                             alt=""
                             style={{ 'max-height': '200px', 'min-width': '160px' }}
                           />
-                        )}{' '}
-                        {this.state.profile.show_pic !== 0 &&
-                          this.state.defImage !== undefined && (
-                            <img
-                              className="rounded-corners"
-                              src={`data:image/jpg;base64,${this.state.defImage}`}
-                              alt=""
-                              style={{ 'max-height': '200px', 'min-width': '160px' }}
-                            />
-                          )}
+                        )}
+                        {this.state.prefImage && this.state.defImage && ' '}
+                        {this.state.defImage && (
+                          <img
+                            className="rounded-corners"
+                            src={`data:image/jpg;base64,${this.state.defImage}`}
+                            alt=""
+                            style={{ 'max-height': '200px', 'min-width': '160px' }}
+                          />
+                        )}
                       </Grid>
                     </Grid>
                     <Grid item xs={12} sm={6} md={6} lg={4}>


### PR DESCRIPTION
Over the weekend I performed an "in-depth investigation" of the funny behavior I've been noticing with the profile images on the public profile page. The changes I've made to the code are minimal, but determining the right changes to make required a bit of testing. Here is my way-too-detailed (but hopefully clear and helpful) analysis of the problem and its solution.

**"Hiccups" with current logic**:

1. If no preferred photo has been set and a user uploads a new preferred photo, no image is displayed on the public profile page for the next ~4 minutes.

2. If a user hides his profile image, the Fighting Scot mascot is only shown for the next ~4 minutes; no image is displayed at all thereafter.

**Resolution**:

After some experimentation, I've determined the following facts about the behavior of the preferred and default profile images returned by the backend when viewing a student's public profile page.

**When logged in as a student**:

- If a preferred image is set, the default image (ID photo) is undefined.
- Regardless of whether or not a preferred image is set, if a person's image is hidden, the preferred image is undefined and the default image is changed to be the Fighting Scots mascot (rather than the ID photo).

**When logged in as faculty or staff**:

- The default image (ID photo) is always defined.
- The preferred image is defined if it exists.
- Whether or not the image is hidden is immaterial.

Our requirements for the behavior of the profile images are as follows.

**Preferred photo**:

- Will be displayed if it is set (and, if being viewed by a student, the person's profile image is not hidden)

**Default (ID) photo**:

- Will be displayed if the viewer is logged in as faculty/staff OR if the viewer is a student and a preferred photo has not been set

Since (as noted earler) the preferred photo is undefined if the profile image is hidden and the viewer is a student, and since the default image defined if the viewer is faculty OR if the viewer is a student and a profile image has not been set, we conclude that the following logic meets our above requirements: **Simply display each photo if and only if it is defined**. The fact that the backend takes care of this so nicely and makes it simple for the frontend is quite refreshing! :)