### PR TITLE
(S20) UX Improvements to Involvement Profiles

### DIFF
--- a/src/views/ActivityProfile/activity-profile.scss
+++ b/src/views/ActivityProfile/activity-profile.scss
@@ -2,9 +2,6 @@
 
 .gordon-activity-profile {
   .activity-image {
-    margin-top: 25px;
-    margin-bottom: 25px;
-
     .img {
       max-width: 100%;
     }

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -25,6 +25,7 @@ import emails from '../../services/emails';
 import session from '../../services/session';
 import { gordonColors } from '../../theme';
 import user from '../../services/user';
+import { CardHeader } from '@material-ui/core';
 //import '../../app.js';
 
 const CROP_DIM = 320; // pixels
@@ -579,7 +580,6 @@ class ActivityProfile extends Component {
           if (activityBlurb.length !== 0) {
             description = (
               <Typography variant="body2">
-                {/* <strong>Description: </strong> */}
                 {activityBlurb}
               </Typography>
             );
@@ -588,7 +588,6 @@ class ActivityProfile extends Component {
           if (activityURL.length !== 0) {
             website = (
               <Typography variant="body2">
-                {/* <strong>Website: </strong> */}
                 <a href={activityURL} className="gc360-text-link" style={{fontWeight:"bold"}}>
                   {' '}
                   {activityURL}
@@ -628,12 +627,10 @@ class ActivityProfile extends Component {
             <section className="gordon-activity-profile">
               <Card>
                 <CardContent>
-                  <Typography align="center" variant="h5">
-                    {activityDescription}
-                  </Typography>
-                  <Typography variant="subtitle1" style={{color: "#777"}}>
-                    {sessionDescription}
-                  </Typography>
+                  <CardHeader
+                    title={activityDescription}
+                    subheader={sessionDescription}
+                  />
                   <Grid align="center" className="activity-image" item>
                     <img
                       alt={activity.activityDescription}
@@ -642,14 +639,15 @@ class ActivityProfile extends Component {
                     />
                   </Grid>
                   <Grid item>{editActivity}</Grid>
-                  <Typography variant="body2">
-                    {description}
-                  </Typography>
-                  <Typography variant="subtitle1">
-                    {website}
-                  </Typography>
+                  <Grid item style={{padding:"16px"}}>
+                    <Typography variant="body2">
+                      {description}
+                    </Typography>
+                    <Typography variant="subtitle1">
+                      {website}
+                    </Typography>
+                  </Grid>
 
-                  <br></br>
                   <hr width="70%"></hr>
                   <br></br>
 
@@ -670,6 +668,8 @@ class ActivityProfile extends Component {
                           <strong>Current Involvement Roster: </strong>
                           {membersNum} {membersWord} and {subscribersNum} {subscribersWord}
                         </Typography>
+                        {/* negative margin necessary because of default padding on Membership */}
+                        {/* perhaps defaults can be changed eventually if all use cases checked */}
                         <div style={{marginLeft: "-8px", padding: "8px 0"}}>
                           {membership}
                         </div>

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -579,7 +579,7 @@ class ActivityProfile extends Component {
           if (activityBlurb.length !== 0) {
             description = (
               <Typography variant="body2">
-                <strong>Description: </strong>
+                {/* <strong>Description: </strong> */}
                 {activityBlurb}
               </Typography>
             );
@@ -588,8 +588,8 @@ class ActivityProfile extends Component {
           if (activityURL.length !== 0) {
             website = (
               <Typography variant="body2">
-                <strong>Website: </strong>
-                <a href={activityURL} className="gc360-text-link">
+                {/* <strong>Website: </strong> */}
+                <a href={activityURL} className="gc360-text-link" style={{fontWeight:"bold"}}>
                   {' '}
                   {activityURL}
                 </a>
@@ -628,8 +628,11 @@ class ActivityProfile extends Component {
             <section className="gordon-activity-profile">
               <Card>
                 <CardContent>
-                  <Typography align="center" variant="display1">
+                  <Typography align="center" variant="h5">
                     {activityDescription}
+                  </Typography>
+                  <Typography variant="subtitle1" style={{color: "#777"}}>
+                    {sessionDescription}
                   </Typography>
                   <Grid align="center" className="activity-image" item>
                     <img
@@ -639,26 +642,26 @@ class ActivityProfile extends Component {
                     />
                   </Grid>
                   <Grid item>{editActivity}</Grid>
+                  <Typography variant="body2">
+                    {description}
+                  </Typography>
+                  <Typography variant="subtitle1">
+                    {website}
+                  </Typography>
+
+                  <br></br>
+                  <hr width="70%"></hr>
+                  <br></br>
+
                   {/* Activity Description */}
                   <Grid item justify="center" align="left">
                     <Grid container lg={12} direction="column" align="left">
-                        <Typography variant="body2">
-                          <strong>Session: </strong>
-                          {sessionDescription}
-                        </Typography>
-                        <Typography variant="body2">
-                          {description}
-                        </Typography>
-                        <Typography variant="body2">
-                          {website}
-                        </Typography>
                         <Typography variant="body2">
                           {groupContacts}
                         </Typography>
                         <Typography variant="body2">
                           {advisors}
                         </Typography>
-                                          
                         <Typography variant="body2">
                           <strong>Special Information for Joining: </strong>
                           {this.state.activityInfo.ActivityJoinInfo}
@@ -667,10 +670,12 @@ class ActivityProfile extends Component {
                           <strong>Current Involvement Roster: </strong>
                           {membersNum} {membersWord} and {subscribersNum} {subscribersWord}
                         </Typography>
+                        <div style={{marginLeft: "-8px", padding: "8px 0"}}>
+                          {membership}
+                        </div>
                     </Grid>
                   </Grid>
                 </CardContent>
-                {membership}
               </Card>
             </section>
           );

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -639,22 +639,36 @@ class ActivityProfile extends Component {
                     />
                   </Grid>
                   <Grid item>{editActivity}</Grid>
-                  <Typography variant="body2">
-                    <strong>Session: </strong>
-                    {sessionDescription}
-                  </Typography>
-                  {description}
-                  {website}
-                  {groupContacts}
-                  {advisors}
-                  <Typography>
-                    <strong>Special Information for Joining: </strong>
-                    {this.state.activityInfo.ActivityJoinInfo}
-                  </Typography>
-                  <Typography variant="body2">
-                    <strong>Current Involvement Roster: </strong>
-                    {membersNum} {membersWord} and {subscribersNum} {subscribersWord}
-                  </Typography>
+                  {/* Activity Description */}
+                  <Grid item justify="center" align="left">
+                    <Grid container lg={12} direction="column" align="left">
+                        <Typography variant="body2">
+                          <strong>Session: </strong>
+                          {sessionDescription}
+                        </Typography>
+                        <Typography variant="body2">
+                          {description}
+                        </Typography>
+                        <Typography variant="body2">
+                          {website}
+                        </Typography>
+                        <Typography variant="body2">
+                          {groupContacts}
+                        </Typography>
+                        <Typography variant="body2">
+                          {advisors}
+                        </Typography>
+                                          
+                        <Typography variant="body2">
+                          <strong>Special Information for Joining: </strong>
+                          {this.state.activityInfo.ActivityJoinInfo}
+                        </Typography>
+                        <Typography variant="body2">
+                          <strong>Current Involvement Roster: </strong>
+                          {membersNum} {membersWord} and {subscribersNum} {subscribersWord}
+                        </Typography>
+                    </Grid>
+                  </Grid>
                 </CardContent>
                 {membership}
               </Card>


### PR DESCRIPTION
Improved UX of the Involvement Profiles (Activity Profile)
- Cleaned up some of messy grid layout (overused nesting of containers)
- Increased font size of main heading
- Moved session/term details to be subtitle on top
- Centered description and website (bolded) and removed "Description: " type leading text
- Added horizontal divider between this above and the extra details
- Left aligned details and fixed paddings/margins

Resolves #724

![image](https://user-images.githubusercontent.com/17221652/84279849-83f03d80-ab04-11ea-9fa2-ab71b2413540.png)

![image](https://user-images.githubusercontent.com/17221652/84279898-936f8680-ab04-11ea-9519-0a8cc78772a5.png)
