### PR TITLE
New font key for development

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,8 +25,9 @@
     <meta name="description" content="Gordon 360 is the student app for Gordon College.">
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/icon-180x180.png">
 
-    <!-- Font will not work in development and will cause a 403, because the only domains allowed are *.gordon.edu -->
-    <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7763712/7294392/css/fonts.css" />
+    <!-- Different font key for development and production -->
+    <!-- Dev font key -->
+    <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/7763712/6754392/css/fonts.css" />
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
This should allow our deployed dev branch to also use the Gordon font. There is a different font key for master and develop, so we should configure the server to automatically copy the correct key instead of having a different file in GitHub for dev and master.