### PR TITLE
Myprofile without username

### DIFF
--- a/src/components/Header/components/NavAvatarRightCorner/index.js
+++ b/src/components/Header/components/NavAvatarRightCorner/index.js
@@ -105,7 +105,7 @@ export default class GordonNavAvatarRightCorner extends Component {
     // const { classes } = this.props;
 
     let username = this.state.username;
-    let myProfileLink = '/myprofile/' + username;
+    let myProfileLink = '/myprofile/';
     let avatar = (
       <Avatar className="nav-avatar nav-avatar-placeholder">{this.getInitials()}</Avatar>
     );

--- a/src/components/Header/components/NavAvatarRightCorner/index.js
+++ b/src/components/Header/components/NavAvatarRightCorner/index.js
@@ -105,7 +105,7 @@ export default class GordonNavAvatarRightCorner extends Component {
     // const { classes } = this.props;
 
     let username = this.state.username;
-    let myProfileLink = '/myprofile/';
+    let myProfileLink = '/myprofile';
     let avatar = (
       <Avatar className="nav-avatar nav-avatar-placeholder">{this.getInitials()}</Avatar>
     );

--- a/src/components/Header/components/NavAvatarRightCorner/index.js
+++ b/src/components/Header/components/NavAvatarRightCorner/index.js
@@ -101,10 +101,6 @@ export default class GordonNavAvatarRightCorner extends Component {
 
   render() {
     const open = Boolean(this.state.anchorEl);
-
-    // const { classes } = this.props;
-
-    let username = this.state.username;
     let myProfileLink = '/myprofile';
     let avatar = (
       <Avatar className="nav-avatar nav-avatar-placeholder">{this.getInitials()}</Avatar>

--- a/src/components/Nav/components/NavAvatar/index.js
+++ b/src/components/Nav/components/NavAvatar/index.js
@@ -72,7 +72,7 @@ class GordonNavAvatar extends Component {
 
     // Link component to be used with Button component
     const buttonLink = ({ ...props }) => (
-      <Link {...props} to={'/myprofile/'} onClick={this.props.onLinkClick} />
+      <Link {...props} to={'/myprofile'} onClick={this.props.onLinkClick} />
     );
 
     return (

--- a/src/components/Nav/components/NavAvatar/index.js
+++ b/src/components/Nav/components/NavAvatar/index.js
@@ -72,7 +72,7 @@ class GordonNavAvatar extends Component {
 
     // Link component to be used with Button component
     const buttonLink = ({ ...props }) => (
-      <Link {...props} to={`/myprofile/${this.state.username}`} onClick={this.props.onLinkClick} />
+      <Link {...props} to={'/myprofile/'} onClick={this.props.onLinkClick} />
     );
 
     return (

--- a/src/routes.js
+++ b/src/routes.js
@@ -80,7 +80,7 @@ export default [
   },
   {
     name: 'My Profile',
-    path: '/myprofile/:username',
+    path: '/myprofile/',
     component: MyProfile,
   },
   {


### PR DESCRIPTION
Currently the NavAvatar and NavAvatarRightCorner both append the current user's username when constructing the URL for the users "myprofile" page.  This is unnecessary and is a hold-over from from when there was a single profile page route to users.  In fact, anything following "myprofile/" in the URL is currently ignored.

This pull request includes changes that rectify this behavior.