### PR TITLE
Involvements Bug

### DIFF
--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -76,7 +76,6 @@ class ActivityProfile extends Component {
       sessionInfo,
       id,
       isAdmin,
-      emailList,
     ] = await Promise.all([
       activity.get(activityCode),
       activity.getAdvisors(activityCode, sessionCode),
@@ -87,8 +86,12 @@ class ActivityProfile extends Component {
       session.get(sessionCode),
       user.getLocalInfo().id,
       membership.checkAdmin(user.getLocalInfo().id, sessionCode, activityCode),
-      emails.get(activityCode),
     ]);
+
+    if (this.state.isAdmin) {
+      const emailList = await emails.get(activityCode);
+      this.setState({ emailList });
+    }
 
     this.setState({
       activityInfo,
@@ -100,7 +103,6 @@ class ActivityProfile extends Component {
       sessionInfo,
       id,
       isAdmin,
-      emailList,
     });
 
     this.setState({


### PR DESCRIPTION
Fixes the issue where:
"When I click on a past involvement that I wasn't in, then I get the "loading circle" forever (or at least for longer than my patience)."


The issue was that any time anyone wanted to access a specific Involvement, the front end was trying to get a list of all the members' emails (when it should only give it to the admins). 
