### PR TITLE
Tweak CL&W Chart

### DIFF
--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -120,7 +120,7 @@ export default class CLWCreditsDaysLeft extends Component {
             </Grid>
             <Grid item>
               <Typography variant="body1" style={{ color: 'gray', textAlign: 'center' }}>
-                {`${current} CL&W Credit` + (current === 1 ? '' : 's')}
+                {`${remaining} CL&W Credit` + (current === 1 ? '' : 's') + 'Left'}
               </Typography>
             </Grid>
           </Grid>

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -120,7 +120,7 @@ export default class CLWCreditsDaysLeft extends Component {
             </Grid>
             <Grid item>
               <Typography variant="body1" style={{ color: 'gray', textAlign: 'center' }}>
-                {`${remaining} CL&W Credit` + (current === 1 ? '' : 's') + 'Left'}
+                {`${remaining} CL&W Credit` + (current === 1 ? '' : 's') + ' Left'}
               </Typography>
             </Grid>
           </Grid>


### PR DESCRIPTION
Replace redundant "CL&W Credits" subtitle at top of card with "CL&W Credits Left" (to match "Days Left").

![image](https://user-images.githubusercontent.com/25457697/46425748-803ecd80-c70a-11e8-95bd-ffbdb3e2fce0.png)
