### PR TITLE
S20 People Search 'No results'

### DIFF
--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -15,7 +15,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import './people-search.css';
 import peopleSearch from '../../../../services/people-search';
-const MIN_QUERY_LENGTH = 3;
+const MIN_QUERY_LENGTH = 2;
 
 //  TextBox Input Field
 const renderInput = inputProps => {
@@ -49,6 +49,7 @@ export default class GordonPeopleSearch extends Component {
   constructor(props) {
     super(props);
     this.getSuggestions = this.getSuggestions.bind(this);
+    this.renderNoResult = this.renderNoResult.bind(this);
     this.renderSuggestion = this.renderSuggestion.bind(this);
     this.reset = this.reset.bind(this);
     this.handleKeys = this.handleKeys.bind(this);
@@ -147,13 +148,23 @@ export default class GordonPeopleSearch extends Component {
     );
   }
 
+  renderNoResult() {
+    return(
+    <MenuItem className="people-search-suggestion" style=
+    {{paddingBottom: '5px'}}>
+      <Typography className="no-results" variant="body2">
+        No results
+      </Typography>
+    </MenuItem>)
+  }
+
   renderSuggestion(params) {
     const { suggestion, itemProps } = params;
     let suggestionIndex = this.state.suggestionIndex;
     let suggestionList = this.state.suggestions;
     // Bail if any required properties are missing
     if (!suggestion.UserName || !suggestion.FirstName || !suggestion.LastName) {
-      return;
+      return null;
     }
     return (
        <MenuItem
@@ -324,12 +335,7 @@ export default class GordonPeopleSearch extends Component {
                   // Styling copied from how renderSuggestion is done with
                   // only bottom padding changed and 'no-results' class used
                     <Paper square className="people-search-dropdown">
-                      <MenuItem className="people-search-suggestion" style=
-                      {{paddingBottom: '5px'}}>
-                        <Typography className="no-results" variant="body2">
-                         No results
-                        </Typography>
-                      </MenuItem>
+                      {this.renderNoResult()}
                     </Paper>) : null}
               </span>
             )}
@@ -369,12 +375,7 @@ export default class GordonPeopleSearch extends Component {
                   // Styling copied from how renderSuggestion is done with
                   // only bottom padding changed and 'no-results' class used
                   <Paper square className="people-search-dropdown">
-                    <MenuItem className="people-search-suggestion" style=
-                    {{paddingBottom: '5px'}}>
-                      <Typography className="no-results" variant="body2">
-                       No results
-                      </Typography>
-                    </MenuItem>
+                    {this.renderNoResult()}
                   </Paper>) : null}
               </span>
             )}

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -111,9 +111,8 @@ export default class GordonPeopleSearch extends Component {
       if (suggestionIndex === -1) suggestionIndex = suggestionList.length - 1;
       this.setState({ suggestionIndex });
     }
-    if (key === 'Backspace') { // Bug fixed where suggestions are remembered after backspacing
-      const suggestions = [];
-      this.setState({suggestions});
+    if (key === 'Backspace') {
+      this.setState({suggestions: []});
     }
   };
 
@@ -167,69 +166,67 @@ export default class GordonPeopleSearch extends Component {
       return null;
     }
     return (
-       <MenuItem
-         {...itemProps}
-         key={suggestion.UserName}
-         component={Link}
-         to={`/profile/${suggestion.UserName}`}
-         onClick={this.reset}
-         className={
-           suggestionList && suggestionList[suggestionIndex] !== undefined
-             ? suggestion.UserName === suggestionList[suggestionIndex].UserName &&
-               suggestionIndex !== -1
-               ? 'people-search-suggestion-selected '
-               : 'people-search-suggestion'
-             : 'people-search-suggestion'
-         }
-       >
-         <Typography variant="body2"> {
-         }
-           {/* If the query contains a space or a period, only highlight occurrences of the first
-               name part of the query in the first name, and only highlight occurrences of the last
-               name part of the query in the last name. Otherwise, highlight occurrences of the
-               query in the first and last name. */}
-           {this.state.highlightQuery.match(/ |\./)
-             ? [
-                 this.getHighlightedText(
-                   suggestion.FirstName + ' ',
-                   this.state.highlightQuery.split(/ |\./)[0],
-                 ),
-                 this.getHighlightedText(
-                   suggestion.LastName,
-                   this.state.highlightQuery.split(/ |\./)[1],
-                 ),
-               ].map(e => <span>{e}</span>)
-             : this.getHighlightedText(
-                 suggestion.FirstName + ' ' + suggestion.LastName,
-                 this.state.highlightQuery,
-               )}
-         </Typography>
-         <Typography variant="caption" component="p"> {
-         }
-           {/* If the first name matches either part (first or last name) of the query, don't
-               highlight occurrences of the query in the first name part of the username.
-               If the username contains a period, add it back in.
-               If the username contains a period,
-               If the last name matches either part (first of last name) of the query, don't
-               highlight occurrences of the query in the last name part of the username. */}
-            {!suggestion.FirstName.match(
+      <MenuItem
+        {...itemProps}
+        key={suggestion.UserName}
+        component={Link}
+        to={`/profile/${suggestion.UserName}`}
+        onClick={this.reset}
+        className={
+          suggestionList && suggestionList[suggestionIndex] !== undefined
+            ? suggestion.UserName === suggestionList[suggestionIndex].UserName &&
+              suggestionIndex !== -1
+              ? 'people-search-suggestion-selected '
+              : 'people-search-suggestion'
+            : 'people-search-suggestion'
+        }
+      >
+        <Typography variant="body2">
+          {/* If the query contains a space or a period, only highlight occurrences of the first
+              name part of the query in the first name, and only highlight occurrences of the last
+              name part of the query in the last name. Otherwise, highlight occurrences of the
+              query in the first and last name. */}
+          {this.state.highlightQuery.match(/ |\./)
+            ? [
+                this.getHighlightedText(
+                  suggestion.FirstName + ' ',
+                  this.state.highlightQuery.split(/ |\./)[0],
+                ),
+                this.getHighlightedText(
+                  suggestion.LastName,
+                  this.state.highlightQuery.split(/ |\./)[1],
+                ),
+              ].map(e => <span>{e}</span>)
+            : this.getHighlightedText(
+                suggestion.FirstName + ' ' + suggestion.LastName,
+                this.state.highlightQuery,
+              )}
+        </Typography>
+        <Typography variant="caption" component="p">
+          {/* If the first name matches either part (first or last name) of the query, don't
+              highlight occurrences of the query in the first name part of the username.
+              If the username contains a period, add it back in.
+              If the username contains a period,
+              If the last name matches either part (first of last name) of the query, don't
+              highlight occurrences of the query in the last name part of the username. */}
+          {!suggestion.FirstName.match(
             new RegExp(`(${this.highlightParse(this.state.highlightQuery)})`, 'i'),
+          )
+            ? this.getHighlightedText(suggestion.UserName.split('.')[0], this.state.highlightQuery)
+            : suggestion.UserName.split('.')[0]}
+          {suggestion.UserName.includes('.') && '.'}
+          {suggestion.UserName.includes('.') &&
+            (!suggestion.LastName.match(
+              new RegExp(`(${this.highlightParse(this.state.highlightQuery)})`, 'i'),
             )
-             ? this.getHighlightedText(suggestion.UserName.split('.')[0], this.state.highlightQuery)
-             : suggestion.UserName.split('.')[0]}
-           {suggestion.UserName.includes('.') && '.'}
-           {suggestion.UserName.includes('.') &&
-             (!suggestion.LastName.match(
-               new RegExp(`(${this.highlightParse(this.state.highlightQuery)})`, 'i'),
-             )
-               ? this.getHighlightedText(
-                   suggestion.UserName.split('.')[1],
-                   this.state.highlightQuery,
-                 )
-               : suggestion.UserName.split('.')[1])}
-         </Typography>
-       </MenuItem>
-     );
+              ? this.getHighlightedText(
+                  suggestion.UserName.split('.')[1],
+                  this.state.highlightQuery,
+                )
+              : suggestion.UserName.split('.')[1])}
+        </Typography>
+      </MenuItem>
+    );
   }
 
   //Makes People Search placeholder switch to People to avoid cutting it off

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -110,6 +110,10 @@ export default class GordonPeopleSearch extends Component {
       if (suggestionIndex === -1) suggestionIndex = suggestionList.length - 1;
       this.setState({ suggestionIndex });
     }
+    if (key === 'Backspace') { // Bug fixed where suggestions are remembered after backspacing
+      const suggestions = [];
+      this.setState({suggestions});
+    }
   };
 
   reset() {
@@ -149,72 +153,72 @@ export default class GordonPeopleSearch extends Component {
     let suggestionList = this.state.suggestions;
     // Bail if any required properties are missing
     if (!suggestion.UserName || !suggestion.FirstName || !suggestion.LastName) {
-      return null;
+      return;
     }
     return (
-      <MenuItem
-        {...itemProps}
-        key={suggestion.UserName}
-        component={Link}
-        to={`/profile/${suggestion.UserName}`}
-        onClick={this.reset}
-        className={
-          suggestionList && suggestionList[suggestionIndex] !== undefined
-            ? suggestion.UserName === suggestionList[suggestionIndex].UserName &&
-              suggestionIndex !== -1
-              ? 'people-search-suggestion-selected '
-              : 'people-search-suggestion'
-            : 'people-search-suggestion'
-        }
-      >
-        <Typography variant="body2">
-          {/* If the query contains a space or a period, only highlight occurrences of the first
-              name part of the query in the first name, and only highlight occurrences of the last
-              name part of the query in the last name. Otherwise, highlight occurrences of the
-              query in the first and last name. */}
-          {this.state.highlightQuery.match(/ |\./)
-            ? [
-                this.getHighlightedText(
-                  suggestion.FirstName + ' ',
-                  this.state.highlightQuery.split(/ |\./)[0],
-                ),
-                this.getHighlightedText(
-                  suggestion.LastName,
-                  this.state.highlightQuery.split(/ |\./)[1],
-                ),
-              ].map(e => <span>{e}</span>)
-            : this.getHighlightedText(
-                suggestion.FirstName + ' ' + suggestion.LastName,
-                this.state.highlightQuery,
-              )}
-        </Typography>
-        <Typography variant="caption" component="p">
-          {/* If the first name matches either part (first or last name) of the query, don't
-              highlight occurrences of the query in the first name part of the username.
-
-              If the username contains a period, add it back in.
-
-              If the username contains a period,
-              If the last name matches either part (first of last name) of the query, don't
-              highlight occurrences of the query in the last name part of the username. */}
-          {!suggestion.FirstName.match(
+       <MenuItem
+         {...itemProps}
+         key={suggestion.UserName}
+         component={Link}
+         to={`/profile/${suggestion.UserName}`}
+         onClick={this.reset}
+         className={
+           suggestionList && suggestionList[suggestionIndex] !== undefined
+             ? suggestion.UserName === suggestionList[suggestionIndex].UserName &&
+               suggestionIndex !== -1
+               ? 'people-search-suggestion-selected '
+               : 'people-search-suggestion'
+             : 'people-search-suggestion'
+         }
+       >
+         <Typography variant="body2"> {
+         }
+           {/* If the query contains a space or a period, only highlight occurrences of the first
+               name part of the query in the first name, and only highlight occurrences of the last
+               name part of the query in the last name. Otherwise, highlight occurrences of the
+               query in the first and last name. */}
+           {this.state.highlightQuery.match(/ |\./)
+             ? [
+                 this.getHighlightedText(
+                   suggestion.FirstName + ' ',
+                   this.state.highlightQuery.split(/ |\./)[0],
+                 ),
+                 this.getHighlightedText(
+                   suggestion.LastName,
+                   this.state.highlightQuery.split(/ |\./)[1],
+                 ),
+               ].map(e => <span>{e}</span>)
+             : this.getHighlightedText(
+                 suggestion.FirstName + ' ' + suggestion.LastName,
+                 this.state.highlightQuery,
+               )}
+         </Typography>
+         <Typography variant="caption" component="p"> {
+         }
+           {/* If the first name matches either part (first or last name) of the query, don't
+               highlight occurrences of the query in the first name part of the username.
+               If the username contains a period, add it back in.
+               If the username contains a period,
+               If the last name matches either part (first of last name) of the query, don't
+               highlight occurrences of the query in the last name part of the username. */}
+            {!suggestion.FirstName.match(
             new RegExp(`(${this.highlightParse(this.state.highlightQuery)})`, 'i'),
-          )
-            ? this.getHighlightedText(suggestion.UserName.split('.')[0], this.state.highlightQuery)
-            : suggestion.UserName.split('.')[0]}
-          {suggestion.UserName.includes('.') && '.'}
-          {suggestion.UserName.includes('.') &&
-            (!suggestion.LastName.match(
-              new RegExp(`(${this.highlightParse(this.state.highlightQuery)})`, 'i'),
             )
-              ? this.getHighlightedText(
-                  suggestion.UserName.split('.')[1],
-                  this.state.highlightQuery,
-                )
-              : suggestion.UserName.split('.')[1])}
-        </Typography>
-      </MenuItem>
-    );
+             ? this.getHighlightedText(suggestion.UserName.split('.')[0], this.state.highlightQuery)
+             : suggestion.UserName.split('.')[0]}
+           {suggestion.UserName.includes('.') && '.'}
+           {suggestion.UserName.includes('.') &&
+             (!suggestion.LastName.match(
+               new RegExp(`(${this.highlightParse(this.state.highlightQuery)})`, 'i'),
+             )
+               ? this.getHighlightedText(
+                   suggestion.UserName.split('.')[1],
+                   this.state.highlightQuery,
+                 )
+               : suggestion.UserName.split('.')[1])}
+         </Typography>
+       </MenuItem>
+     );
   }
 
   //Makes People Search placeholder switch to People to avoid cutting it off
@@ -315,7 +319,18 @@ export default class GordonPeopleSearch extends Component {
                       }),
                     )}
                   </Paper>
-                ) : null}
+                ) : isOpen && this.state.suggestions.length === 0 &&
+                  this.state.query.length >= MIN_QUERY_LENGTH ? (
+                  // Styling copied from how renderSuggestion is done with
+                  // only bottom padding changed and 'no-results' class used
+                    <Paper square className="people-search-dropdown">
+                      <MenuItem className="people-search-suggestion" style=
+                      {{paddingBottom: '5px'}}>
+                        <Typography className="no-results" variant="body2">
+                         No results
+                        </Typography>
+                      </MenuItem>
+                    </Paper>) : null}
               </span>
             )}
           </Downshift>
@@ -349,7 +364,18 @@ export default class GordonPeopleSearch extends Component {
                       }),
                     )}
                   </Paper>
-                ) : null}
+                ) : isOpen && this.state.suggestions.length === 0 &&
+                  this.state.query.length >= MIN_QUERY_LENGTH ? (
+                  // Styling copied from how renderSuggestion is done with
+                  // only bottom padding changed and 'no-results' class used
+                  <Paper square className="people-search-dropdown">
+                    <MenuItem className="people-search-suggestion" style=
+                    {{paddingBottom: '5px'}}>
+                      <Typography className="no-results" variant="body2">
+                       No results
+                      </Typography>
+                    </MenuItem>
+                  </Paper>) : null}
               </span>
             )}
           </Downshift>

--- a/src/components/Header/components/PeopleSearch/people-search.scss
+++ b/src/components/Header/components/PeopleSearch/people-search.scss
@@ -39,6 +39,11 @@
     background-color: white;
   }
 
+  .no-results {
+    font-style: italic;
+    color: gray;
+  }
+
   @media (min-width: 0px) {
     .people-search-root {
       width: 7rem;


### PR DESCRIPTION
src/components/Header/components/PeopleSearch/index.js: Added 'No results' dropdown when there are no people search suggestions & fixed bug where backspacing the search and entering when no suggestions dropdown is shown redirects the user to the first previously available top suggestion.

src/components/Header/components/PeopleSearch/people-search.scss: Added class for 'No results' for gray text and italics.

Edit: Added renderNoResult() function to avoid DRY code. Changed MIN_QUERY_LENGTH from 3 to 2 to include people searches for individuals with 2 letter first or last names.