### PR TITLE
S20 pwa installer: Change back env variable to Train

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=https://360Api.gordon.edu/
+REACT_APP_API_URL=https://360ApiTrain.gordon.edu/

--- a/public/sw_global_variables.js
+++ b/public/sw_global_variables.js
@@ -5,7 +5,7 @@
 /* eslint-disable no-unused-vars */
 
 // Cache version
-const cacheVersion = 'cache v1.2';
+const cacheVersion = 'cache v1.3';
 
 // API Source
 // @PROD (** Make sure the URL is all lowercase or the service worker will fail to remove user data **)


### PR DESCRIPTION
Changes the production environment variable to point towards 360APITrain instead of 360API