### PR TITLE
Center button.

### DIFF
--- a/src/views/EventsAttended/index.js
+++ b/src/views/EventsAttended/index.js
@@ -63,12 +63,13 @@ export default class EventsAttended extends Component {
         );
       } else {
         content = (
-          <Grid item>
+          <Grid item align="center">
             <br />
             <br />
             <Typography variant="h4" align="center">
               No Events To Show
             </Typography>
+            <br />
             <Button
               variant="contained"
               style={style.button}


### PR DESCRIPTION
Tiny change to center button on attended events page when you have not attended any events.

The old view:

![Screenshot (49)](https://user-images.githubusercontent.com/36084988/77687012-2ff9a200-6f74-11ea-8300-c350f0307f74.png)

The new view:

![Screenshot (51)](https://user-images.githubusercontent.com/36084988/77687140-66372180-6f74-11ea-925c-2f133bf4680e.png)

For reference, this is what it looks like when you have attended events:

![Screenshot (50)](https://user-images.githubusercontent.com/36084988/77687266-836bf000-6f74-11ea-8373-c2bdc278d2eb.png)
