### PR TITLE
HandleSubmit for social media linx dialog

### DIFF
--- a/src/views/MyProfile/Components/LinksDialog/index.js
+++ b/src/views/MyProfile/Components/LinksDialog/index.js
@@ -249,7 +249,13 @@ export default class LinksDialog extends React.Component {
           <Button onClick={this.handleClose} variant="contained" style={button}>
             Cancel
           </Button>
-          <Button type="submit" disabled={!this.state.formValid} variant="contained" style={button}>
+          <Button
+            onClick={this.handleSubmit}
+            type="submit"
+            disabled={!this.state.formValid}
+            variant="contained"
+            style={button}
+          >
             Submit
           </Button>
         </DialogActions>


### PR DESCRIPTION
The button is no longer missing the actual _submit_ functionality.