### PR TITLE
fixed duplicate time on mobile

### DIFF
--- a/src/components/EventList/index.js
+++ b/src/components/EventList/index.js
@@ -75,7 +75,7 @@ export default class EventList extends Component {
           label: 'Location',
         },
         {
-          key: 'timeRange',
+          key: 'date',
           label: 'Date',
         },
         {


### PR DESCRIPTION
Matt noticed an error on the mobile view of the Events page

Both date and time had the time showing before.

![image](https://user-images.githubusercontent.com/7535545/42898391-057145f2-8a91-11e8-9a4b-48e3a011ae2c.png)
