### PR TITLE
(S20) News Page - "Delete News" UI

### DIFF
--- a/src/services/news.js
+++ b/src/services/news.js
@@ -150,7 +150,7 @@ const getNewsByCategory = async category => {
 }
 
 /**
- * Submits a student news
+ * Submits a student news item
  * @param {any} newsItem The data which makes up the student news item
  * @return {Promise<any>} Response body
  */
@@ -163,12 +163,27 @@ async function submitStudentNews(newsItem) {
   }
 };
 
+/**
+ * Deletes a student news item
+ * @param {any} newsID The SNID of the news item to delete
+ * @return {Promise<any>} Response body
+ */
+async function deleteStudentNews(newsID) {
+  try {
+    return http.delete('news', newsID);
+  }
+  catch (reason) {
+    console.log("Caught news deletion error: " + reason);
+  }
+};
+
 export default {
   getNewsByCategory,
-  submitStudentNews,
   getCategories,
   getTodaysNews,
   getPersonalUnapprovedFormatted,
   getNewNews,
   getNotExpiredFormatted,
+  submitStudentNews,
+  deleteStudentNews,
 };

--- a/src/services/news.js
+++ b/src/services/news.js
@@ -166,11 +166,11 @@ async function submitStudentNews(newsItem) {
 /**
  * Deletes a student news item
  * @param {any} newsID The SNID of the news item to delete
- * @return {Promise<any>} Response body
+ * @return {Promise.<Object>} deleted object
  */
 async function deleteStudentNews(newsID) {
   try {
-    return http.delete('news', newsID);
+    return http.del(`news/${newsID}`);
   }
   catch (reason) {
     console.log("Caught news deletion error: " + reason);

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -40,6 +40,8 @@ export default class NewsItem extends Component {
     else {
       this.props.updateSnackbar('News Posting Deleted Successfully');
     }
+    // Should be changed in future to allow react to only reload the updated news list
+    window.top.location.reload();
   }
 
   render() {

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -53,12 +53,30 @@ export default class NewsItem extends Component {
       // Shows 'pending approval' instead of the date posted
       posting.dayPosted = <i style={{textTransform: "lowercase"}}>"pending approval..."</i>;
     }
+    
+    // Only show the delete button if the current user is the author of the posting
+    let deleteButton;
+    if(this.props.currentUsername.toLowerCase() === posting.ADUN.toLowerCase()) {
+      deleteButton = (
+        <Button
+          variant="outlined"
+          color="primary"
+          startIcon={<DeleteIcon />}
+          onClick={this.handleDelete.bind(this)}
+        >
+          Delete
+        </Button>
+      );
+    }
+    else {
+      deleteButton = (<div></div>);
+    }
 
     // SINGLE SIZE - single column per news item
     if(size === "single") {
       return (
         <section style={this.props.style} className={unapproved ? "unapproved" : "approved"}>
-          <Grid container onClick={this.handleExpandClick} className="news-item">
+          <Grid container onClick={this.handleExpandClick} className="news-item" justify="center">
             <Grid item xs={12}>
               <Typography variant="h6" className="news-heading" style={{fontWeight: "bold"}}> {posting.Subject} </Typography>
               <Link className="news-authorProfileLink" to={`/profile/${posting.ADUN}`}>
@@ -72,14 +90,7 @@ export default class NewsItem extends Component {
                 <Typography className="news-content">"{posting.categoryName}"</Typography>
                 <Typography className="news-content ">{posting.Body}</Typography>
               </CardContent>
-              <Button
-                      variant="outlined"
-                      color="primary"
-                      startIcon={<DeleteIcon />}
-                      onClick={this.handleDelete.bind(this)}
-                    >
-                      Delete
-                    </Button>
+              {deleteButton}
             </Collapse>
           </Grid>
         </section>
@@ -117,14 +128,7 @@ export default class NewsItem extends Component {
                     </Typography>
                   </Grid>
                   <Grid item xs={4}>
-                    <Button
-                      variant="outlined"
-                      color="primary"
-                      startIcon={<DeleteIcon />}
-                      onClick={this.handleDelete.bind(this)}
-                    >
-                      Delete
-                    </Button>
+                    {deleteButton}
                   </Grid>
                 </Grid>
               </CardContent>
@@ -148,3 +152,5 @@ NewsItem.propTypes = {
     // Expiration: PropTypes.string.isRequired,
   }).isRequired,
 };
+
+

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -4,6 +4,9 @@ import React, { Component } from 'react';
 import CardContent from '@material-ui/core/CardContent';
 import Collapse from '@material-ui/core/Collapse';
 import Grid from '@material-ui/core/Grid';
+import Container from '@material-ui/core/Container';
+import Button from '@material-ui/core/Button';
+import DeleteIcon from '@material-ui/icons/Delete';
 import { Link } from 'react-router-dom';
 
 import './newsItem.scss';
@@ -84,6 +87,15 @@ export default class NewsItem extends Component {
                   {postingDescription}
                 </Typography>
               </CardContent>
+              <Container>
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  startIcon={<DeleteIcon />}
+                >
+                  Delete
+                </Button>
+              </Container>
             </Collapse>
           </Grid>
         </section>

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -4,8 +4,8 @@ import React, { Component } from 'react';
 import CardContent from '@material-ui/core/CardContent';
 import Collapse from '@material-ui/core/Collapse';
 import Grid from '@material-ui/core/Grid';
-import Container from '@material-ui/core/Container';
 import Button from '@material-ui/core/Button';
+import newsService from './../../../../services/news';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { Link } from 'react-router-dom';
 
@@ -16,15 +16,34 @@ export default class NewsItem extends Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      open: false,
+      posting: props.posting,
+      snackbarOpen: false,
+      snackbarMessage: 'Something went wrong',
+    };
+    
     this.handleExpandClick = this.handleExpandClick.bind(this);
-
-    this.state = { open: false };
   }
+
   handleExpandClick() {
     this.setState({ open: !this.state.open });
   }
+
+  async handleDelete() {
+    const newsID = this.state.posting.SNID;
+    // delete the news item and give feedback
+    let result = await newsService.deleteStudentNews(newsID);
+    if(result === undefined) {
+      this.props.updateSnackbar('News Posting Failed to Delete');
+    }
+    else {
+      this.props.updateSnackbar('News Posting Deleted Successfully');
+    }
+  }
+
   render() {
-    const { posting } = this.props;
+    const posting = this.state.posting;
     const { size } = this.props;
     const postingDescription = posting.Body;
     // Unapproved news should be distinct,
@@ -48,11 +67,19 @@ export default class NewsItem extends Component {
                 </Typography>
               </Link>
             </Grid>
-            <Collapse in={this.state.open} timeout="auto" unmountOnExit style={{textAlign: "left"}}>
+            <Collapse in={this.state.open} timeout="auto" unmountOnExit>
               <CardContent>
                 <Typography className="news-content">"{posting.categoryName}"</Typography>
                 <Typography className="news-content ">{posting.Body}</Typography>
               </CardContent>
+              <Button
+                      variant="outlined"
+                      color="primary"
+                      startIcon={<DeleteIcon />}
+                      onClick={this.handleDelete.bind(this)}
+                    >
+                      Delete
+                    </Button>
             </Collapse>
           </Grid>
         </section>
@@ -80,22 +107,27 @@ export default class NewsItem extends Component {
               <Typography className="news-column">{posting.dayPosted}</Typography>
             </Grid>
             
-            <Collapse in={this.state.open} timeout="auto" unmountOnExit style={{textAlign: "left"}}>
+            <Collapse in={this.state.open} timeout="auto" unmountOnExit style={{width: "100%"}}>
               <CardContent>
-                <Typography className="descriptionText">Description:</Typography>
-                <Typography type="caption" className="descriptionText">
-                  {postingDescription}
-                </Typography>
+                <Grid container direction="row" alignItems="center" justify="space-around">
+                  <Grid item xs={8} style={{textAlign: "left"}}>
+                    <Typography className="descriptionText">Description:</Typography>
+                    <Typography type="caption" className="descriptionText">
+                      {postingDescription}
+                    </Typography>
+                  </Grid>
+                  <Grid item xs={4}>
+                    <Button
+                      variant="outlined"
+                      color="primary"
+                      startIcon={<DeleteIcon />}
+                      onClick={this.handleDelete.bind(this)}
+                    >
+                      Delete
+                    </Button>
+                  </Grid>
+                </Grid>
               </CardContent>
-              <Container>
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  startIcon={<DeleteIcon />}
-                >
-                  Delete
-                </Button>
-              </Container>
             </Collapse>
           </Grid>
         </section>

--- a/src/views/News/components/NewsItem/newsItem.scss
+++ b/src/views/News/components/NewsItem/newsItem.scss
@@ -12,8 +12,11 @@
 .unapproved .news-item {
     background-color: $neutral-light-gray;
     border-color: $neutral-gray;
-    opacity: 0.6;
     font-style: italic;
+}
+
+.unapproved p {
+    opacity: 0.6;
 }
 
 .news-item:hover {
@@ -23,8 +26,11 @@
 }
 
 .unapproved .news-item:hover {
-    opacity: 1.0;
     background-color: $neutral-gray;
+}
+
+.unapproved .news-item:hover p {
+    opacity: 1.0;
 }
 
 .news-authorProfileLink {

--- a/src/views/News/components/NewsList/index.js
+++ b/src/views/News/components/NewsList/index.js
@@ -49,7 +49,7 @@ export default class NewsList extends Component {
     window.removeEventListener('resize', this.resize);
   }
 
-  render() {;
+  render() {
     const { news } = this.props;
     const { personalUnapprovedNews } = this.props;
     let postings;

--- a/src/views/News/components/NewsList/index.js
+++ b/src/views/News/components/NewsList/index.js
@@ -66,11 +66,22 @@ export default class NewsList extends Component {
     // Show single 'news' column for narrrow viewports
     if (window.innerWidth < this.breakpointWidth) {
       personalUnapprovedPostings = personalUnapprovedNews.map(posting => (
-        <NewsItem posting={posting} key={posting.SNID} size="single" unapproved/>
+        <NewsItem 
+          posting={posting} 
+          key={posting.SNID} 
+          size="single" 
+          updateSnackbar={this.props.updateSnackbar} 
+          currentUsername={this.props.currentUsername} 
+          unapproved/>
       ));
 
       postings = news.map(posting => (
-        <NewsItem posting={posting} key={posting.SNID} size="single" />
+        <NewsItem 
+          posting={posting} 
+          key={posting.SNID} 
+          size="single"
+          updateSnackbar={this.props.updateSnackbar} 
+          currentUsername={this.props.currentUsername}  />
       ));
 
       header = (
@@ -89,11 +100,22 @@ export default class NewsList extends Component {
     // Show full news columns in header for larger viewports
     else if (news) {
       personalUnapprovedPostings = personalUnapprovedNews.map(posting => (
-        <NewsItem posting={posting} key={posting.SNID} size="full" updateSnackbar={this.props.updateSnackbar} unapproved/>
+        <NewsItem 
+          posting={posting} 
+          key={posting.SNID} 
+          size="full" 
+          updateSnackbar={this.props.updateSnackbar} 
+          currentUsername={this.props.currentUsername} 
+          unapproved/>
       ));
 
       postings = news.map(posting => (
-        <NewsItem posting={posting} key={posting.SNID} updateSnackbar={this.props.updateSnackbar} size="full" />
+        <NewsItem 
+          posting={posting} 
+          key={posting.SNID} 
+          updateSnackbar={this.props.updateSnackbar} 
+          currentUsername={this.props.currentUsername}
+          size="full" />
       ));
         
       header = (

--- a/src/views/News/components/NewsList/index.js
+++ b/src/views/News/components/NewsList/index.js
@@ -49,7 +49,7 @@ export default class NewsList extends Component {
     window.removeEventListener('resize', this.resize);
   }
 
-  render() {
+  render() {;
     const { news } = this.props;
     const { personalUnapprovedNews } = this.props;
     let postings;
@@ -89,11 +89,11 @@ export default class NewsList extends Component {
     // Show full news columns in header for larger viewports
     else if (news) {
       personalUnapprovedPostings = personalUnapprovedNews.map(posting => (
-        <NewsItem posting={posting} key={posting.SNID} size="full" unapproved/>
+        <NewsItem posting={posting} key={posting.SNID} size="full" updateSnackbar={this.props.updateSnackbar} unapproved/>
       ));
 
       postings = news.map(posting => (
-        <NewsItem posting={posting} key={posting.SNID} size="full" />
+        <NewsItem posting={posting} key={posting.SNID} updateSnackbar={this.props.updateSnackbar} size="full" />
       ));
         
       header = (

--- a/src/views/News/index.js
+++ b/src/views/News/index.js
@@ -7,6 +7,7 @@ import PostAddIcon from '@material-ui/icons/PostAdd';
 import Typography from '@material-ui/core/Typography';
 import gordonEvent from './../../services/event';
 import news from './../../services/news';
+import userService from './../../services/user';
 import NewsList from '../News/components/NewsList';
 import GordonLoader from '../../components/Loader';
 import Card from '@material-ui/core/Card';
@@ -57,6 +58,7 @@ export default class StudentNews extends Component {
       newPostBody: '',
       snackbarOpen: false,
       snackbarMessage: 'Something went wrong',
+      currentUsername: '',
     };
     this.isMobileView = false;
     this.breakpointWidth = 540;
@@ -66,6 +68,14 @@ export default class StudentNews extends Component {
   componentWillMount() {
     this.setState({ loading: false })
     this.loadNews();
+    this.loadUsername();
+  }
+
+  async loadUsername() {
+    const user = await userService.getProfileInfo();
+    this.setState({
+      currentUsername: user.AD_Username,
+    });
   }
 
   handlePostClick() {
@@ -219,7 +229,8 @@ export default class StudentNews extends Component {
         content = <NewsList 
           news={this.state.news} 
           personalUnapprovedNews={this.state.personalUnapprovedNews}
-          updateSnackbar={this.updateSnackbar} />;
+          updateSnackbar={this.updateSnackbar}
+          currentUsername={this.state.currentUsername} />;
       } else {
         content = (
           <Grid item>

--- a/src/views/News/index.js
+++ b/src/views/News/index.js
@@ -60,6 +60,7 @@ export default class StudentNews extends Component {
     };
     this.isMobileView = false;
     this.breakpointWidth = 540;
+    this.updateSnackbar = this.updateSnackbar.bind(this);
   }
 
   componentWillMount() {
@@ -93,6 +94,11 @@ export default class StudentNews extends Component {
     this.setState({[event.target.name]: event.target.value});
   }
 
+  updateSnackbar(message) {
+    this.setState({ snackbarMessage: message });
+    this.setState({ snackbarOpen: true });
+  }
+
   async handleSubmit() {
     // create the JSON newsItem object to post
     let newsItem = {
@@ -104,12 +110,11 @@ export default class StudentNews extends Component {
     // submit the news item and give feedback
     let result = await news.submitStudentNews(newsItem);
     if(result === undefined) {
-      this.setState({ snackbarMessage: 'News Posting Failed to Submit' })
+      this.updateSnackbar('News Posting Failed to Submit');
     }
     else {
-      this.setState({ snackbarMessage: 'News Posting Submitted Successfully' })
+      this.updateSnackbar('News Posting Submitted Successfully');
     }
-    this.setState({ snackbarOpen: true })
 
     // close the window and reload to update data
     // (necessary since data is currently not pulled from render method)
@@ -213,7 +218,8 @@ export default class StudentNews extends Component {
       } else if (this.state.news.length > 0) {
         content = <NewsList 
           news={this.state.news} 
-          personalUnapprovedNews={this.state.personalUnapprovedNews} />;
+          personalUnapprovedNews={this.state.personalUnapprovedNews}
+          updateSnackbar={this.updateSnackbar} />;
       } else {
         content = (
           <Grid item>
@@ -360,7 +366,7 @@ export default class StudentNews extends Component {
                     ]}
                   ></Snackbar>
 
-              <Grid item xs={12} md={12} lg={8}>
+              <Grid item xs={12} md={12} lg={8} style={{marginBottom: "7rem"}}>
                 {/* list of news */}
                 {content}
               </Grid>


### PR DESCRIPTION
## NEWS FEATURE UPDATE 3.0
#### Initial UI For Delete News on the news page -> DEVELOP
News is still an unfinished feature. This pull request adds the ability to delete news displayed on the News Page UI from the database.

Currently Working:
- Delete news: a button that shows *only* for news items that the currently authenticated user has authored
- Snackbar displays success/failure message
Closes #805

Needs Work:
- Improve snackbar feedback (icon change? like with membership requests)
- Maybe see if there is any way to make snackbars not be terrible (have to pass through every child to send to each component, probably no workarounds).
- Delete button does not contrast well with approved news items (navy on cyan, perhaps change all news items to gray like unapproved news items)
- (Most things from News 2.0)
   - More consistent item heights
  - Perhaps allow re-rendering of data without refreshing page (move data retrieval from mount method to render method?)
  - Edit personal news items
  - Limit number of news entries get pulled into home card (or manage somehow)
  - Home card listings are sorted by category but not in the way originally intended (which is probably better anyway)
  - Search bar
  - Filter news page

![image](https://user-images.githubusercontent.com/17221652/87254837-bd91cc80-c453-11ea-9c0f-2bb0486a305b.png)
