### PR TITLE
Involvement page superadmin functionality

### DIFF
--- a/src/views/ActivityProfile/components/Membership/index.js
+++ b/src/views/ActivityProfile/components/Membership/index.js
@@ -54,6 +54,7 @@ export default class Membership extends Component {
       participationCode: '',
       titleComment: '',
       isAdmin: this.props.isAdmin,
+      isSuperAdmin: this.props.isSuperAdmin,
       participationDetail: [],
       id: this.props.id,
       addEmail: '',
@@ -295,9 +296,12 @@ export default class Membership extends Component {
     if (this.state.loading === true) {
       content = <GordonLoader />;
     } else {
-      if (this.state.participationDetail[0] && this.state.participationDetail[1] !== 'Guest') {
-        // User is in activity and not a guest
-        if (this.state.isAdmin) {
+      if (
+        (this.state.participationDetail[0] && this.state.participationDetail[1] !== 'Guest') ||
+        this.state.isSuperAdmin
+      ) {
+        // User is in activity and not a guest (unless user is superadmin [god mode])
+        if (this.state.isAdmin || this.state.isSuperAdmin) {
           header = (
             <div style={headerStyle}>
               <Grid container direction="row" spacing={16}>
@@ -329,7 +333,8 @@ export default class Membership extends Component {
           } else {
             requestList = <RequestDetail involvement={membership} />;
           }
-          if (this.state.participationDetail[1] === 'Advisor') {
+          // Only advisors and superadmins can re-open the roster
+          if (this.state.participationDetail[1] === 'Advisor' || this.state.isSuperAdmin) {
             if (this.state.status === 'OPEN') {
               confirmRoster = (
                 <Button variant="contained" color="primary" onClick={this.onConfirmRoster} raised>

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -57,6 +57,7 @@ class ActivityProfile extends Component {
       tempActivityJoinInfo: '', // For editing activity
       tempActivityURL: '', // For editing activity
       isAdmin: false, // Boolean for current user
+      isSuperAdmin: false, // Boolean for current user
       openEditActivity: false,
       openRemoveImage: false,
       emailList: [],
@@ -76,6 +77,7 @@ class ActivityProfile extends Component {
       activityStatus,
       sessionInfo,
       id,
+      college_role, // for testing purposes only, remove before push
       isAdmin,
       participationDescription,
       emailList,
@@ -88,10 +90,13 @@ class ActivityProfile extends Component {
       activity.getStatus(activityCode, sessionCode),
       session.get(sessionCode),
       user.getLocalInfo().id,
+      user.getLocalInfo().college_role,
       membership.checkAdmin(user.getLocalInfo().id, sessionCode, activityCode),
       membership.search(user.getLocalInfo().id, sessionCode, activityCode),
       emails.get(activityCode),
     ]);
+
+    console.log('College role:', college_role);
 
     this.setState({
       activityInfo,
@@ -103,21 +108,28 @@ class ActivityProfile extends Component {
       sessionInfo,
       id,
       isAdmin,
+      isSuperAdmin: college_role === 'god' ? true : false,
       participationDescription,
       tempActivityBlurb: activityInfo.ActivityBlurb,
       tempActivityJoinInfo: activityInfo.ActivityJoinInfo,
       tempActivityURL: activityInfo.ActivityURL,
     });
 
+    console.log('isAdmin:', isAdmin);
+    console.log('state.isAdmin:', this.state.isAdmin);
+    console.log('state.isSuperAdmin:', this.state.isSuperAdmin);
+
     if (this.state.isAdmin) {
       this.setState({ emailList });
     }
 
     if (
-      this.state.participationDescription[0] &&
-      this.state.participationDescription[1] !== 'Guest'
+      (this.state.participationDescription[0] &&
+        this.state.participationDescription[1] !== 'Guest') ||
+      this.state.isSuperAdmin
     ) {
-      // Only if the user is in the activity and not a guest can this get called
+      // Only if the user is in the activity and not a guest can this get called (unless user is
+      // a superadmin [god mode])
       // else Unauthorized error
       const activityMembers = await membership.get(
         this.state.activityInfo.ActivityCode,
@@ -556,6 +568,7 @@ class ActivityProfile extends Component {
           participationDetail={this.state.participationDetail}
           id={this.state.id}
           isAdmin={this.state.isAdmin}
+          isSuperAdmin={this.state.isSuperAdmin}
           status={this.state.activityStatus}
         />
       );

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -96,8 +96,6 @@ class ActivityProfile extends Component {
       emails.get(activityCode),
     ]);
 
-    console.log('College role:', college_role);
-
     this.setState({
       activityInfo,
       activityAdvisors,
@@ -114,10 +112,6 @@ class ActivityProfile extends Component {
       tempActivityJoinInfo: activityInfo.ActivityJoinInfo,
       tempActivityURL: activityInfo.ActivityURL,
     });
-
-    console.log('isAdmin:', isAdmin);
-    console.log('state.isAdmin:', this.state.isAdmin);
-    console.log('state.isSuperAdmin:', this.state.isSuperAdmin);
 
     if (this.state.isAdmin) {
       this.setState({ emailList });

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -107,7 +107,7 @@ class ActivityProfile extends Component {
       activityStatus,
       sessionInfo,
       id,
-      isAdmin,
+      isAdmin: isAdmin || college_role === 'god',
       isSuperAdmin: college_role === 'god' ? true : false,
       participationDescription,
       tempActivityBlurb: activityInfo.ActivityBlurb,


### PR DESCRIPTION
Superadmins can now view, change, and confirm the rosters for any involvement. They are also able to edit any involvement, which includes changing the photo.

This partially fixes #336.