### PR TITLE
Give superAdmins all the permissions admins have on Involvement Profiles

### DIFF
--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -67,6 +67,7 @@ class ActivityProfile extends Component {
   async componentWillMount() {
     this.setState({ loading: true });
     const { sessionCode, activityCode } = this.props.match.params;
+    const { college_role } = user.getLocalInfo();
     const [
       activityInfo,
       activityAdvisors,
@@ -93,6 +94,12 @@ class ActivityProfile extends Component {
       emails.get(activityCode),
     ]);
 
+    if (isAdmin || college_role === 'god') {
+      // god == superAdmin
+      this.setState({ isAdmin: true });
+    } else {
+    }
+
     this.setState({
       activityInfo,
       activityAdvisors,
@@ -102,7 +109,6 @@ class ActivityProfile extends Component {
       activityStatus,
       sessionInfo,
       id,
-      isAdmin,
       participationDescription,
       tempActivityBlurb: activityInfo.ActivityBlurb,
       tempActivityJoinInfo: activityInfo.ActivityJoinInfo,


### PR DESCRIPTION
Fixes issue #336 
Basically, now a superAdmin can do anything a regular admin can do to a group.