### PR TITLE
(S20) Resolving Good First Issues

### DIFF
--- a/src/components/SchedulePanel/index.js
+++ b/src/components/SchedulePanel/index.js
@@ -235,11 +235,11 @@ class GordonSchedulePanel extends Component {
   render() {
     const replaced = this.state.description
   .replace(urlRegex({strict: false}), function(url) {
-    if ((url.split('://')[0] !== 'http') || url.split('://')[0] !== 'https'){
-     return '<a target="_blank" rel="noopener" href="https://'+ url + '">' + url + "</a>";
+    if ((url.split('://')[0] !== 'http') && url.split('://')[0] !== 'https'){
+      return '<a target="_blank" rel="noopener" href="https://'+ url + '">' + url + "</a>";
     }
     else{
-  return '<a target="_blank" rel="noopener" href="'+ url + '">' + url + "</a>";
+      return '<a target="_blank" rel="noopener" href="'+ url + '">' + url + "</a>";
     }
   });
 

--- a/src/views/MyProfile/index.js
+++ b/src/views/MyProfile/index.js
@@ -749,8 +749,9 @@ class MyProfile extends Component {
                     {VPScore}
                   </Grid>
 
-                  <Grid item xs={12} lg={12} align="center">
-                    <Grid container xs={12} lg={10} spacing={2} justify="center">
+                  <Grid item xs={12} lg={10} align="center">
+                    {/* max width style necessary because of poorly used margins */}
+                    <Grid container xs={12} lg={12} spacing={2} justify="center" style={{'max-width': 'calc(100% + 16px)',}}>
                       <Grid item xs={12} lg={12}>
                         <GordonSchedulePanel profile={this.state.profile} myProf={true} />
                       </Grid>

--- a/src/views/PeopleSearch/components/MobilePeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/MobilePeopleSearchResult/index.js
@@ -109,6 +109,7 @@ export default class PeopleSearchResult extends Component {
           <Grid
             container
             alignItems="center"
+            justify="center"
             spacing={2}
             style={{
               padding: '1rem',
@@ -123,7 +124,12 @@ export default class PeopleSearchResult extends Component {
                 placeholderColor="#FFF"
               />
             </Grid>
-            <Grid item>
+            <Grid
+              item
+              style={{
+                width: '250px',
+              }}
+            >
               <Typography variant="h5">{fullName}</Typography>
               <Typography variant="body2">{nickname}</Typography>
               <Typography variant="body2">{personClassJobTitle}</Typography>

--- a/src/views/PeopleSearch/components/MobilePeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/MobilePeopleSearchResult/index.js
@@ -127,7 +127,9 @@ export default class PeopleSearchResult extends Component {
             <Grid
               item
               style={{
-                width: '250px',
+                // a set width is necessary to keep profile images in line 
+                // while maintaining center alignment
+                width: '260px',
               }}
             >
               <Typography variant="h5">{fullName}</Typography>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -132,7 +132,7 @@ export default class PeopleSearchResult extends Component {
             <Grid item xs={2}>
               <Typography>{Person.LastName}</Typography>
             </Grid>
-            <Grid item xs={2}>
+            <Grid item xs={1}>
               <Typography>{Person.Type}</Typography>
             </Grid>
             <Grid item xs={3}>

--- a/src/views/Profile/index.js
+++ b/src/views/Profile/index.js
@@ -357,6 +357,7 @@ export default class Profile extends Component {
                 </Grid>
 
                 <Grid item xs={12} lg={10} align="center">
+                  {/* max width style necessary because of poorly used margins */}
                   <Grid container xs={12} lg={12} spacing={2} justify="center" style={{'max-width': 'calc(100% + 16px)',}}>
                     <Grid item xs={12} lg={12}>
                       <GordonSchedulePanel profile={this.state.profile} myProf={false} />

--- a/src/views/Profile/index.js
+++ b/src/views/Profile/index.js
@@ -356,8 +356,8 @@ export default class Profile extends Component {
                   </Card>
                 </Grid>
 
-                <Grid item xs={12} lg={12} align="center">
-                  <Grid container xs={12} lg={10} spacing={2} justify="center">
+                <Grid item xs={12} lg={10} align="center">
+                  <Grid container xs={12} lg={12} spacing={2} justify="center" style={{'max-width': 'calc(100% + 16px)',}}>
                     <Grid item xs={12} lg={12}>
                       <GordonSchedulePanel profile={this.state.profile} myProf={false} />
                     </Grid>

--- a/src/views/Profile/profile.scss
+++ b/src/views/Profile/profile.scss
@@ -18,15 +18,10 @@
     }
   }
   &_email {
-    display: grid;
-    grid-template-columns: 10% 10% 70% 10%;
-    justify-items: center;
+    display: flex;
+    justify-content: space-around;
     &_icon {
-      grid-column: 2;
       font-size: 28px;
-    }
-    &_text {
-      grid-column: 3;
     }
   }
 }


### PR DESCRIPTION
Minor bug fixes:
- Fixed bug with overlapping long emails covering the email icon (resolves #640),
- Fixed issue with layout sizing on people search. The person "type" was given a larger buffer than the correct size given by the headers. This resolved the email address / mailbox section from overflowing side of card.
- Centered people search results on mobile. Potential new issue to note: fixed widths to 250px (to maintain image alignment).
- Corrected the width and location of the "schedule" card on profiles
- Resolved url issue on "schedule" card where links would be https://http// etc. The issue was a logic && mistake. (resolves #639)