### PR TITLE
Fix empty mailbox

### DIFF
--- a/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
+++ b/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
@@ -145,6 +145,10 @@ export default class MemberList extends Component {
   }
 
   render() {
+    // Only display mailLoc if they have a mailbox
+    let mailLoc = 'Box #' + this.props.member.Mail_Location;
+    mailLoc = mailLoc == 'Box #' ? '' : mailLoc;
+
     let content;
     const rowStyle = {
       padding: '10px',
@@ -371,7 +375,7 @@ export default class MemberList extends Component {
                   <Typography>{this.props.member.ParticipationDescription} </Typography>
                 </Grid>
                 <Grid item xs={2} sm={2} md={2}>
-                  <Typography>Box #{this.props.member.Mail_Location}</Typography>
+                  <Typography>{mailLoc}</Typography>
                 </Grid>
               </Grid>
             </ExpansionPanelSummary>
@@ -397,7 +401,7 @@ export default class MemberList extends Component {
               <Typography>{this.state.participationDescription}</Typography>
             </Grid>
             <Grid item xs={4} sm={2} style={rowStyle}>
-              <Typography>Box #{this.props.member.Mail_Location}</Typography>
+              <Typography>{mailLoc}</Typography>
             </Grid>
             <Grid item xs={2} sm={2} style={rowStyle}>
               {options}

--- a/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
+++ b/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
@@ -147,7 +147,7 @@ export default class MemberList extends Component {
   render() {
     // Only display mailLoc if they have a mailbox
     let mailLoc = 'Box #' + this.props.member.Mail_Location;
-    mailLoc = mailLoc == 'Box #' ? '' : mailLoc;
+    mailLoc = mailLoc === 'Box #' ? '' : mailLoc;
 
     let content;
     const rowStyle = {


### PR DESCRIPTION
On the involvements page, if a user had no mailbox it would still show "Box #". This change removes that issue, now "Box #" is only shown if the user actually has a mailbox.