### PR TITLE
Updates to about page

### DIFF
--- a/src/views/About/index.js
+++ b/src/views/About/index.js
@@ -155,6 +155,14 @@ export default class About extends Component {
                 Dr.&nbsp;Russ Tuck, Dr.&nbsp;Jonathan Senning&nbsp;&apos;85, Summer Practicum in
                 Computer Science (2018)
               </Typography>
+              <Typography variant="subtitle1" gutterBottom>
+                <strong>Software Development Team, 2018/2019</strong>
+              </Typography>
+              <Typography variant="body2" paragraph>
+                Addison Abbot&nbsp;&apos;20, Nikki Adevai&nbsp;&apos;19, Emily Bishop&nbsp;&apos;20,
+                Nathaniel Rudenberg&nbsp;&apos;20, and Sam Nguyen&nbsp;&apos;19,
+                <br /> Chris Hansen, Jason Whitehouse&nbsp;&apos;99, Information Systems Group
+              </Typography>
               <Typography variant="subheading" gutterBottom>
                 <strong>Software Development Team, Summer 2019</strong>
               </Typography>
@@ -166,6 +174,14 @@ export default class About extends Component {
                 <br />
                 Dr.&nbsp;Russ Tuck, Dr.&nbsp;Jonathan Senning&nbsp;&apos;85, Summer Practicum in
                 Computer Science (2019)
+              </Typography>
+              <Typography variant="subtitle1" gutterBottom>
+                <strong>Software Development Team, 2019/2020</strong>
+              </Typography>
+              <Typography variant="body2" paragraph>
+                Ben Abbett&nbsp;&apos;21 Addison Abbot&nbsp;&apos;20, Nathaniel
+                Rudenberg&nbsp;&apos;20, Jessica Guan&nbsp;&apos;21 and Joshua Rogers&nbsp;&apos;21
+                <br /> Chris Hansen, Jason Whitehouse&nbsp;&apos;99, Information Systems Group
               </Typography>
               <Typography variant="subtitle1" gutterBottom>
                 <strong>Beneficent Philanthropes</strong>

--- a/src/views/About/index.js
+++ b/src/views/About/index.js
@@ -167,10 +167,10 @@ export default class About extends Component {
                 <strong>Software Development Team, Summer 2019</strong>
               </Typography>
               <Typography variant="body2" paragraph>
-                Hyeok Chin (Jake) Moon&nbsp;&apos;19, Evan Platzer&nbsp;&apos;20, Yi (Edward)
-                Zhou&nbsp;&apos;20, Phil Lee, Joshua Rogers&nbsp;&apos;21, Isaac
-                Bleecker&nbsp;&apos;21, Yerang Lim&nbsp;&apos;21, Jahnuel Dorelus&nbsp;&apos;21, and
-                SeHee Hyung&nbsp;&apos;22
+                Isaac Bleecker&nbsp;&apos;21, Jahnuel Dorelus&nbsp;&apos;21, SeHee
+                Hyung&nbsp;&apos;22, Phil Lee, Yerang Lim&nbsp;&apos;21, Hyeok Chin (Jake)
+                Moon&nbsp;&apos;19, Evan Platzer&nbsp;&apos;20, Joshua Rogers&nbsp;&apos;21, and Yi
+                (Edward) Zhou&nbsp;&apos;20
                 <br />
                 Dr.&nbsp;Russ Tuck, Dr.&nbsp;Jonathan Senning&nbsp;&apos;85, Summer Practicum in
                 Computer Science (2019)


### PR DESCRIPTION
Changed the team from this summer to be listed alphabetical, and added last year's and this year's dev teams.

I am wondering if the 'found a bug, report to cts' button should be directed to our team directly rather than to CTS. Does CTS ever forward reports on to us? (Do we get any?)