### PR TITLE
Display meal plan info for SuperAdmins in addition to students.

### DIFF
--- a/src/views/Home/components/DiningBalance/index.js
+++ b/src/views/Home/components/DiningBalance/index.js
@@ -38,7 +38,7 @@ export default class DiningBalance extends Component {
     const daysLeft = await daysLeftPromise;
     const diningInfo = await diningInfoPromise;
     this.daysLeft = daysLeft;
-    if (college_role === 'student') {
+    if (college_role === 'student' || college_role === 'god') {
       this.diningInfo = diningInfo;
     } else {
       this.facStaffBalance = diningInfo;


### PR DESCRIPTION
Students who are also SuperAdmins can now view their entire meal plan balance, not just the number of dining dollars.

- This change requires a similar change to be made in the back end. The [studentAdminDining](https://github.com/gordon-cs/gordon-360-api/tree/studentAdminDining) branch on `gordon-360-api` has the required changes. Be sure to run that branch when testing this pull request. Also don't forget to merge that branch into develop and redeploy the API before merging and deploying this one.

![student-admin-dining](https://user-images.githubusercontent.com/5964594/56511244-1fd27a80-64fa-11e9-8e7b-22c0632dba18.PNG)
