### PR TITLE
Add real URL for student timesheets page

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -12,8 +12,6 @@ import HomeIcon from '@material-ui/icons/Home';
 import LocalActivityIcon from '@material-ui/icons/LocalActivity';
 import EventIcon from '@material-ui/icons/Event';
 import PeopleIcon from '@material-ui/icons/People';
-//Add back in when we re-enable timesheet link
-//import WorkIcon from '@material-ui/icons/Work';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Button from '@material-ui/core/Button';
@@ -205,14 +203,6 @@ export default class GordonHeader extends Component {
       }
     }
 
-    //Add to return statement when re-enabling work link
-    //<Tab
-    //              className="tab"
-    //              icon={<WorkIcon />}
-    //              label="Timesheets"
-    //              component={NavLink}
-    //              to="/timesheets"
-    //            />
     return (
       <section className="gordon-header">
         <AppBar className="app-bar" position="static">

--- a/src/components/Nav/components/NavLinks/index.js
+++ b/src/components/Nav/components/NavLinks/index.js
@@ -12,8 +12,6 @@ import HomeIcon from '@material-ui/icons/Home';
 import LocalActivityIcon from '@material-ui/icons/LocalActivity';
 import EventIcon from '@material-ui/icons/Event';
 import PeopleIcon from '@material-ui/icons/People';
-//re-enable when we add back links to work page
-//import WorkIcon from '@material-ui/icons/Work';
 import Button from '@material-ui/core/Button';
 import React, { Component } from 'react';
 import { NavLink } from 'react-router-dom';
@@ -168,8 +166,6 @@ export default class GordonNavLinks extends Component {
     let admin;
     let peopleButton;
     let signInOut;
-    //Add this back when Timesheets link re-enabled.
-    //let timesheetButton;
     if (this.props.Authentication) {
       // Creates the Admin button depending on the status of the network found in local storage
       if (networkStatus === 'online') {
@@ -242,18 +238,6 @@ export default class GordonNavLinks extends Component {
           </ListItem>
         </NavLink>
       );
-      // Re-Enable when adding the link to the timesheet page
-      // Creates the Timesheets button
-      //timesheetButton = (
-      //  <NavLink className="gc360-link" exact to="/timesheets" onClick={this.props.onLinkClick}>
-      //    <ListItem button>
-      //      <ListItemIcon>
-      //        <WorkIcon />
-      //      </ListItemIcon>
-      //      <ListItemText primary="Timesheets" />
-      //    </ListItem>
-      //  </NavLink>
-      //);
 
       // Creates the Home button
       homeButton = (
@@ -375,32 +359,6 @@ export default class GordonNavLinks extends Component {
           </NavLink>
         );
       }
-
-      //Re-enable when adding the link to timesheets page
-      // Creates the Timesheet button depending on the status of the network found in local storage
-      //if (networkStatus === 'online') {
-      //  timesheetButton = (
-      //    <NavLink className="gc360-link" exact to="/timesheets" onClick={this.props.onLinkClick}>
-      //      <ListItem button>
-      //        <ListItemIcon>
-      //          <WorkIcon />
-      //        </ListItemIcon>
-      //        <ListItemText primary="Timesheets" />
-      //      </ListItem>
-      //    </NavLink>
-      //  );
-      //} else {
-      //  timesheetButton = (
-      //    <NavLink className="gc360-link" onClick={this.openDialogBox}>
-      //      <ListItem button disabled={networkStatus}>
-      //        <ListItemIcon>
-      //          <WorkIcon />
-      //        </ListItemIcon>
-      //        <ListItemText primary="Timesheets" />
-      //      </ListItem>
-      //    </NavLink>
-      //  );
-      //}
 
       // Creates the Signout button depending on the status of the network found in local storage
       if (networkStatus === 'online') {

--- a/src/components/QuickLinksDialog/components/LinksList/index.js
+++ b/src/components/QuickLinksDialog/components/LinksList/index.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListSubheader from '@material-ui/core/ListSubheader';
-
+import { Link } from 'react-router-dom';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import LinkIcon from '@material-ui/icons/InsertLink';
+import WorkIcon from '@material-ui/icons/Work';
 import Typography from '@material-ui/core/Typography';
 
 import { ListItemIcon } from '@material-ui/core';
@@ -90,6 +91,20 @@ export default class GordonLinksList extends Component {
             </ListItemIcon>
             <ListItemText primary="Blackboard Learn" />
           </ListItemLink>
+        </List>
+        <List component="nav" subheader={<ListSubheader component="div">Employment</ListSubheader>}>
+          <Link
+            to='/student-timesheets'
+            className="gc360-text-link"
+            onClick={this.props.onClose}
+          >
+            <ListItem>
+              <ListItemIcon>
+                <WorkIcon />
+              </ListItemIcon>
+              <ListItemText primary="Student Timesheets" />
+            </ListItem>
+          </Link>
         </List>
         <List
           component="nav"

--- a/src/components/QuickLinksDialog/index.js
+++ b/src/components/QuickLinksDialog/index.js
@@ -64,7 +64,7 @@ export default class GordonQuickLinksDialog extends Component {
       >
         <DialogTitle id="useful-links">Useful links</DialogTitle>
         <DialogContent dividers="true">
-          <GordonLinksList />
+          <GordonLinksList onClose={this.props.handleLinkClose}/>
         </DialogContent>
       </GordonDialog>
     );

--- a/src/routes.js
+++ b/src/routes.js
@@ -96,8 +96,8 @@ export default [
     component: Admin,
   },
   {
-    name: 'Timesheets',
-    path: '/t1m35433t5',
+    name: 'Student Timesheets',
+    path: '/student-timesheets',
     component: Timesheets,
   },
   {

--- a/src/views/Timesheets/components/SavedShiftsList/index.js
+++ b/src/views/Timesheets/components/SavedShiftsList/index.js
@@ -1,3 +1,4 @@
+//Displays shifts and sets up buttons for submitting shifts
 import React, { Component } from 'react';
 import {
   Typography,
@@ -81,6 +82,21 @@ export default class SavedShiftsList extends Component {
         });
       });
     });
+  }
+
+  componentDidMount() {
+    let {shifts, directSupervisor, reportingSupervisor} = this.props;
+    let supervisorIdsReady = directSupervisor && reportingSupervisor;
+    let shouldGetSupervisors; 
+    if (shifts.length > 0) {
+      shouldGetSupervisors = this.props.cardTitle === "Saved Shifts" && (shifts[0].EML !== this.prevJob || (!this.state.directSupervisor || !this.state.reportingSupervisor));
+      this.prevJob = shifts[0].EML
+    } else {
+      shouldGetSupervisors = this.props.cardTitle === "Saved Shifts" && supervisorIdsReady && (!this.state.directSupervisor || !this.state.reportingSupervisor) && shifts !== null;
+    }
+    if (shouldGetSupervisors) {
+      this.getSupervisors();
+    }
   }
 
   componentDidUpdate() {
@@ -240,7 +256,7 @@ export default class SavedShiftsList extends Component {
               {shiftsList}
             </Grid>
           </CardContent>
-            {(cardTitle === "Approved Shifts" || cardTitle === "Submitted Shifts") &&
+            {(cardTitle === "Saved Shifts" || cardTitle === "Approved Shifts" || cardTitle === "Submitted Shifts") &&
               <CardContent>
                 <Grid container>
                   <Grid item xs={12} sm={6}>

--- a/src/views/Timesheets/components/ShiftDisplay/index.js
+++ b/src/views/Timesheets/components/ShiftDisplay/index.js
@@ -1,3 +1,4 @@
+//Handles the fetching and preperation for displaying of shifts
 import React, { Component } from 'react';
 import {
     Grid,

--- a/src/views/Timesheets/components/ShiftItem/index.js
+++ b/src/views/Timesheets/components/ShiftItem/index.js
@@ -1,3 +1,4 @@
+//Representation of a shift
 import React, { Component } from 'react';
 import {
   Typography,

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -1,3 +1,4 @@
+//Main student timesheets page
 import React, { useState, useRef } from 'react';
 import 'date-fns';
 import {
@@ -92,7 +93,6 @@ const Timesheets = (props) => {
   };
 
   const checkForFutureDate = (dateIn, dateOut) => {
-    console.log('checking for future date');
     let now = Date.now();
     setEnteredFutureTime((dateIn.getTime() > now) || (dateOut.getTime() > now));
   }


### PR DESCRIPTION
### Plz no merge until end of production trial run (so end of finals week)

Fixes URL for timesheets so it's no longer a "random" string
Adds link to Student Timesheets page to the quick links dialog

Co-authored-by: adamprinciotta <adamprinciotta@gmail.com>
Co-authored-by: Jacob <jacob.bradley@gordon.edu>

![image](https://user-images.githubusercontent.com/5964594/80927354-6a244380-8d6b-11ea-840d-0579ac7395c9.png)
