### PR TITLE
Change shift rounding from 15 minutes to 5 minutes (quarter to 12th of an hour)

### DIFF
--- a/src/views/Timesheets/components/ShiftItem/index.js
+++ b/src/views/Timesheets/components/ShiftItem/index.js
@@ -222,8 +222,8 @@ export default class ShiftItem extends Component {
       zeroLengthShift = timeDiff === 0;
       shiftTooLong = calculatedTimeDiff > 20;
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
-      if (roundedHourDifference == 0.00) {
-        roundedHourDifference = 0.08; //minimum 1/12th hour for working a shift (5 minutes)
+      if (roundedHourDifference == "0.00") {
+        roundedHourDifference = "0.08"; //minimum 1/12th hour for working a shift (5 minutes)
       } 
 
       this.setState({

--- a/src/views/Timesheets/components/ShiftItem/index.js
+++ b/src/views/Timesheets/components/ShiftItem/index.js
@@ -222,10 +222,10 @@ export default class ShiftItem extends Component {
       zeroLengthShift = timeDiff === 0;
       shiftTooLong = calculatedTimeDiff > 20;
       let roundedHourDifference = 0;
-      if (calculatedTimeDiff > 0 && calculatedTimeDiff < 0.25) {
-        roundedHourDifference = 0.25;
-      } else if (calculatedTimeDiff >= 0.25) {
-        roundedHourDifference = (Math.round(calculatedTimeDiff * 4) / 4).toFixed(2);
+      if (calculatedTimeDiff > 0 && calculatedTimeDiff < 0.1) {
+        roundedHourDifference = 0.1;
+      } else if (calculatedTimeDiff >= 0.1) {
+        roundedHourDifference = (Math.round(calculatedTimeDiff * 10) / 10).toFixed(2);
       }
 
       this.setState({

--- a/src/views/Timesheets/components/ShiftItem/index.js
+++ b/src/views/Timesheets/components/ShiftItem/index.js
@@ -212,21 +212,19 @@ export default class ShiftItem extends Component {
     let shiftTooLong = false;
     let isOverlappingShift = false;
     let timeDiff;
-    let calculatedTimeDiff = timeDiff / 1000 / 60 / 60;
+    let calculatedTimeDiff = timeDiff / 3600000; //3,600,000 milliseconds in an hour.
     if (this.state.newDateTimeIn && this.state.newDateTimeOut) {
       enteredFutureTime =
         this.state.newDateTimeIn.getTime() > now || this.state.newDateTimeOut.getTime() > now;
       timeDiff = this.state.newDateTimeOut.getTime() - this.state.newDateTimeIn.getTime();
-      calculatedTimeDiff = timeDiff / 1000 / 60 / 60;
+      calculatedTimeDiff = timeDiff / 3600000; //3,600,000 milliseconds in an hour.
       timeOutIsBeforeTimeIn = timeDiff < 0;
       zeroLengthShift = timeDiff === 0;
       shiftTooLong = calculatedTimeDiff > 20;
-      let roundedHourDifference = 0;
-      if (calculatedTimeDiff > 0 && calculatedTimeDiff < 0.1) {
-        roundedHourDifference = 0.1;
-      } else if (calculatedTimeDiff >= 0.1) {
-        roundedHourDifference = (Math.round(calculatedTimeDiff * 10) / 10).toFixed(2);
-      }
+      let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
+      if (roundedHourDifference == 0.00) {
+        roundedHourDifference = 0.08; //minimum 1/12th hour for working a shift (5 minutes)
+      } 
 
       this.setState({
         newHoursWorked: roundedHourDifference,

--- a/src/views/Timesheets/components/ShiftItem/index.js
+++ b/src/views/Timesheets/components/ShiftItem/index.js
@@ -222,8 +222,8 @@ export default class ShiftItem extends Component {
       zeroLengthShift = timeDiff === 0;
       shiftTooLong = calculatedTimeDiff > 20;
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
-      if (roundedHourDifference == "0.00") {
-        roundedHourDifference = "0.08"; //minimum 1/12th hour for working a shift (5 minutes)
+      if (roundedHourDifference === 0.00) {
+        roundedHourDifference = 0.08; //minimum 1/12th hour for working a shift (5 minutes)
       } 
 
       this.setState({

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -140,8 +140,8 @@ const Timesheets = props => {
       let timeDiff = timeOut.getTime() - timeIn.getTime();
       let calculatedTimeDiff = timeDiff / 3600000; //3,600,000 milliseconds in an hour.
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
-      if (roundedHourDifference == "0.00") {
-        roundedHourDifference = "0.08"; //minimum 1/12th hour (5 minutes) for working a shift.
+      if (roundedHourDifference === 0.00) {
+        roundedHourDifference = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
       } 
       setHoursWorkedInDecimal(roundedHourDifference);
       let hoursWorked = Math.floor(calculatedTimeDiff);
@@ -222,8 +222,8 @@ const Timesheets = props => {
         let timeDiff2 = timeOut2.getTime() - timeIn2.getTime();
         let calculatedTimeDiff2 = timeDiff2 / 3600000; //3,600,000 milliseconds in an hour.
         let roundedHourDifference2 = (Math.round(calculatedTimeDiff2 * 12) / 12).toFixed(2);
-        if (roundedHourDifference2 == "0.00") {
-          roundedHourDifference2 = "0.08"; //minimum 1/12th hour (5 minutes) for working a shift.
+        if (roundedHourDifference2 === 0.00) {
+          roundedHourDifference2 = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
         } 
 
         // Do not save the shift if it has zero length
@@ -263,8 +263,8 @@ const Timesheets = props => {
       let timeDiff1 = timeOut.getTime() - timeIn.getTime();
       let calculatedTimeDiff = timeDiff1 / 3600000; //3,600,000 milliseconds in an hour.
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
-      if (roundedHourDifference == "0.00") {
-        roundedHourDifference = "0.08"; //minimum 1/12th hour (5 minutes) for working a shift.
+      if (roundedHourDifference === 0.00) {
+        roundedHourDifference = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
       } 
 
       saveShift(

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -138,13 +138,13 @@ const Timesheets = props => {
     if (timeIn !== null && timeOut !== null) {
       checkForFutureDate(timeIn, timeOut);
       let timeDiff = timeOut.getTime() - timeIn.getTime();
-      let calculatedTimeDiff = timeDiff / 1000 / 60 / 60;
-      let roundedHourDifference = 0;
-      if (calculatedTimeDiff > 0 && calculatedTimeDiff < 0.1) {
-        roundedHourDifference = 0.1;
-      } else if (calculatedTimeDiff >= 0.1) {
-        roundedHourDifference = (Math.round(calculatedTimeDiff * 10) / 10).toFixed(2);
+      let calculatedTimeDiff = timeDiff / 3600000; //3,600,000 milliseconds in an hour.
+      let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
+      
+      if (roundedHourDifference == 0.00) {
+        roundedHourDifference = 0.08; //minimum 1/12 hour for working a shift (5 minutes)
       }
+      
       setHoursWorkedInDecimal(roundedHourDifference);
       let hoursWorked = Math.floor(calculatedTimeDiff);
       let minutesWorked = Math.round((calculatedTimeDiff - hoursWorked) * 60).toFixed(2);
@@ -222,14 +222,14 @@ const Timesheets = props => {
         timeOut.setMinutes(59);
 
         let timeDiff2 = timeOut2.getTime() - timeIn2.getTime();
-        let calculatedTimeDiff2 = timeDiff2 / 1000 / 60 / 60;
-        let roundedHourDifference2 = 0;
-        if (calculatedTimeDiff2 > 0 && calculatedTimeDiff2 < 0.1) {
-          roundedHourDifference2 = 0.1;
-        } else if (calculatedTimeDiff2 >= 0.1) {
-          roundedHourDifference2 = (Math.round(calculatedTimeDiff2 * 10) / 10).toFixed(2);
+        let calculatedTimeDiff2 = timeDiff2 / 3600000; //3,600,000 milliseconds in an hour.
+        let roundedHourDifference2 = (Math.round(calculatedTimeDiff2 * 12) / 12).toFixed(2);
+        if (roundedHourDifference2 == 0.00) {
+          roundedHourDifference2 = 0.08; //minimum 1/12 hour for working a shift (5 minutes)
         }
-
+      
+      }
+        
         // Do not save the shift if it has zero length
         if (calculatedTimeDiff2 > 0) {
           saveShift(

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -140,10 +140,10 @@ const Timesheets = props => {
       let timeDiff = timeOut.getTime() - timeIn.getTime();
       let calculatedTimeDiff = timeDiff / 1000 / 60 / 60;
       let roundedHourDifference = 0;
-      if (calculatedTimeDiff > 0 && calculatedTimeDiff < 0.25) {
-        roundedHourDifference = 0.25;
-      } else if (calculatedTimeDiff >= 0.25) {
-        roundedHourDifference = (Math.round(calculatedTimeDiff * 4) / 4).toFixed(2);
+      if (calculatedTimeDiff > 0 && calculatedTimeDiff < 0.1) {
+        roundedHourDifference = 0.1;
+      } else if (calculatedTimeDiff >= 0.1) {
+        roundedHourDifference = (Math.round(calculatedTimeDiff * 10) / 10).toFixed(2);
       }
       setHoursWorkedInDecimal(roundedHourDifference);
       let hoursWorked = Math.floor(calculatedTimeDiff);
@@ -224,10 +224,10 @@ const Timesheets = props => {
         let timeDiff2 = timeOut2.getTime() - timeIn2.getTime();
         let calculatedTimeDiff2 = timeDiff2 / 1000 / 60 / 60;
         let roundedHourDifference2 = 0;
-        if (calculatedTimeDiff2 > 0 && calculatedTimeDiff2 < 0.25) {
-          roundedHourDifference2 = 0.25;
-        } else if (calculatedTimeDiff2 >= 0.25) {
-          roundedHourDifference2 = (Math.round(calculatedTimeDiff2 * 4) / 4).toFixed(2);
+        if (calculatedTimeDiff2 > 0 && calculatedTimeDiff2 < 0.1) {
+          roundedHourDifference2 = 0.1;
+        } else if (calculatedTimeDiff2 >= 0.1) {
+          roundedHourDifference2 = (Math.round(calculatedTimeDiff2 * 10) / 10).toFixed(2);
         }
 
         // Do not save the shift if it has zero length
@@ -267,10 +267,10 @@ const Timesheets = props => {
       let timeDiff1 = timeOut.getTime() - timeIn.getTime();
       let calculatedTimeDiff = timeDiff1 / 1000 / 60 / 60;
       let roundedHourDifference;
-      if (calculatedTimeDiff > 0 && calculatedTimeDiff < 0.25) {
-        roundedHourDifference = 0.25;
+      if (calculatedTimeDiff > 0 && calculatedTimeDiff < 0.1) {
+        roundedHourDifference = 0.1;
       } else {
-        roundedHourDifference = (Math.round(calculatedTimeDiff * 4) / 4).toFixed(2);
+        roundedHourDifference = (Math.round(calculatedTimeDiff * 10) / 10).toFixed(2);
       }
 
       saveShift(

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -140,8 +140,8 @@ const Timesheets = props => {
       let timeDiff = timeOut.getTime() - timeIn.getTime();
       let calculatedTimeDiff = timeDiff / 3600000; //3,600,000 milliseconds in an hour.
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
-      if (roundedHourDifference == 0.00) {
-        roundedHourDifference = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
+      if (roundedHourDifference == "0.00") {
+        roundedHourDifference = "0.08"; //minimum 1/12th hour (5 minutes) for working a shift.
       } 
       setHoursWorkedInDecimal(roundedHourDifference);
       let hoursWorked = Math.floor(calculatedTimeDiff);
@@ -222,8 +222,8 @@ const Timesheets = props => {
         let timeDiff2 = timeOut2.getTime() - timeIn2.getTime();
         let calculatedTimeDiff2 = timeDiff2 / 3600000; //3,600,000 milliseconds in an hour.
         let roundedHourDifference2 = (Math.round(calculatedTimeDiff2 * 12) / 12).toFixed(2);
-        if (roundedHourDifference2 == 0.00) {
-          roundedHourDifference2 = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
+        if (roundedHourDifference2 == "0.00") {
+          roundedHourDifference2 = "0.08"; //minimum 1/12th hour (5 minutes) for working a shift.
         } 
 
         // Do not save the shift if it has zero length
@@ -263,8 +263,8 @@ const Timesheets = props => {
       let timeDiff1 = timeOut.getTime() - timeIn.getTime();
       let calculatedTimeDiff = timeDiff1 / 3600000; //3,600,000 milliseconds in an hour.
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
-      if (roundedHourDifference == 0.00) {
-        roundedHourDifference = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
+      if (roundedHourDifference == "0.00") {
+        roundedHourDifference = "0.08"; //minimum 1/12th hour (5 minutes) for working a shift.
       } 
 
       saveShift(

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -140,11 +140,9 @@ const Timesheets = props => {
       let timeDiff = timeOut.getTime() - timeIn.getTime();
       let calculatedTimeDiff = timeDiff / 3600000; //3,600,000 milliseconds in an hour.
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
-      
       if (roundedHourDifference == 0.00) {
-        roundedHourDifference = 0.08; //minimum 1/12th hour for working a shift (5 minutes)
-      }
-      
+        roundedHourDifference = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
+      } 
       setHoursWorkedInDecimal(roundedHourDifference);
       let hoursWorked = Math.floor(calculatedTimeDiff);
       let minutesWorked = Math.round((calculatedTimeDiff - hoursWorked) * 60).toFixed(2);
@@ -225,13 +223,11 @@ const Timesheets = props => {
         let calculatedTimeDiff2 = timeDiff2 / 3600000; //3,600,000 milliseconds in an hour.
         let roundedHourDifference2 = (Math.round(calculatedTimeDiff2 * 12) / 12).toFixed(2);
         if (roundedHourDifference2 == 0.00) {
-          roundedHourDifference2 = 0.08; //minimum 1/12th hour for working a shift (5 minutes)
-        }
-      
-      }
-        
-      // Do not save the shift if it has zero length
-      if (calculatedTimeDiff2 > 0) {
+          roundedHourDifference2 = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
+        } 
+
+        // Do not save the shift if it has zero length
+        if (calculatedTimeDiff2 > 0) {
           saveShift(
             selectedJob.EMLID,
             timeIn2.toLocaleString(),
@@ -268,7 +264,7 @@ const Timesheets = props => {
       let calculatedTimeDiff = timeDiff1 / 3600000; //3,600,000 milliseconds in an hour.
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
       if (roundedHourDifference == 0.00) {
-        roundedHourDifference = 0.08; //minimum 1/12th hour for working a shift (5 minutes)
+        roundedHourDifference = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
       } 
 
       saveShift(

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -142,7 +142,7 @@ const Timesheets = props => {
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
       
       if (roundedHourDifference == 0.00) {
-        roundedHourDifference = 0.08; //minimum 1/12 hour for working a shift (5 minutes)
+        roundedHourDifference = 0.08; //minimum 1/12th hour for working a shift (5 minutes)
       }
       
       setHoursWorkedInDecimal(roundedHourDifference);
@@ -225,13 +225,13 @@ const Timesheets = props => {
         let calculatedTimeDiff2 = timeDiff2 / 3600000; //3,600,000 milliseconds in an hour.
         let roundedHourDifference2 = (Math.round(calculatedTimeDiff2 * 12) / 12).toFixed(2);
         if (roundedHourDifference2 == 0.00) {
-          roundedHourDifference2 = 0.08; //minimum 1/12 hour for working a shift (5 minutes)
+          roundedHourDifference2 = 0.08; //minimum 1/12th hour for working a shift (5 minutes)
         }
       
       }
         
-        // Do not save the shift if it has zero length
-        if (calculatedTimeDiff2 > 0) {
+      // Do not save the shift if it has zero length
+      if (calculatedTimeDiff2 > 0) {
           saveShift(
             selectedJob.EMLID,
             timeIn2.toLocaleString(),
@@ -265,13 +265,11 @@ const Timesheets = props => {
       }
 
       let timeDiff1 = timeOut.getTime() - timeIn.getTime();
-      let calculatedTimeDiff = timeDiff1 / 1000 / 60 / 60;
-      let roundedHourDifference;
-      if (calculatedTimeDiff > 0 && calculatedTimeDiff < 0.1) {
-        roundedHourDifference = 0.1;
-      } else {
-        roundedHourDifference = (Math.round(calculatedTimeDiff * 10) / 10).toFixed(2);
-      }
+      let calculatedTimeDiff = timeDiff1 / 3600000; //3,600,000 milliseconds in an hour.
+      let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
+      if (roundedHourDifference == 0.00) {
+        roundedHourDifference = 0.08; //minimum 1/12th hour for working a shift (5 minutes)
+      } 
 
       saveShift(
         selectedJob.EMLID,


### PR DESCRIPTION
Recording time more precisely will help make it affordable to hire Class Assistants to do cleaning between classes (lots of people, working frequent short shifts between their classes).