### PR TITLE
Print blob size before sending ID photo to backend

### DIFF
--- a/src/services/user.js
+++ b/src/services/user.js
@@ -325,6 +325,7 @@ const postIDImage = dataURI => {
   let type = blob.type.replace('image/', '');
   let headerOptions = {};
   imageData.append('canvasImage', blob, 'canvasImage.' + type);
+  console.log("blob size: " + blob.size);
   return http.post('profiles/IDimage', imageData, headerOptions);
 };
 


### PR DESCRIPTION
Attempting to isolate bug that results in a blank ID photo submission, with a very small file size.