### PR TITLE
(S20) PATCH 'News Page - "Delete News" UI' (bug reloading home page)

### DIFF
--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -57,8 +57,10 @@ export default class NewsItem extends Component {
     }
     
     // Only show the delete button if the current user is the author of the posting
+    // null check temporarily fixes issue on home card when user has not yet been authenticated
     let deleteButton;
-    if(this.props.currentUsername.toLowerCase() === posting.ADUN.toLowerCase()) {
+    if(this.props.currentUsername != null && 
+        this.props.currentUsername.toLowerCase() === posting.ADUN.toLowerCase()) {
       deleteButton = (
         <Button
           variant="outlined"


### PR DESCRIPTION
fixed bug reloading home page infinitely news
null username while not yet authenticated on home page
temporary patch probably, will need to be looked more carefully at in future