### PR TITLE
Replace 'Gordon 360' with 'Gordon 2\u03C0' (Gordon 2pi) in strategic places on March 14 ("Pi Day")

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -17,20 +17,21 @@ import './header.css';
 import GordonPeopleSearch from './components/PeopleSearch';
 import GordonNavAvatarRightCorner from './components/NavAvatarRightCorner';
 import routes from '../../routes';
+import { projectName } from '../../project-name';
 
 const getRouteName = route => {
   if (route.name) {
     return () => (
       <span>
-        <DocumentTitle title={`${route.name} | Gordon 360`} />
+        <DocumentTitle title={`${route.name} | ${projectName}`} />
         {route.name}
       </span>
     );
   }
   return () => (
     <span>
-      <DocumentTitle title="Gordon 360" />
-      Gordon 360
+      <DocumentTitle title={`${projectName}`} />
+      {projectName}
     </span>
   );
 };

--- a/src/project-name.js
+++ b/src/project-name.js
@@ -1,0 +1,13 @@
+// Set Project Name
+
+var d = new Date();
+const monNumber = 2; // March (couting from 0; Jan = 0, Feb = 1, Mar = 2, etc.)
+const dayNumber = 14; // Fourteenth day (counting from 1)
+export var projectName;
+
+// Celebrate Pi Day (March 14).  Replace Gordon 360 by Gordon 2pi
+if (d.getMonth() === monNumber && d.getDate() === dayNumber) {
+  projectName = 'Gordon 2\u03C0'; // renders as Gordon 2pi
+} else {
+  projectName = 'Gordon 360';
+}

--- a/src/views/About/index.js
+++ b/src/views/About/index.js
@@ -5,6 +5,7 @@ import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import { gordonColors } from '../../theme';
 import Version from '../../services/version';
+import { projectName } from '../../project-name';
 import './about.css';
 
 export default class About extends Component {
@@ -52,7 +53,8 @@ export default class About extends Component {
               <Card>
                 <div style={headerStyle}>
                   <Typography variant="body2" style={headerStyle}>
-                    GORDON&apos;S 360 MOBILE INVOLVEMENTS PLATFORM: THE SCOTTIE FAIRE IN YOUR HAND
+                    {projectName}: THE SCOTTIE FAIRE IN YOUR HAND
+                    {/*GORDON&apos;S 360 MOBILE INVOLVEMENTS PLATFORM: THE SCOTTIE FAIRE IN YOUR HAND*/}
                   </Typography>
                 </div>
               </Card>

--- a/src/views/Login/index.js
+++ b/src/views/Login/index.js
@@ -17,6 +17,7 @@ import './login.css';
 import { authenticate } from '../../services/auth';
 import GordonLogoVerticalWhite from './gordon-logo-vertical-white.svg';
 import { gordonColors } from '../../theme';
+import { projectName } from '../../project-name';
 
 // To temporarily disable the Login Hang message, set this boolean to false
 const LOGIN_BUG_MESSAGE = true; // Login Hang
@@ -93,11 +94,11 @@ export default class Login extends Component {
   render() {
     return (
       <Grid className="gordon-login" container alignItems="center" justify="center" spacing={0}>
-        <DocumentTitle title="Login | Gordon 360" />
+        <DocumentTitle title={`Login | ${projectName}`} />
         <Grid className="container" item xs={12} sm={6} md={5} lg={4} xl={4}>
-          <img src={GordonLogoVerticalWhite} alt="Gordon 360" />
+          <img src={GordonLogoVerticalWhite} alt={`${projectName}`} />
           <form onSubmit={this.logIn}>
-            <Typography variant="subheading">Welcome to Gordon 360!</Typography>
+            <Typography variant="subheading">Welcome to {projectName}!</Typography>
             <TextField
               id="username"
               label="Username"


### PR DESCRIPTION
To celebrate Pi Day, on March 14th each year Gordon 360 should become Gordon 2\u03C0.

There are only a few places that "Gordon 360": window titles (appears in title bar and browser tabs), and the About and Feedback pages.  It seems reasonable to leave the feedback page alone, but the change implemented in this pull-request changes the window titles and one line on the About page.

Ideally a different carousel image would be loaded on this day, assuming that "Gordon 360" remains on the main banner image.  If we do move to a true banner rather than a carousel, this might most easily be done using a background image and regular text in the foreground.