### PR TITLE
(S20) PATCH 'News Page - "Submit News" and "View Personal Unapproved"' (sass opacity fix)

### DIFF
--- a/src/views/News/components/NewsItem/newsItem.scss
+++ b/src/views/News/components/NewsItem/newsItem.scss
@@ -12,7 +12,7 @@
 .unapproved .news-item {
     background-color: $neutral-light-gray;
     border-color: $neutral-gray;
-    opacity: 60%;
+    opacity: 0.6;
     font-style: italic;
 }
 
@@ -23,7 +23,7 @@
 }
 
 .unapproved .news-item:hover {
-    opacity: 100%;
+    opacity: 1.0;
     background-color: $neutral-gray;
 }
 


### PR DESCRIPTION
Patch to PR #825 
Sass does not interpret percentage opacity correctly, so changed to decimals
"Keep in mind, though, that if you are using Sass, it will not handle the percentage value, and will compile it to 1%."