### PR TITLE
Remove Role, ID number, and Session from dining URL

### DIFF
--- a/src/services/user.js
+++ b/src/services/user.js
@@ -432,7 +432,7 @@ const getDiningInfo = async () => {
   //const sessionCode = '201809';
   const role = getLocalInfo().college_role;
   //console.log(id + ' ' + sessionCode + ' ' + role);
-  return await http.get(`dining/${role}/${id}/${sessionCode}`);
+  return await http.get('dining');
 };
 
 /**

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -424,14 +424,6 @@ const getChapelCredits = async () => {
  * @return {Promise.<DiningInfo>} Dining plan info object
  */
 const getDiningInfo = async () => {
-  //const id = 999999003;
-  //const id = 999999001;
-  //const id = 40000097;
-  const { id } = getLocalInfo();
-  const { SessionCode: sessionCode } = await session.getCurrent();
-  //const sessionCode = '201809';
-  const role = getLocalInfo().college_role;
-  //console.log(id + ' ' + sessionCode + ' ' + role);
   return await http.get('dining');
 };
 


### PR DESCRIPTION
This branch changes the dining balance API call from "api/dining/{role}/{id}/{session}" to just "api/dining".  This API change means (1) it is not necessary to know the role (student,facstaff,etc) of the user, (2) users cannot get meal plan info or dining balance information for other users, and (3) information is always only accessed for the current session (as data for other sessions is unavailable anyway).

This branch should be merged with develop at the same time the branch FinalEmployment is merged into gordon-360-api as that branch contains the corresponding API change.