### PR TITLE
My current involvements section displays involvements for specified session

### DIFF
--- a/src/services/user.js
+++ b/src/services/user.js
@@ -461,6 +461,21 @@ const getCurrentMembershipsWithoutGuests = async id => {
   return myCurrentInvolvementsWithoutGuests;
 };
 
+//Take student's memberships and filter for specifiied session only, omit the memberships that are just 'Guest'
+const getSessionMembershipsWithoutGuests = async (id, session) => {
+  let myInvolvements = await getMembershipsAlphabetically(id);
+  let myCurrentInvolvementsWithoutGuests = [];
+  for (let i = 0; i < myInvolvements.length; i += 1) {
+    if (
+      myInvolvements[i].SessionCode === session &&
+      !(myInvolvements[i].ParticipationDescription === 'Guest')
+    ) {
+      myCurrentInvolvementsWithoutGuests.push(myInvolvements[i]);
+    }
+  }
+  return myCurrentInvolvementsWithoutGuests;
+};
+
 /**
  * Get requests sent by a specific student
  * @param {String} id Identifier for student
@@ -581,6 +596,7 @@ export default {
   getMembershipsAlphabetically,
   getCurrentMemberships,
   getCurrentMembershipsWithoutGuests,
+  getSessionMembershipsWithoutGuests,
   getLeaderPositions,
   getSentMembershipRequests,
   getProfileInfo,

--- a/src/views/ActivitiesAll/components/ActivityGrid/index.js
+++ b/src/views/ActivitiesAll/components/ActivityGrid/index.js
@@ -35,7 +35,7 @@ class GordonActivityGrid extends Component {
       content = (
         <Grid item xs={12}>
           <Typography variant="headline" align="center">
-            We found no current Involvements for you. Get connected below!
+            {this.props.noInvolvementsText}
           </Typography>
         </Grid>
       );

--- a/src/views/ActivitiesAll/index.js
+++ b/src/views/ActivitiesAll/index.js
@@ -98,6 +98,24 @@ export default class GordonActivitiesAll extends Component {
     let allInvolvements;
     let myInvolvements;
     let involvementsHeading;
+    let noInvolvementsText;
+
+    if (this.state.session === this.state.currentSession) {
+      involvementsHeading = 'CURRENT';
+      noInvolvementsText =
+        "It looks like you're not currently a member of any Involvements. Get connected below!";
+    } else {
+      for (var i = 0; i < this.state.sessions.length; i++) {
+        if (this.state.session === this.state.sessions[i].SessionCode) {
+          involvementsHeading = this.state.sessions[i].SessionDescription.toString();
+        }
+      }
+      noInvolvementsText = 'No Involvements found for ' + involvementsHeading;
+      involvementsHeading = involvementsHeading.toUpperCase();
+    }
+
+    console.log(noInvolvementsText);
+
     if (this.state.loading === true) {
       allInvolvements = <GordonLoader />;
       myInvolvements = <GordonLoader />;
@@ -109,18 +127,9 @@ export default class GordonActivitiesAll extends Component {
         <GordonActivityGrid
           myInvolvements={this.state.myInvolvements}
           sessionCode={this.state.session}
+          noInvolvementsText={noInvolvementsText}
         />
       );
-    }
-
-    if (this.state.session === this.state.currentSession) {
-      involvementsHeading = 'CURRENT';
-    } else {
-      for (var i = 0; i < this.state.sessions.length; i++) {
-        if (this.state.session === this.state.sessions[i].SessionCode) {
-          involvementsHeading = this.state.sessions[i].SessionDescription.toString().toUpperCase();
-        }
-      }
     }
 
     const sessionOptions = this.state.sessions.map(

--- a/src/views/ActivitiesAll/index.js
+++ b/src/views/ActivitiesAll/index.js
@@ -24,6 +24,8 @@ export default class GordonActivitiesAll extends Component {
     this.filter = this.filter.bind(this);
 
     this.state = {
+      currentSession: '',
+      profile: '',
       activities: [],
       allActivities: [],
       myInvolvements: [],
@@ -42,7 +44,7 @@ export default class GordonActivitiesAll extends Component {
     try {
       const profile = await user.getProfileInfo();
       const { SessionCode: sessionCode } = await session.getCurrent();
-      this.setState({ session: sessionCode });
+      this.setState({ session: sessionCode, currentSession: sessionCode });
 
       const [activities, types, sessions] = await Promise.all([
         activity.getAll(sessionCode),
@@ -52,6 +54,7 @@ export default class GordonActivitiesAll extends Component {
       const myInvolvements = await user.getCurrentMembershipsWithoutGuests(profile.ID);
 
       this.setState({
+        profile,
         activities,
         allActivities: activities,
         myInvolvements: myInvolvements,
@@ -63,16 +66,23 @@ export default class GordonActivitiesAll extends Component {
       this.setState({ error });
     }
   }
+
   async changeSession(event) {
     await this.setState({ session: event.target.value, loading: true });
     const allActivities = await activity.getAll(this.state.session);
+    const myInvolvements = await user.getSessionMembershipsWithoutGuests(
+      this.state.profile.ID,
+      this.state.session,
+    );
     const { type, search } = this.state;
     await this.setState({
       activities: activity.filter(allActivities, type, search),
       allActivities,
+      myInvolvements,
       loading: false,
     });
   }
+
   filter(name) {
     return async event => {
       await this.setState({ [name]: event.target.value });
@@ -87,6 +97,7 @@ export default class GordonActivitiesAll extends Component {
 
     let allInvolvements;
     let myInvolvements;
+    let involvementsHeading;
     if (this.state.loading === true) {
       allInvolvements = <GordonLoader />;
       myInvolvements = <GordonLoader />;
@@ -100,6 +111,16 @@ export default class GordonActivitiesAll extends Component {
           sessionCode={this.state.session}
         />
       );
+    }
+
+    if (this.state.session === this.state.currentSession) {
+      involvementsHeading = 'CURRENT';
+    } else {
+      for (var i = 0; i < this.state.sessions.length; i++) {
+        if (this.state.session === this.state.sessions[i].SessionCode) {
+          involvementsHeading = this.state.sessions[i].SessionDescription.toString().toUpperCase();
+        }
+      }
     }
 
     const sessionOptions = this.state.sessions.map(
@@ -173,7 +194,7 @@ export default class GordonActivitiesAll extends Component {
             <Card>
               <div style={headerStyle}>
                 <Typography variant="body2" style={headerStyle}>
-                  MY CURRENT INVOLVEMENTS
+                  MY {involvementsHeading} INVOLVEMENTS
                 </Typography>
               </div>
             </Card>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7535545/43163516-5dca30e0-8f5c-11e8-9212-734836cc719c.png)

The "my current involvements" section at the top of the involvements page now displays the involvements for the specified session. The heading says my current involvements when the session is set to the current session.