### PR TITLE
Cct leadership redesign

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -78,7 +78,7 @@ export default class GordonHeader extends Component {
           <Toolbar>
             <IconButton
               className="menu-button"
-              color="contrast"
+              color="default"
               aria-label="open drawer"
               onClick={this.props.onDrawerToggle}
             >

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -565,9 +565,11 @@ function compareByTitle(a, b) {
 }
 
 //compares items by SessionCode, used by getTranscriptInfo to sort by SessionCode
-function compareBySession(a, b) {
+/*function compareBySession(a, b) {
   const sessA = a.SessionCode;
+  console.log(sessA)
   const sessB = b.SessionCode;
+  console.log(sessB)
 
   let comparison = 0;
   if (sessA > sessB) {
@@ -575,10 +577,11 @@ function compareBySession(a, b) {
   } else if (sessA < sessB) {
     comparison = -1;
   }
+  console.log(comparison)
   return comparison;
-}
+}*/
 
-//compares items by ActivityCode, used by getTranscriptInfo to sort by SessionCode
+//compares items by ActivityCode, used by getTranscriptMembershipsInfo to sort by ActivityCode
 function compareByActCode(a, b) {
   const codeA = a.ActivityCode;
   const codeB = b.ActivityCode;
@@ -598,7 +601,6 @@ function compareByActCode(a, b) {
 //sorts by SessionCode and ActivityCode
 const getTranscriptMembershipsInfo = async id => {
   let transcriptInfo = await getMembershipsWithoutGuests(id);
-  transcriptInfo.sort(compareBySession);
   transcriptInfo.sort(compareByActCode);
   return transcriptInfo;
 };

--- a/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptActivity/coCurricularTranscriptActivity.scss
+++ b/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptActivity/coCurricularTranscriptActivity.scss
@@ -25,7 +25,7 @@
   grid-template-columns: 5% 70% 25%;
   grid-template-rows: auto auto;
   justify-items: stretch;
-  grid-row-gap: 20px;
+  grid-row-gap: 0px;
 }
 
 .organization-role {
@@ -38,6 +38,15 @@
   grid-column: 3;
   grid-row: 1;
   text-align: left;
+}
+
+.leadership-line {
+  grid-column: 2;
+  display: grid;
+  grid-template-columns: 5% 70% 25%;
+  grid-template-rows: auto auto;
+  justify-items: stretch;
+  grid-row-gap: 20px;
 }
 
 @media print {

--- a/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptActivity/coCurricularTranscriptActivity.scss
+++ b/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptActivity/coCurricularTranscriptActivity.scss
@@ -25,7 +25,6 @@
   grid-template-columns: 5% 70% 25%;
   grid-template-rows: auto auto;
   justify-items: stretch;
-  grid-row-gap: 0px;
 }
 
 .organization-role {

--- a/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptActivity/index.js
+++ b/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptActivity/index.js
@@ -7,12 +7,12 @@ export default class Activity extends Component {
 
   // Returns: string of year in format YYYY
   sliceYear = sesCode => {
-    return sesCode.toString().slice(0, 4);
+    return sesCode.slice(0, 4);
   };
 
   // Returns: string of month (Mon), month being the first month of the given semester
   sliceStart = sesCode => {
-    switch (sesCode.toString().slice(4, 6)) {
+    switch (sesCode.slice(4, 6)) {
       case '09':
         return 'Sep';
       case '01':
@@ -27,7 +27,7 @@ export default class Activity extends Component {
 
   // Returns: string of month (Mon), month being last month of the given semester
   sliceEnd = sesCode => {
-    switch (sesCode.toString().slice(4, 6)) {
+    switch (sesCode.slice(4, 6)) {
       case '09':
         return 'Dec';
       case '01':
@@ -118,15 +118,23 @@ export default class Activity extends Component {
   };
 
   render() {
-    const { Activity, Sessions } = this.props;
+    const { Activity, Sessions, LeaderSessions } = this.props;
     let duration = this.formatDuration(Sessions);
+    let leaderDuration;
+    if (LeaderSessions.length > 0) {
+      leaderDuration = this.formatDuration(LeaderSessions);
+    }
 
     return (
       <div className="activities">
-        <div className="organization-role">
-          {Activity.ActivityDescription}, {Activity.ParticipationDescription}
-        </div>
+        <div className="organization-role">{Activity.ActivityDescription}</div>
         <div className="date"> {duration} </div>
+        {!(leaderDuration === undefined) && (
+          <div className="leadership-line">
+            <div className="organization-role">Leader</div>
+            <div className="date">{leaderDuration}</div>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptActivity/index.js
+++ b/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptActivity/index.js
@@ -1,80 +1,132 @@
-//import Grid from '@material-ui/core/Grid';
-//import Divider from '@material-ui/core/Divider';
 import React, { Component } from 'react';
-//import List from '@material-ui/core/List';
-//import Typography from '@material-ui/core/Typography';
 import './coCurricularTranscriptActivity.css';
 
-//This component is a child of the CoCurricularTranscript component. Separates Headings from content in order
-//that activities be grouped by session. Returns a formatted table grid of activites to be displayed
-//by the Transcript component
-//Activity object and isUnique bool passed as props from CoCurricularTranscript
-
 export default class Activity extends Component {
-  /*getHeading = () => {
-    const { Activity } = this.props;
-    let heading = (
-      <div>
-        <Grid container className="heading">
-          <Grid item xs={12}>
-            <Typography variant="title">
-              <b> {Activity.SessionDescription} </b>
-            </Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <List>
-              <b> Activity </b>
-            </List>
-          </Grid>
-          <Grid item xs={6}>
-            <List>
-              <b> Participation </b>
-            </List>
-          </Grid>
-        </Grid>
-        <div className="divider">
-          <Divider />
-        </div>
-        <Grid />
-      </div>
-    );
-    if (!this.props.isUnique) {
-      return (
-        <div className="divider">
-          <Divider light={true} />
-        </div>
-      );
-    }
-    return heading;
+  // Helper functions for parsing and translating sessionCode which is of the format "YYYYSE"
+  // where SE is 09 for fall, 01 for spring, 05 for summer
+
+  // Returns: string of year in format YYYY
+  sliceYear = sesCode => {
+    return sesCode.toString().slice(0, 4);
   };
 
-  getContent = () => {
-    const { Activity } = this.props;
+  // Returns: string of month (Mon), month being the first month of the given semester
+  sliceStart = sesCode => {
+    switch (sesCode.toString().slice(4, 6)) {
+      case '09':
+        return 'Sep';
+      case '01':
+        return 'Jan';
+      case '05':
+        return 'May';
+      default:
+        console.log('An unrecognized semester code was provided');
+        return '';
+    }
+  };
 
-    let content = (
-      <Grid container>
-        <Grid item xs={6}>
-          <List>
-            <Typography className="text"> {Activity.ActivityDescription} </Typography>
-          </List>
-        </Grid>
-        <Grid item xs={6}>
-          <List>
-            <Typography className="text"> {Activity.ParticipationDescription} </Typography>
-          </List>
-        </Grid>
-      )
-    return content;
-};*/
+  // Returns: string of month (Mon), month being last month of the given semester
+  sliceEnd = sesCode => {
+    switch (sesCode.toString().slice(4, 6)) {
+      case '09':
+        return 'Dec';
+      case '01':
+        return 'May';
+      case '05':
+        return 'Sep';
+      default:
+        console.log('An unrecognized semester code was provided');
+        return '';
+    }
+  };
+
+  // Param: expects an array of [month in which the earlier session ended,
+  //                             year in which the ealier session ended,
+  //                             month in which the later session started (format: Mon),
+  //                             year in which the later session started (YYYY)]
+  // Returns: true if given month-year pairs are consecutive, false otherwise. Summers are not
+  //        considered a break consecutiveness because there are no summer activities. */
+  checkConsecutiveness = dates => {
+    return (
+      dates[1] === dates[3] ||
+      (parseInt(dates[1], 10) + 1 === parseInt(dates[3], 10) &&
+        dates[0] === 'Dec' &&
+        dates[2] === 'Jan')
+    );
+  };
+
+  // Prepares a list of sessions to be displayed as one coherent string representing the timepsan
+  // of the membership.
+
+  // Param: sessionsList - a list of sessionCodes
+  // Returns: A string representing the duration of the user's membership based on the sessionsList
+  formatDuration = sessionsList => {
+    let duration = '';
+    sessionsList.sort(function(sessA, sessB) {
+      return sessA - sessB;
+    });
+
+    // format sessions into a string representing the timespan(s) of the membership
+    //while (sessionsList.length > 0) {
+    let curSess = sessionsList.shift();
+
+    // Pop first session code from array and split into months and years, which are saved as
+    // the initial start and end dates
+    let startMon = this.sliceStart(curSess);
+    let endMon = this.sliceEnd(curSess);
+    let startYear = this.sliceYear(curSess),
+      endYear = startYear;
+
+    // For each other session, if it is consecutive to the current end date,
+    // save its end date as the new end date, otherwise, add the current start and end dates to
+    // the string 'duration' (because the streak is broken) and prepare to start a new streak.
+    // Loop assumes sessions will be sorted from earliest to latest
+    while (sessionsList.length > 0) {
+      let curSess = sessionsList.shift();
+      let nextStartMon = this.sliceStart(curSess);
+      let nextYear = this.sliceYear(curSess);
+      if (this.checkConsecutiveness([endMon, endYear, nextStartMon, nextYear])) {
+        // a streak of consecutive involvement continues
+        endMon = this.sliceEnd(curSess);
+        endYear = this.sliceYear(curSess);
+      } else {
+        // a streak has been broken; add its start and end to the string and start new streak
+
+        // don't show the year twice if the months are of the same year
+        if (startYear === endYear) {
+          duration += startMon;
+        } else {
+          duration += startMon + ' ' + startYear;
+        }
+        duration += '-' + endMon + ' ' + endYear + ', ';
+        startMon = this.sliceStart(curSess);
+        endMon = this.sliceEnd(curSess);
+        startYear = endYear = this.sliceYear(curSess);
+      }
+    }
+
+    // Flush the remaining start and end info to duration.
+    // Again, don't show the year twice if the months are of the same year
+    if (startYear === endYear) {
+      duration += startMon;
+    } else {
+      duration += startMon + ' ' + startYear;
+    }
+    duration += '-' + endMon + ' ' + endYear;
+
+    return duration;
+  };
 
   render() {
-    const { Activity } = this.props;
+    const { Activity, Sessions } = this.props;
+    let duration = this.formatDuration(Sessions);
+
     return (
       <div className="activities">
         <div className="organization-role">
           {Activity.ActivityDescription}, {Activity.ParticipationDescription}
         </div>
-        <div className="date"> {this.props.Duration} </div>
+        <div className="date"> {duration} </div>
       </div>
     );
   }

--- a/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptExperience/index.js
+++ b/src/views/CoCurricularTranscript/Components/CoCurricularTranscriptExperience/index.js
@@ -55,7 +55,7 @@ export default class Experience extends Component {
       let endTime = experience.Job_End_Date;
 
       if (endTime === null) {
-        endTime = 'Present';
+        Duration = startMonth + startYear + '- Present';
       } else {
         let endMonth = this.sliceMonth(experience.Job_End_Date.split('-')[1]);
         let endYear = ' ' + experience.Job_End_Date.split('-')[0];

--- a/src/views/CoCurricularTranscript/index.js
+++ b/src/views/CoCurricularTranscript/index.js
@@ -298,7 +298,6 @@ export default class Transcript extends Component {
               <Button
                 className="button"
                 onClick={this.handleDownload}
-                //raised
                 style={buttonColors}
                 variant="contained"
               >

--- a/src/views/CoCurricularTranscript/index.js
+++ b/src/views/CoCurricularTranscript/index.js
@@ -112,6 +112,7 @@ export default class Transcript extends Component {
     while (activities.length > 0) {
       let curAct = activities.shift();
       let sessions = [];
+      let leaderSessions = [];
 
       // keep track of the activity code which will be used to identify all activities of the same
       // code so they can be grouped into one activity component
@@ -122,18 +123,29 @@ export default class Transcript extends Component {
       // the string 'duration' (because the streak is broken) and prepare to start a new streak.
       // Loop assumes activities will be sorted by session and Activity Code.
       sessions.push(curAct.SessionCode);
+      if (curAct.Participation === 'LEAD') {
+        leaderSessions.push(curAct.SessionCode);
+      }
       while (activities.length > 0 && activities[0].ActivityCode === curActCode) {
         sessions.push(activities[0].SessionCode);
+        if (activities[0].Participation === 'LEAD') {
+          leaderSessions.push(activities[0].SessionCode);
+        }
         activities.shift();
       }
 
-      let sessionsOrdered = sessions.sort(function(a, b) {
-        return a - b;
-      });
+      let sessionsOrdered = sessions.sort();
+
+      let leaderSessionsOrdered = leaderSessions.sort();
 
       // add the new TranscriptItem component to the array
       condensedActs.push(
-        <Activity key={curAct.ActivityCode} Activity={curAct} Sessions={sessionsOrdered} />,
+        <Activity
+          key={curAct.ActivityCode}
+          Activity={curAct}
+          Sessions={sessionsOrdered}
+          LeaderSessions={leaderSessionsOrdered}
+        />,
       );
     }
 
@@ -169,13 +181,10 @@ export default class Transcript extends Component {
     while (memberships.length > 0) {
       let membership = memberships.shift();
 
-      // Add Honors and Leadership to the honors list
-      if (membership.Participation === 'LEAD' || honorsTypes.includes(membership.ActivityType)) {
+      // Filter memberships into either Honors, Experience, Service, or Activities
+      if (honorsTypes.includes(membership.ActivityType)) {
         filtered.honors.push(membership);
-      }
-
-      // Filter memberships into either Experience, Service, or Activities
-      if (experienceTypes.includes(membership.ActivityType)) {
+      } else if (experienceTypes.includes(membership.ActivityType)) {
         filtered.experience.experiences.push(membership);
       } else if (serviceTypes.includes(membership.ActivityType)) {
         filtered.service.push(membership);

--- a/src/views/CoCurricularTranscript/index.js
+++ b/src/views/CoCurricularTranscript/index.js
@@ -86,132 +86,71 @@ export default class Transcript extends Component {
     }
   }
 
-  /* Helper functions for parsing and translating sessionCode which is of the format "YYYYSE"
-     where SE is 09 for fall, 01 for spring, 05 for summer
-
-  /* Returns: string of year in format YYYY */
-  sliceYear = sesCode => {
-    return sesCode.toString().slice(0, 4);
-  };
-  /* Returns: string of month (Mon), month being the first month of the given semester */
-  sliceStart = sesCode => {
-    switch (sesCode.toString().slice(4, 6)) {
-      case '09':
-        return 'Sep';
-      case '01':
-        return 'Jan';
-      case '05':
-        return 'May';
-      default:
-        console.log('An unrecognized semester code was provided');
-        return '';
-    }
+  // Sorts a list of activity components in order of most recent end date to least recent end date.
+  // Param: activities - an array of Activity components with props Activity and Sessions
+  // Returns: the same array, sorted in order of most recent (newest) to least recent
+  sortNewestFirst = activities => {
+    let sorted = activities.sort(function(a, b) {
+      let lastSessA = a.props.Sessions[a.props.Sessions.length - 1];
+      let lastSessB = b.props.Sessions[b.props.Sessions.length - 1];
+      return lastSessB - lastSessA;
+    });
+    return sorted;
   };
 
-  /* Returns: string of month (Mon), month being last month of the given semester */
-  sliceEnd = sesCode => {
-    switch (sesCode.toString().slice(4, 6)) {
-      case '09':
-        return 'Dec';
-      case '01':
-        return 'May';
-      case '05':
-        return 'Sep';
-      default:
-        console.log('An unrecognized semester code was provided');
-        return '';
-    }
-  };
+  // For each activity in an array of activities, this finds all other activities of the same Code
+  // and keeps an array of all the sessions during which the student was involved in this activity.
+  // One Activity component is created with that ActivityDescription and the array of sessions.
+  // Once all Activity components have been made, they are sorted from most to least recent.
 
-  /* Param: expects an array of [month in which the earlier session ended,
-                                 year in which the ealier session ended,
-                                 month in which the later session started (format: Mon),
-                                 year in which the later session started (YYYY)]
-     Returns: true if given month-year pairs are consecutive, false otherwise. Summers are not
-            considered a break consecutiveness because there are no summer activities. */
-  checkConsecutiveness = dates => {
-    console.log(dates);
-    return (
-      dates[1] === dates[3] ||
-      (parseInt(dates[1], 10) + 1 === parseInt(dates[3], 10) &&
-        dates[0] === 'Dec' &&
-        dates[2] === 'Jan')
-    );
-  };
-
-  /* For each activity in an array of activities, this finds all other activities of the same Code
-     and keeps an array of all the sessions during which the student was involved in this activity.
-     Once all activities of the same activityCode are found, the array of sessions is processed
-     and translated into a duration. Then, one Activity component is created with that
-     ActivityDescription and the duration.
-
-     Param: activities - a list of activity objects ("Memberships" as defined in gordon-360-api)
-     Returns: array of Activity components with props Activity and Duration.
-  */
+  // Param: activities - a list of activity objects ("Memberships" as defined in gordon-360-api)
+  // Returns: array of Activity components with props Activity and Sessions.
   groupActivityByCode = activities => {
     let condensedActs = [];
 
     // sort activities by ActivityCode
     while (activities.length > 0) {
       let curAct = activities.shift();
+      let sessions = [];
 
       // keep track of the activity code which will be used to identify all activities of the same
       // code so they can be grouped into one activity component
       let curActCode = curAct.ActivityCode;
 
-      // Pop first session code from array and split into months and years, which are saved as
-      // the initial start and end dates
-      let sess = curAct.SessionCode;
-      let startMon = this.sliceStart(sess);
-      let endMon = this.sliceEnd(sess);
-      let startYear = this.sliceYear(sess),
-        endYear = startYear;
-
       // For each other activity matching curActCode, if it is consecutive to the current end date,
       // save its end date as the new end date, otherwise, add the current start and end dates to
       // the string 'duration' (because the streak is broken) and prepare to start a new streak.
       // Loop assumes activities will be sorted by session and Activity Code.
-      let duration = '';
+      sessions.push(curAct.SessionCode);
       while (activities.length > 0 && activities[0].ActivityCode === curActCode) {
-        sess = activities.shift().SessionCode;
-        let curStartMon = this.sliceStart(sess);
-        let curYear = this.sliceYear(sess);
-        if (this.checkConsecutiveness([endMon, endYear, curStartMon, curYear])) {
-          // a streak of consecutive involvement continues
-          endMon = this.sliceEnd(sess);
-          endYear = this.sliceYear(sess);
-        } else {
-          // a streak has been broken; add its start and end to the string and start new streak
-
-          // don't show the year twice if the months are of the same year
-          if (startYear === endYear) {
-            duration += startMon;
-          } else {
-            duration += startMon + ' ' + startYear;
-          }
-          duration += '-' + endMon + ' ' + endYear + ', ';
-
-          startMon = this.sliceStart(sess);
-          endMon = this.sliceEnd(sess);
-          startYear = endYear = this.sliceYear(sess);
-        }
+        sessions.push(activities[0].SessionCode);
+        activities.shift();
       }
 
-      // Flush the remaining start and end info to duration.
-      // Again, don't show the year twice if the months are of the same year
-      if (startYear === endYear) {
-        duration += startMon;
-      } else {
-        duration += startMon + ' ' + startYear;
-      }
-      duration += '-' + endMon + ' ' + endYear;
+      let sessionsOrdered = sessions.sort(function(a, b) {
+        return a - b;
+      });
 
       // add the new TranscriptItem component to the array
-      condensedActs.push(<Activity Activity={curAct} Duration={duration} />);
+      condensedActs.push(
+        <Activity key={curAct.ActivityCode} Activity={curAct} Sessions={sessionsOrdered} />,
+      );
     }
-    return condensedActs;
+
+    let sorted = this.sortNewestFirst(condensedActs);
+
+    return sorted;
   };
 
+  // Filters general memberships from the 360 Database into one of four categories
+  //        1. Honors, Leadership, and Research
+  //        2. Experience
+  //        3. Service and Service Learning
+  //        4. Activities (the catch-all)
+  // Memberships ars sorted based on their Activity Code, although this is not a perfect indicator
+  // of which category a membership should belong to.
+  // Params: memberships - An array of membership objects retrieved from the database.
+  // Returns: An array of four arrays-one per category-into which the  memberships have been filtered
   filterMemberships = memberships => {
     let filtered = {
       honors: [],
@@ -248,6 +187,7 @@ export default class Transcript extends Component {
     return filtered;
   };
 
+  // Returns: the graduation date of the current user, or nothing if they have no declared grad date
   getGradCohort() {
     let gradDate = this.state.profile.GradDate;
     if (gradDate === undefined || gradDate === '') {
@@ -257,6 +197,9 @@ export default class Transcript extends Component {
     }
   }
 
+  // Formats an array of major objects into a string for display on the transcript
+  // Params: majors - An array of major objects
+  // Returns: A string of all the current user's majors.
   getMajors = majors => {
     let majorsString = 'Majors: ';
 
@@ -272,6 +215,9 @@ export default class Transcript extends Component {
     return majorsString.substr(0, majorsString.length - 2);
   };
 
+  // Formats an array of minor objects into a string for display on the transcript
+  // Params: minors - An array of minor objects
+  // Returns: A string of all the current user's minors.
   getMinors = minors => {
     let minorsString = 'Minors: ';
 
@@ -317,9 +263,9 @@ export default class Transcript extends Component {
         this.state.categorizedMemberships.experience.experiences,
       );
       experienceList = experienceList.concat(
-        this.state.categorizedMemberships.experience.employments.map(employment => (
-          <Experience Experience={employment} />
-        )),
+        this.state.categorizedMemberships.experience.employments
+          .map(employment => <Experience Experience={employment} />)
+          .reverse(),
       );
     }
 
@@ -336,14 +282,14 @@ export default class Transcript extends Component {
 
     return (
       <div className="co-curricular-transcript">
-        <Card className="card" elevation="10">
+        <Card className="card" elevation={10}>
           <CardContent className="card-content">
             <div className="print-only">{/* <img src={require('./logo.png')} alt="" /> */}</div>
             <div>
               <Button
                 className="button"
                 onClick={this.handleDownload}
-                raised
+                //raised
                 style={buttonColors}
                 variant="contained"
               >


### PR DESCRIPTION
After talking to Chris Carlson, it was decided that the Co-Curricular Transcript should display memberships in order from most recently ended to least recently ended, and that each membership should only display in one category, showing the full duration of the user's membership, and-if needed-the duration of the user's leadership.

This pull request fixes #500 and #499 