### PR TITLE
Make date out picker initially focus on same day as date in picker

### DIFF
--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -370,7 +370,7 @@ const Timesheets = (props) => {
     } else if (isZeroLengthShift) {
       errorText = (
         <Typography variant="overline" color="error">
-          A shift cannot have zero length.
+          The entered shift has zero length.
       </Typography>
       );
     } else if (shiftTooLong) {
@@ -382,7 +382,7 @@ const Timesheets = (props) => {
     } else if (isOverlappingShift) {
       errorText = (
         <Typography variant="overline" color="error">
-          The entered shift conflicts with a previous shift.
+          You have already entered hours that fall within this time frame.
       </Typography>
       );
     }
@@ -450,6 +450,7 @@ const Timesheets = (props) => {
                         autoOk
                         variant="inline"
                         disabled={selectedDateIn === null}
+                        initialFocusedDate={selectedDateIn}
                         shouldDisableDate={disableDisallowedDays}
                         margin="normal"
                         id="date-picker-out-dialog"


### PR DESCRIPTION
The date out picker no longer autopopulates on the first click, and it now causes the getJobs to run every time the dialog is closed