### PR TITLE
Make 360newtrain use "train" backend

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://360ApiTrain.gordon.edu/


### PR DESCRIPTION
Add .env.development, which I hope will be used in place of .env.production
in development mode.