### PR TITLE
Error Logging for ID Uploader

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=https://360ApiTrain.gordon.edu/
+REACT_APP_API_URL=https://360Api.gordon.edu

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=https://360Api.gordon.edu
+REACT_APP_API_URL=https://360Api.gordon.edu/

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=https://360Api.gordon.edu/
+REACT_APP_API_URL=https://360Api.gordon.edu

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=https://360Api.gordon.edu
+REACT_APP_API_URL=https://360Api.gordon.edu/

--- a/src/services/errorLog.js
+++ b/src/services/errorLog.js
@@ -1,0 +1,85 @@
+/**
+ * Error Log
+ *
+ * @module errorLog
+ */
+
+import http from './http.js';
+
+const postErrorLog = message => {
+  let currentTime = new Date();
+  let data = {
+    LOG_MESSAGE: message,
+    LOG_TIME: currentTime,
+  };
+  return http.post('log/add', data);
+};
+
+const postErrorMessage = message => {
+  return http.post('log', message);
+};
+
+//Code modified from https://medium.com/creative-technology-concepts-code/detect-device-browser-and-version-using-javascript-8b511906745
+function matchItem(string, data) {
+  var i = 0,
+    regex,
+    match;
+
+  for (i = 0; i < data.length; i += 1) {
+    regex = new RegExp(data[i].value, 'i');
+    match = regex.test(string);
+    if (match) {
+      return {
+        name: data[i].name,
+      };
+    }
+  }
+  return { name: 'unknown' };
+}
+
+const parseNavigator = navigator => {
+  //Code modified from https://medium.com/creative-technology-concepts-code/detect-device-browser-and-version-using-javascript-8b511906745
+  var oses = [
+    { name: 'Windows Phone', value: 'Windows Phone' },
+    { name: 'Windows', value: 'Win' },
+    { name: 'iPhone', value: 'iPhone' },
+    { name: 'iPad', value: 'iPad' },
+    { name: 'Kindle', value: 'Silk' },
+    { name: 'Android', value: 'Android' },
+    { name: 'PlayBook', value: 'PlayBook' },
+    { name: 'BlackBerry', value: 'BlackBerry' },
+    { name: 'Macintosh', value: 'Mac' },
+    { name: 'Linux', value: 'Linux' },
+    { name: 'Palm', value: 'Palm' },
+  ];
+
+  var browsers = [
+    { name: 'Chrome', value: 'Chrome' },
+    { name: 'Firefox', value: 'Firefox' },
+    { name: 'Safari', value: 'Safari' },
+    { name: 'Internet Explorer', value: 'MSIE' },
+    { name: 'Opera', value: 'Opera' },
+    { name: 'BlackBerry', value: 'CLDC' },
+    { name: 'Mozilla', value: 'Mozilla' },
+  ];
+
+  var header = [
+    navigator.platform,
+    navigator.userAgent,
+    navigator.appVersion,
+    navigator.vendor,
+    window.opera,
+  ];
+
+  var agent = header.join(' ');
+  var os = matchItem(agent, oses);
+  var browser = matchItem(agent, browsers);
+  let result = 'OS: ' + os.name + ', Browser: ' + browser.name + ',';
+  return result;
+};
+
+export default {
+  postErrorLog,
+  postErrorMessage,
+  parseNavigator,
+};

--- a/src/services/errorLog.js
+++ b/src/services/errorLog.js
@@ -20,7 +20,7 @@ const postErrorMessage = message => {
 };
 
 //Code modified from https://medium.com/creative-technology-concepts-code/detect-device-browser-and-version-using-javascript-8b511906745
-function matchItem(string, data) {
+const matchItem = (string, data) => {
   var i = 0,
     regex,
     match;
@@ -35,7 +35,7 @@ function matchItem(string, data) {
     }
   }
   return { name: 'unknown' };
-}
+};
 
 const parseNavigator = navigator => {
   //Code modified from https://medium.com/creative-technology-concepts-code/detect-device-browser-and-version-using-javascript-8b511906745
@@ -74,7 +74,7 @@ const parseNavigator = navigator => {
   var agent = header.join(' ');
   var os = matchItem(agent, oses);
   var browser = matchItem(agent, browsers);
-  let result = 'OS: ' + os.name + ', Browser: ' + browser.name + ',';
+  let result = 'OS: ' + os.name + ', Browser: ' + browser.name;
   return result;
 };
 

--- a/src/services/membership.js
+++ b/src/services/membership.js
@@ -153,7 +153,7 @@ const toggleMembershipPrivacy = userMembership => {
   let newMembershipPrivacy = !currentMembershipPrivacy;
   let setMembershipPrivacy = async function(value) {
     return http
-      .put('/memberships/' + userMembership.MembershipID + '/privacy/' + value, value)
+      .put('memberships/' + userMembership.MembershipID + '/privacy/' + value, value)
       .catch(reason => {
         console.log(reason);
         //TODO handle error

--- a/src/services/membership.js
+++ b/src/services/membership.js
@@ -53,7 +53,7 @@ import http from './http';
  * @return {Promise<any>} Response
  */
 function addMembership(data) {
-  return http.post(`memberships`, data).catch(reason => {
+  return http.post('memberships', data).catch(reason => {
     console.log(reason);
   });
 }

--- a/src/views/IDUploader/index.js
+++ b/src/views/IDUploader/index.js
@@ -18,6 +18,7 @@ import Cropper from 'react-cropper';
 import 'cropperjs/dist/cropper.css';
 import './IDUploader.css';
 import user from '../../services/user';
+import errorLog from '../../services/errorLog';
 
 const CROP_DIM = 1200; // pixels
 export default class IDUploader extends Component {
@@ -43,7 +44,6 @@ export default class IDUploader extends Component {
   handleCloseSubmit = () => {
     if (this.state.preview != null) {
       var croppedImage = this.refs.cropper.getCroppedCanvas({ width: CROP_DIM }).toDataURL();
-      console.log('Posting ID photo...');
       this.postCroppedImage(croppedImage, 0);
       var imageNoHeader = croppedImage.replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
       this.setState({
@@ -57,17 +57,20 @@ export default class IDUploader extends Component {
   };
 
   async postCroppedImage(croppedImage, n) {
-    console.log('ID photo resubmission #' + n);
+    let logMessage = 'ID photo submission #' + n + ' from ' + errorLog.parseNavigator(navigator);
     try {
       await user.postIDImage(croppedImage);
       this.setState({ submitDialogOpen: true });
     } catch (error) {
+      let errorMessage = ' but image failed to post with error: ' + error;
+      logMessage = errorMessage + logMessage;
       if (n < 5) {
         this.postCroppedImage(croppedImage, n + 1);
       } else {
         this.setState({ errorDialogOpen: true });
       }
     }
+    errorLog.postErrorMessage(logMessage);
   }
 
   handleCloseCancel = () => {

--- a/src/views/IDUploader/index.js
+++ b/src/views/IDUploader/index.js
@@ -56,16 +56,24 @@ export default class IDUploader extends Component {
     }
   };
 
-  async postCroppedImage(croppedImage, n) {
-    let logMessage = 'ID photo submission #' + n + ' from ' + errorLog.parseNavigator(navigator);
+  async postCroppedImage(croppedImage, attemptNumber) {
+    let profile = await user.getProfileInfo();
+    console.log(profile);
+    let logMessage =
+      'ID photo submission #' +
+      attemptNumber +
+      ' for ' +
+      profile.fullName +
+      ' from ' +
+      errorLog.parseNavigator(navigator);
     try {
       await user.postIDImage(croppedImage);
       this.setState({ submitDialogOpen: true });
     } catch (error) {
-      let errorMessage = ' but image failed to post with error: ' + error;
+      let errorMessage = ', but image failed to post with error: ' + error;
       logMessage = errorMessage + logMessage;
-      if (n < 5) {
-        this.postCroppedImage(croppedImage, n + 1);
+      if (attemptNumber < 5) {
+        this.postCroppedImage(croppedImage, attemptNumber + 1);
       } else {
         this.setState({ errorDialogOpen: true });
       }

--- a/src/views/IDUploader/index.js
+++ b/src/views/IDUploader/index.js
@@ -58,7 +58,6 @@ export default class IDUploader extends Component {
 
   async postCroppedImage(croppedImage, attemptNumber) {
     let profile = await user.getProfileInfo();
-    console.log(profile);
     let logMessage =
       'ID photo submission #' +
       attemptNumber +


### PR DESCRIPTION
Added generic error logging service to UI. Includes method to get user's browser and OS. Currently only used by ID Uploader, to record successes and failures, as well as the browser / os.
It uses a new logging route in the API, to record logs to the database.

Hopefully, this logging service will be helpful for collecting errors from actual website usage. 

Currently the size of the error message seems to be limited -- might need to look into sending multipart file content, or something that can handle larger messages. We were unable to send an entire 6 mb blob, but for typical strings it is currently fine.