### PR TITLE
Update deployment shell script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # DEPLOY_PASSWORD password to log into server
 # PRODUCTION_DIR absolute path to directory for production app
 # STAGING_DIR absolute path to directory for staging app
-
+echo `date +"%m-%d-%Y-%H:%M"`
 # Variable used to create web.config
 # Note: Regular expression replaces all quotes with two quotes, i.e. " => "" (for PowerShell)
 WEB_CONFIG=`sed -e 's/\"/\"\"/g' web_config`
@@ -26,7 +26,7 @@ else
 fi
 
 BUILD_DIR="build"
-DATE = date +"%m-%d-%Y-%H:%M"
+DATE = `date +"%m-%d-%Y-%H:%M"`
 
 printf "%s\n" "Removing backup directory from previous deployment..."
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # DEPLOY_PASSWORD password to log into server
 # PRODUCTION_DIR absolute path to directory for production app
 # STAGING_DIR absolute path to directory for staging app
-echo `date +"%m-%d-%Y-%H:%M"`
+
 # Variable used to create web.config
 # Note: Regular expression replaces all quotes with two quotes, i.e. " => "" (for PowerShell)
 WEB_CONFIG=`sed -e 's/\"/\"\"/g' web_config`

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,6 +26,7 @@ else
 fi
 
 BUILD_DIR="build"
+DATE = date +"%m-%d-%Y-%H:%M"
 
 printf "%s\n" "Removing backup directory from previous deployment..."
 
@@ -43,7 +44,7 @@ fi
 printf "%s\n" "Moving app to backup directory... "
 
 # Move app to temporary directory
-sshpass -p "$DEPLOY_PASSWORD" ssh "$DEPLOY_USER"@"$HOSTNAME" cp -r "$DIR" "$DIR-backup"
+sshpass -p "$DEPLOY_PASSWORD" ssh "$DEPLOY_USER"@"$HOSTNAME" mv "$DIR" "$DIR-backup-$DATE"
 
 if [ $? == 0 ]; then
   printf "%s\n" "Successfully moved app to backup directory"
@@ -51,16 +52,16 @@ else
   printf "%s\n" "Failed to move app to backup directory"
 fi
 
-printf "%s\n" "Clearing out app directory... "
+#printf "%s\n" "Clearing out app directory... "
 
 # Clear out app directory
-sshpass -p "$DEPLOY_PASSWORD" ssh "$DEPLOY_USER"@"$HOSTNAME" rm -r "$DIR/*"
+#sshpass -p "$DEPLOY_PASSWORD" ssh "$DEPLOY_USER"@"$HOSTNAME" rm -r "$DIR/*"
 
-if [ $? == 0 ]; then
-  printf "%s\n" "Sucessfully cleared out app directory"
-else
-  printf "%s\n" "Failed to clear out app directory"
-fi
+#if [ $? == 0 ]; then
+#  printf "%s\n" "Sucessfully cleared out app directory"
+#else
+#  printf "%s\n" "Failed to clear out app directory"
+#fi
 
 printf "%s\n" "Copying app to server... "
 


### PR DESCRIPTION
This pull request updates the deployment script to more efficiently handle automatic backups. Previously, the script copied a backup of the old web code folder, then deleted the original. After that process, the new build was moved in.
Instead of doing that combination of copy and delete, we can consolidate both actions into a simple rename of the folder--marking it as a backup. Then, we can move in the newly built files.

TODO: automatic deletion procedure, as this will no longer automatically delete older versions. (Perhaps use Unix epoch time to designate different backups, for ease of calculating when to remove old backups)