### PR TITLE
Fix mixed up building/dept search parameters

### DIFF
--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -219,8 +219,8 @@ class PeopleSearch extends Component {
     homeCity,
     state,
     country,
-    building,
     department,
+    building,
   ) {
     if (
       this.state.includeAlumni === false &&


### PR DESCRIPTION
The search parameters were off between dept/building, causing an error.