### PR TITLE
Add 'no description' text for events without a null description

### DIFF
--- a/src/components/EventList/components/EventItem/index.js
+++ b/src/components/EventList/components/EventItem/index.js
@@ -20,7 +20,8 @@ export default class GordonEventItem extends Component {
   }
   render() {
     const { event } = this.props;
-
+    let eventDescription = event.Description;
+    eventDescription = eventDescription === '' ? 'No description available' : eventDescription;
     return (
       <section>
         <Grid container direction="row" onClick={this.handleExpandClick} className="event-item">
@@ -40,7 +41,7 @@ export default class GordonEventItem extends Component {
             <CardContent>
               <Typography className="descriptionText">Description:</Typography>
               <Typography type="caption" className="descriptionText">
-                {event.Description}
+                {eventDescription}
               </Typography>
             </CardContent>
           </Collapse>


### PR DESCRIPTION
Solves #680 
On the events page, some events have a "No description available" description, while some just have an empty field. Now both cases just display "No description available".