### PR TITLE
Change default member roster view for mobile and smaller window sizes

### DIFF
--- a/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
+++ b/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
@@ -384,7 +384,7 @@ export default class MemberList extends Component {
           </Grid>
         );
         content = (
-          <ExpansionPanel defaultExpanded={showLeaveButton || this.state.admin}>
+          <ExpansionPanel defaultExpanded={(showLeaveButton || this.state.admin) && (!(window.innerWidth < this.breakpointWidth))}>
             <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
               <Grid container>
                 <Grid item xs={6} sm={7} md={8}>


### PR DESCRIPTION
Changes the default member roster view to collapsed on smaller window sizes. Helps clean up the UI on mobile and tablet views. 

Fixes [on Mobile - can the default roster view be collapsed for all members?] (https://github.com/gordon-cs/gordon-360-ui/issues/403) and [MembersList view on mobile looks messy] (https://github.com/gordon-cs/gordon-360-ui/issues/726)