### PR TITLE
(S20) News Page - "Edit News" UI

### DIFF
--- a/src/services/news.js
+++ b/src/services/news.js
@@ -194,6 +194,10 @@ async function editStudentNews(newsID) {
   }
 };
 
+// async function getPostingByID(newsID) {
+
+// }
+
 export default {
   getNewsByCategory,
   getCategories,
@@ -204,4 +208,5 @@ export default {
   submitStudentNews,
   deleteStudentNews,
   editStudentNews,
+  // getPostingByISD,
 };

--- a/src/services/news.js
+++ b/src/services/news.js
@@ -156,7 +156,7 @@ const getNewsByCategory = async category => {
  */
 async function submitStudentNews(newsItem) {
   try {
-    return http.post('news', newsItem);
+    return await http.post('news', newsItem);
   }
   catch (reason) {
     console.log("Caught news submission error: " + reason);
@@ -170,10 +170,27 @@ async function submitStudentNews(newsItem) {
  */
 async function deleteStudentNews(newsID) {
   try {
-    return http.del(`news/${newsID}`);
+    return await http.del(`news/${newsID}`);
   }
   catch (reason) {
     console.log("Caught news deletion error: " + reason);
+  }
+};
+
+/**
+ * Edits a student news item
+ * Posting must be authored by user and unapproved to edit
+ * Calls delete, then create rather than an actual update request
+ * @param {any} newsID The SNID of the news item to delete
+ * @return {Promise.<Object>} deleted object
+ */
+async function editStudentNews(newsID) {
+  try {
+    const newsItem = await deleteStudentNews(newsID);
+    return await submitStudentNews(newsItem);
+  }
+  catch (reason) {
+    console.log("Caught news update error: " + reason);
   }
 };
 
@@ -186,4 +203,5 @@ export default {
   getNotExpiredFormatted,
   submitStudentNews,
   deleteStudentNews,
+  editStudentNews,
 };

--- a/src/services/news.js
+++ b/src/services/news.js
@@ -43,8 +43,7 @@ const getPersonalUnapproved = () => http.get('news/personal-unapproved');
 
 const getCategories = () => http.get(`news/categories`);
 
-// this has an await build in since it is a standalone call
-// const getPostingByID = (id) => await http.get(`news/${id}`);
+const getPostingByID = (id) => http.get(`news/${id}`);
 
 
 /**
@@ -196,12 +195,12 @@ async function deleteStudentNews(newsID) {
  * Posting must be authored by user and unapproved to edit
  * Calls delete, then create rather than an actual update request
  * @param {any} newsID The SNID of the news item to delete
+ * @param {any} newData The JSON object that contains new data for update
  * @return {Promise.<Object>} deleted object
  */
-async function editStudentNews(newsID) {
+async function editStudentNews(newsID, newData) {
   try {
-    const newsItem = await deleteStudentNews(newsID);
-    return await submitStudentNews(newsItem);
+    return await http.put(`news/${newsID}`, newData);
   }
   catch (reason) {
     console.log("Caught news update error: " + reason);
@@ -218,5 +217,5 @@ export default {
   submitStudentNews,
   deleteStudentNews,
   editStudentNews,
-  // getPostingByID,
+  getPostingByID,
 };

--- a/src/services/news.js
+++ b/src/services/news.js
@@ -4,6 +4,7 @@
  * @module studentNews
  */
  // Written by Jessica Guan
+ // Modified by Cameron Abbot
 
 import { DateTime } from 'luxon';
 import http from './http';
@@ -33,15 +34,18 @@ import http from './http';
  */
 
 
-
-
 const getNotExpired = () => http.get(`news/not-expired`);
 
+// news since 10am (today's news)
 const getNewNews = () => http.get(`news/new`);
 
 const getPersonalUnapproved = () => http.get('news/personal-unapproved');
 
 const getCategories = () => http.get(`news/categories`);
+
+// this has an await build in since it is a standalone call
+// const getPostingByID = (id) => await http.get(`news/${id}`);
+
 
 /**
  * Format a news posting by adding fields:
@@ -69,9 +73,11 @@ function formatPosting(posting) {
   posting.author = fname + " " + lname;
 }
 
+/******************* GET **********************/
+
 /**
- * Gets all unexpired news
- * for use on the News Page
+ * Gets all unexpired student news
+ * and formats
  * @return {Promise<any>} Student news
  */
 const getNotExpiredFormatted = async () => {
@@ -87,6 +93,7 @@ const getNotExpiredFormatted = async () => {
 /**
  * Gets today's news
  * for use on the Home Page card
+ * and formats
  * @return {Promise<any>} Student news
  */
 const getTodaysNews = async () => {
@@ -100,6 +107,7 @@ const getTodaysNews = async () => {
 }
 
 /**
+ * NOTE: not currently used, might be used in future filter features
  * Gets today's news for given category
  * for use on the Home Page card
  * @param {Number} category the category of news
@@ -149,6 +157,8 @@ const getNewsByCategory = async category => {
   return categoryNews;
 }
 
+/******************* POST **********************/
+
 /**
  * Submits a student news item
  * @param {any} newsItem The data which makes up the student news item
@@ -163,6 +173,8 @@ async function submitStudentNews(newsItem) {
   }
 };
 
+/******************* DELETE **********************/
+
 /**
  * Deletes a student news item
  * @param {any} newsID The SNID of the news item to delete
@@ -176,6 +188,8 @@ async function deleteStudentNews(newsID) {
     console.log("Caught news deletion error: " + reason);
   }
 };
+
+/******************* EDIT (PUT) **********************/
 
 /**
  * Edits a student news item
@@ -194,10 +208,6 @@ async function editStudentNews(newsID) {
   }
 };
 
-// async function getPostingByID(newsID) {
-
-// }
-
 export default {
   getNewsByCategory,
   getCategories,
@@ -208,5 +218,5 @@ export default {
   submitStudentNews,
   deleteStudentNews,
   editStudentNews,
-  // getPostingByISD,
+  // getPostingByID,
 };

--- a/src/views/Home/components/NewsCard/index.js
+++ b/src/views/Home/components/NewsCard/index.js
@@ -4,11 +4,11 @@
 // But currently it is not being implemented (commented out)
 // May be a potential future feature, but not sure
 
-
 import React, { Component } from 'react';
 import Grid from '@material-ui/core/Grid';
 import CardHeader from '@material-ui/core/CardHeader';
 import Card from '@material-ui/core/Card';
+import Typography from '@material-ui/core/Typography';
 import { CardContent } from '@material-ui/core';
 import { Button } from '@material-ui/core';
 import { gordonColors } from '../../../../theme';
@@ -50,7 +50,6 @@ export default class DailyNews extends Component {
 
   render() {
     // let categories;
-    let news;
 
     const button = {
       color: 'white',
@@ -64,10 +63,26 @@ export default class DailyNews extends Component {
     //     <CategorizedNews category={item.categoryID} />
     //   ));
 
-    news = this.state.news
-      .map(item => (
-        <NewsItem posting={item} key={item.SNID} size="single" style={{border: "2px solid #bbb", marginBottom: "-2px"}} />
+
+    let news;
+    if(this.state.news.length > 0) {
+      news = this.state.news.map(item => (
+        <NewsItem 
+          posting={item} 
+          key={item.SNID} 
+          size="single" 
+          style={{border: "2px solid #bbb", marginBottom: "-2px"}} 
+        />
       ));
+    }
+    else {
+      news = (
+        <Grid item>
+          <Typography variant="subtitle1">No News To Show</Typography>
+        </Grid>
+      );
+    }
+    
 
     return (
       <Card>

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -19,12 +19,14 @@ export default class NewsItem extends Component {
     super(props);
 
     this.state = {
+      // for collapsable news postings
       open: false,
       posting: props.posting,
       snackbarOpen: false,
       snackbarMessage: 'Something went wrong',
     };
     
+    // for collapsable news postings
     this.handleExpandClick = this.handleExpandClick.bind(this);
   }
 
@@ -69,10 +71,14 @@ export default class NewsItem extends Component {
     window.removeEventListener('message', () => {});
   }
 
+  // for collapsable news postings
   handleExpandClick() {
     this.setState({ open: !this.state.open });
   }
 
+  /**
+   * When the edit (like submit) button is clicked on update news posting form
+   */ 
   async handleEdit() {
     const newsID = this.state.posting.SNID;
     let newsItem = await newsService.deleteStudentNews(newsID);
@@ -89,23 +95,26 @@ export default class NewsItem extends Component {
     // window.top.location.reload();
   }
 
+  /**
+   * When the delete button is clicked for a posting
+   */
   async handleDelete() {
     const newsID = this.state.posting.SNID;
     // delete the news item and give feedback
     let result = await newsService.deleteStudentNews(newsID);
     if(result === undefined) {
       this.callFunction('updateSnackbar', 'News Posting Failed to Delete');
-      //this.props.updateSnackbar('News Posting Failed to Delete');
     }
     else {
       this.callFunction('updateSnackbar', 'News Posting Deleted Successfully');
-      //this.props.updateSnackbar('News Posting Deleted Successfully');
     }
     // Should be changed in future to allow react to only reload the updated news list
     window.top.location.reload();
   }
 
-  // Calls parent function in News
+  // Calls a parent function in News
+  // Must be passed down through props of each component
+  // News -> NewsList -> NewsItem (currently)
   callFunction(functionName, param) {
     this.props.callFunction(functionName, param);
   }
@@ -212,11 +221,20 @@ export default class NewsItem extends Component {
               <Typography className="news-column" style={{fontWeight: "bold"}}>{posting.Subject}</Typography>
             </Grid>
             <Grid item xs={3}>
+              
+              {this.state.network === 'online' ? 
+              // online -> show author profile link
               <Link className="news-authorProfileLink" to={`/profile/${posting.ADUN}`}>
-                <Typography className="news-column" style={{ textTransform: 'capitalize' }}>
+                <Typography variant="h7" className="news-column" style={{ textTransform: 'capitalize' }}>
                   {posting.author}
                 </Typography>
               </Link>
+              : 
+              // offline -> hide author profile link
+              <Typography variant="h7" className="news-column" style={{ textTransform: 'capitalize' }}>
+                {posting.author}
+              </Typography>}
+              
             </Grid>
             <Grid item xs={2}>
               <Typography className="news-column">{posting.dayPosted}</Typography>

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -81,20 +81,11 @@ export default class NewsItem extends Component {
 
   /**
    * When the edit (like submit) button is clicked on update news posting form
-   */ 
+   * (handled by News parent component)
+   */
   async handleEdit() {
     const newsID = this.state.posting.SNID;
     this.callFunction('handleNewsItemEdit', newsID);
-    // // update the news item and give feedback
-    // let result = await newsService.editStudentNews(newsID);
-    // if(result === undefined) {
-    //   this.props.updateSnackbar('News Posting Failed to Update');
-    // }
-    // else {
-    //   this.props.updateSnackbar('News Posting Updated Successfully');
-    // }
-    // // Should be changed in future to allow react to only reload the updated news list
-    // window.top.location.reload();
   }
 
   /**
@@ -135,6 +126,27 @@ export default class NewsItem extends Component {
       // Shows 'pending approval' instead of the date posted
       posting.dayPosted = <i style={{textTransform: "lowercase"}}>"pending approval..."</i>;
     }
+
+    let authorProfileLink;
+    if(!this.state.network === 'online' || unapproved) {
+      // offline or unapproved -> hide author profile link
+      authorProfileLink = (
+        <Typography variant="h7" className="news-column" style={{ textTransform: 'capitalize' }}>
+          {posting.author}
+        </Typography>
+      );
+    }
+    else {
+      // online and approved -> show author profile link
+      authorProfileLink = (
+        <Link className="news-authorProfileLink" to={`/profile/${posting.ADUN}`}>
+          <Typography variant="h7" className="news-column" style={{ textTransform: 'capitalize' }}>
+            {posting.author}
+          </Typography>
+        </Link>
+      );
+    }
+    
 
     // Only show the edit button if the current user is the author of the posting
     // AND posting is unapproved
@@ -186,20 +198,7 @@ export default class NewsItem extends Component {
           <Grid container onClick={this.handleExpandClick} className="news-item" justify="center">
             <Grid item xs={12}>
               <Typography variant="h6" className="news-heading" style={{fontWeight: "bold"}}> {posting.Subject} </Typography>
-              
-              {this.state.network === 'online' ? 
-              // online -> show author profile link
-              <Link className="news-authorProfileLink" to={`/profile/${posting.ADUN}`}>
-                <Typography variant="h7" className="news-column" style={{ textTransform: 'capitalize' }}>
-                  {posting.author}
-                </Typography>
-              </Link>
-              : 
-              // offline -> hide author profile link
-              <Typography variant="h7" className="news-column" style={{ textTransform: 'capitalize' }}>
-                {posting.author}
-              </Typography>}
-              
+              {authorProfileLink}
             </Grid>
             <Collapse in={this.state.open} timeout="auto" unmountOnExit>
               <CardContent>
@@ -227,20 +226,7 @@ export default class NewsItem extends Component {
               <Typography className="news-column" style={{fontWeight: "bold"}}>{posting.Subject}</Typography>
             </Grid>
             <Grid item xs={3}>
-              
-              {this.state.network === 'online' ? 
-              // online -> show author profile link
-              <Link className="news-authorProfileLink" to={`/profile/${posting.ADUN}`}>
-                <Typography variant="h7" className="news-column" style={{ textTransform: 'capitalize' }}>
-                  {posting.author}
-                </Typography>
-              </Link>
-              : 
-              // offline -> hide author profile link
-              <Typography variant="h7" className="news-column" style={{ textTransform: 'capitalize' }}>
-                {posting.author}
-              </Typography>}
-              
+              {authorProfileLink}
             </Grid>
             <Grid item xs={2}>
               <Typography className="news-column">{posting.dayPosted}</Typography>

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -13,7 +13,8 @@ import { Link } from 'react-router-dom';
 
 import './newsItem.scss';
 
-//Switched to table rows
+
+
 export default class NewsItem extends Component {
   constructor(props) {
     super(props);
@@ -29,6 +30,8 @@ export default class NewsItem extends Component {
     // for collapsable news postings
     this.handleExpandClick = this.handleExpandClick.bind(this);
   }
+
+
 
   componentDidMount() {
     /* Used to re-render the page when the network connection changes.
@@ -81,8 +84,7 @@ export default class NewsItem extends Component {
    */ 
   async handleEdit() {
     const newsID = this.state.posting.SNID;
-    let newsItem = await newsService.deleteStudentNews(newsID);
-    this.callFunction('populateNewsWindow', newsItem);
+    this.callFunction('handleNewsItemEdit', newsID);
     // // update the news item and give feedback
     // let result = await newsService.editStudentNews(newsID);
     // if(result === undefined) {
@@ -119,6 +121,9 @@ export default class NewsItem extends Component {
     this.props.callFunction(functionName, param);
   }
 
+
+
+
   render() {
     const posting = this.state.posting;
     const { size } = this.props;
@@ -134,6 +139,7 @@ export default class NewsItem extends Component {
     // Only show the edit button if the current user is the author of the posting
     // AND posting is unapproved
     // null check temporarily fixes issue on home card when user has not yet been authenticated
+    // it is because the home card doesn't give these properties
     let editButton;
     if(this.props.currentUsername != null && 
         this.props.currentUsername.toLowerCase() === posting.ADUN.toLowerCase() && unapproved) {
@@ -240,6 +246,7 @@ export default class NewsItem extends Component {
               <Typography className="news-column">{posting.dayPosted}</Typography>
             </Grid>
             
+            {/* Collapsable details */}
             <Collapse in={this.state.open} timeout="auto" unmountOnExit style={{width: "100%"}}>
               <CardContent>
                 <Grid container direction="row" alignItems="center" justify="space-around">
@@ -249,8 +256,10 @@ export default class NewsItem extends Component {
                       {postingDescription}
                     </Typography>
                   </Grid>
+                  {/* Possible action buttons */}
                   <Grid item xs={4}>
                     <Grid container justify="space-evenly">
+                      {/* these conditionally render - see respective methods */}
                       {editButton}
                       {deleteButton}
                     </Grid>

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -6,6 +6,7 @@ import Collapse from '@material-ui/core/Collapse';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import newsService from './../../../../services/news';
+import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { Link } from 'react-router-dom';
 
@@ -28,6 +29,20 @@ export default class NewsItem extends Component {
 
   handleExpandClick() {
     this.setState({ open: !this.state.open });
+  }
+
+  async handleEdit() {
+    const newsID = this.state.posting.SNID;
+    // update the news item and give feedback
+    let result = await newsService.editStudentNews(newsID);
+    if(result === undefined) {
+      this.props.updateSnackbar('News Posting Failed to Update');
+    }
+    else {
+      this.props.updateSnackbar('News Posting Updated Successfully');
+    }
+    // Should be changed in future to allow react to only reload the updated news list
+    window.top.location.reload();
   }
 
   async handleDelete() {
@@ -55,6 +70,27 @@ export default class NewsItem extends Component {
       // Shows 'pending approval' instead of the date posted
       posting.dayPosted = <i style={{textTransform: "lowercase"}}>"pending approval..."</i>;
     }
+
+    // Only show the edit button if the current user is the author of the posting
+    // AND posting is unapproved
+    let editButton;
+    console.log(this.props.currentUsername.toLowerCase() + " - " +  posting.ADUN.toLowerCase() + " - " +  unapproved);
+    if(this.props.currentUsername.toLowerCase() === posting.ADUN.toLowerCase() && unapproved) {
+      editButton = (
+        <Button
+          variant="outlined"
+          color="primary"
+          startIcon={<EditIcon />}
+          onClick={this.handleEdit.bind(this)}
+          className="btn"
+        >
+          Edit
+        </Button>
+      );
+    }
+    else {
+      editButton = (<div></div>);
+    }
     
     // Only show the delete button if the current user is the author of the posting
     let deleteButton;
@@ -65,6 +101,7 @@ export default class NewsItem extends Component {
           color="primary"
           startIcon={<DeleteIcon />}
           onClick={this.handleDelete.bind(this)}
+          className="btn deleteButton"
         >
           Delete
         </Button>
@@ -92,7 +129,10 @@ export default class NewsItem extends Component {
                 <Typography className="news-content">"{posting.categoryName}"</Typography>
                 <Typography className="news-content ">{posting.Body}</Typography>
               </CardContent>
-              {deleteButton}
+              <Grid container justify="space-evenly">
+                {editButton}
+                {deleteButton}
+              </Grid>
             </Collapse>
           </Grid>
         </section>
@@ -130,7 +170,10 @@ export default class NewsItem extends Component {
                     </Typography>
                   </Grid>
                   <Grid item xs={4}>
-                    {deleteButton}
+                    <Grid container justify="space-evenly">
+                      {editButton}
+                      {deleteButton}
+                    </Grid>
                   </Grid>
                 </Grid>
               </CardContent>

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -33,16 +33,18 @@ export default class NewsItem extends Component {
 
   async handleEdit() {
     const newsID = this.state.posting.SNID;
-    // update the news item and give feedback
-    let result = await newsService.editStudentNews(newsID);
-    if(result === undefined) {
-      this.props.updateSnackbar('News Posting Failed to Update');
-    }
-    else {
-      this.props.updateSnackbar('News Posting Updated Successfully');
-    }
-    // Should be changed in future to allow react to only reload the updated news list
-    window.top.location.reload();
+    let newsItem = await newsService.deleteStudentNews(newsID);
+    this.callFunction('populateNewsWindow', newsItem);
+    // // update the news item and give feedback
+    // let result = await newsService.editStudentNews(newsID);
+    // if(result === undefined) {
+    //   this.props.updateSnackbar('News Posting Failed to Update');
+    // }
+    // else {
+    //   this.props.updateSnackbar('News Posting Updated Successfully');
+    // }
+    // // Should be changed in future to allow react to only reload the updated news list
+    // window.top.location.reload();
   }
 
   async handleDelete() {
@@ -50,13 +52,20 @@ export default class NewsItem extends Component {
     // delete the news item and give feedback
     let result = await newsService.deleteStudentNews(newsID);
     if(result === undefined) {
-      this.props.updateSnackbar('News Posting Failed to Delete');
+      this.callFunction('updateSnackbar', 'News Posting Failed to Delete');
+      //this.props.updateSnackbar('News Posting Failed to Delete');
     }
     else {
-      this.props.updateSnackbar('News Posting Deleted Successfully');
+      this.callFunction('updateSnackbar', 'News Posting Deleted Successfully');
+      //this.props.updateSnackbar('News Posting Deleted Successfully');
     }
     // Should be changed in future to allow react to only reload the updated news list
     window.top.location.reload();
+  }
+
+  // Calls parent function in News
+  callFunction(functionName, param) {
+    this.props.callFunction(functionName, param);
   }
 
   render() {
@@ -73,9 +82,10 @@ export default class NewsItem extends Component {
 
     // Only show the edit button if the current user is the author of the posting
     // AND posting is unapproved
+    // null check temporarily fixes issue on home card when user has not yet been authenticated
     let editButton;
-    console.log(this.props.currentUsername.toLowerCase() + " - " +  posting.ADUN.toLowerCase() + " - " +  unapproved);
-    if(this.props.currentUsername.toLowerCase() === posting.ADUN.toLowerCase() && unapproved) {
+    if(this.props.currentUsername != null && 
+        this.props.currentUsername.toLowerCase() === posting.ADUN.toLowerCase() && unapproved) {
       editButton = (
         <Button
           variant="outlined"
@@ -94,7 +104,8 @@ export default class NewsItem extends Component {
     
     // Only show the delete button if the current user is the author of the posting
     let deleteButton;
-    if(this.props.currentUsername.toLowerCase() === posting.ADUN.toLowerCase()) {
+    if(this.props.currentUsername != null && 
+        this.props.currentUsername.toLowerCase() === posting.ADUN.toLowerCase()) {
       deleteButton = (
         <Button
           variant="outlined"

--- a/src/views/News/components/NewsItem/newsItem.scss
+++ b/src/views/News/components/NewsItem/newsItem.scss
@@ -58,3 +58,14 @@
 .unapproved .news-item:hover .news-heading {
     color: $neutral-dark-gray;
 }
+
+// Prepending "button." increases the specificity of the selector
+// and allows override of MUI theme
+button.btn {
+    margin: 0.5rem;
+}
+
+button.deleteButton {
+    border-color: $secondary-red;
+    color: $secondary-red;
+}

--- a/src/views/News/components/NewsList/index.js
+++ b/src/views/News/components/NewsList/index.js
@@ -72,6 +72,7 @@ export default class NewsList extends Component {
           size="single" 
           updateSnackbar={this.props.updateSnackbar} 
           currentUsername={this.props.currentUsername} 
+          callFunction={this.props.callFunction}
           unapproved/>
       ));
 
@@ -81,7 +82,8 @@ export default class NewsList extends Component {
           key={posting.SNID} 
           size="single"
           updateSnackbar={this.props.updateSnackbar} 
-          currentUsername={this.props.currentUsername}  />
+          currentUsername={this.props.currentUsername} 
+          callFunction={this.props.callFunction} />
       ));
 
       header = (
@@ -106,6 +108,7 @@ export default class NewsList extends Component {
           size="full" 
           updateSnackbar={this.props.updateSnackbar} 
           currentUsername={this.props.currentUsername} 
+          callFunction={this.props.callFunction}
           unapproved/>
       ));
 
@@ -115,6 +118,7 @@ export default class NewsList extends Component {
           key={posting.SNID} 
           updateSnackbar={this.props.updateSnackbar} 
           currentUsername={this.props.currentUsername}
+          callFunction={this.props.callFunction}
           size="full" />
       ));
         

--- a/src/views/News/index.js
+++ b/src/views/News/index.js
@@ -59,6 +59,7 @@ export default class StudentNews extends Component {
       snackbarOpen: false,
       snackbarMessage: 'Something went wrong',
       currentUsername: '',
+      isEditing: false,
     };
     this.isMobileView = false;
     this.breakpointWidth = 540;
@@ -135,12 +136,18 @@ export default class StudentNews extends Component {
       newPostCategory: newsItem.categoryID,
       newPostSubject: newsItem.Subject,
       newPostBody: newsItem.Body,
+      currentlyEditing: newsItem,
     });
   }
 
   updateSnackbar(message) {
     this.setState({ snackbarMessage: message });
     this.setState({ snackbarOpen: true });
+  }
+
+  async handleEdit() {
+    //delete the news item
+    //create news item
   }
 
   async handleSubmit() {
@@ -274,6 +281,25 @@ export default class StudentNews extends Component {
         );
       }
 
+      let submitButton = (
+        <Button 
+          variant="contained"
+          color="primary"
+          onClick={this.handleSubmit.bind(this)}
+          disabled={submitButtonDisabled}>
+          Submit
+        </Button>
+      );
+      let editButton = (
+        <Button 
+          variant="contained"
+          color="primary"
+          onClick={this.handleEdit.bind(this)}
+          disabled={submitButtonDisabled}>
+          Update
+        </Button>
+      );
+
       let news;
       // If the user is online
       if (networkStatus === 'online' || (networkStatus === 'offline' && this.props.Authentication)) {
@@ -377,21 +403,15 @@ export default class StudentNews extends Component {
                       </Grid>
                     </DialogContent>
 
-                    {/* CANCEL/SUBMIT */}
-                    <DialogActions>
+                    {/* CANCEL/SUBMIT/EDIT */}
+                    {<DialogActions>
                       <Button 
                         variant="contained" 
                         onClick={this.handleWindowClose.bind(this)}>
                         Cancel
                       </Button>
-                      <Button 
-                        variant="contained"
-                        color="primary"
-                        onClick={this.handleSubmit.bind(this)}
-                        disabled={submitButtonDisabled}>
-                        Submit
-                      </Button>
-                    </DialogActions>
+                      {this.state.isEditing ? editButton : submitButton}
+                    </DialogActions>}
                   </Dialog>
 
                   {/* USER FEEDBACK */}

--- a/src/views/News/index.js
+++ b/src/views/News/index.js
@@ -63,6 +63,8 @@ export default class StudentNews extends Component {
     this.isMobileView = false;
     this.breakpointWidth = 540;
     this.updateSnackbar = this.updateSnackbar.bind(this);
+    this.populateNewsWindow = this.populateNewsWindow.bind(this);
+    this.callFunction = this.callFunction.bind(this);
   }
 
   componentWillMount() {
@@ -102,6 +104,38 @@ export default class StudentNews extends Component {
                 "for the onChange() function to work");
     }
     this.setState({[event.target.name]: event.target.value});
+  }
+
+  callFunction(functionName, param) {    
+    if(functionName == null) {
+      throw new Error("Function name not specified to callFunction (news)");
+    }
+    switch(functionName) {
+      case 'updateSnackbar':
+        if(param == null) {
+          throw new Error("callFunction 'Update Snackbar' requires a parameter (news)");
+        }
+        this.updateSnackbar(param);
+        break;
+      case 'populateNewsWindow':
+        if(param == null) {
+          throw new Error("callFunction 'populateNewsWindow' requires a parameter (news)");
+        }
+        this.populateNewsWindow(param);
+        break;
+      default:
+        console.log("callFunction function name not applicable, double check your parameter");
+      }
+  }
+
+  populateNewsWindow(newsItem) {
+    // add an isEditing thing to state to save object from deletion on cancel (until endpoint added)
+    this.setState({ 
+      openPostActivity: true,
+      newPostCategory: newsItem.categoryID,
+      newPostSubject: newsItem.Subject,
+      newPostBody: newsItem.Body,
+    });
   }
 
   updateSnackbar(message) {
@@ -230,7 +264,8 @@ export default class StudentNews extends Component {
           news={this.state.news} 
           personalUnapprovedNews={this.state.personalUnapprovedNews}
           updateSnackbar={this.updateSnackbar}
-          currentUsername={this.state.currentUsername} />;
+          currentUsername={this.state.currentUsername}
+          callFunction={this.callFunction} />;
       } else {
         content = (
           <Grid item>


### PR DESCRIPTION
## NEWS FEATURE UPDATE 4.0
#### Initial UI For Edit News on the news page -> DEVELOP
News is still an unfinished feature. This pull request adds the ability to edit news displayed on the News Page UI from the database.

Currently Working:
- Edit news: a button that shows *only* for news items that the currently authenticated user has authored AND that are unapproved
- Snackbar displays success/failure message
Closes #830 

Needs Work:
- Everything from PR #829 
- Currently the whole page refreshes to update after submission/deletion/edition, but we should allow React to only re-render the updated parts

![image](https://user-images.githubusercontent.com/17221652/87586400-7bb09280-c6ae-11ea-8de8-c99185691812.png)
![image](https://user-images.githubusercontent.com/17221652/87586434-88cd8180-c6ae-11ea-9051-76e3ed2f1c9c.png)
