### PR TITLE
(F20) Student News Bug Fix - shows unapproved news even if no other news

### DIFF
--- a/src/views/News/index.js
+++ b/src/views/News/index.js
@@ -297,10 +297,10 @@ export default class StudentNews extends Component {
     const networkStatus = JSON.parse(localStorage.getItem('network-status')) || 'online';
 
     if(this.props.Authentication) {
-
+      
       if (this.state.loading === true) {
         content = <GordonLoader />;
-      } else if (this.state.news.length > 0) {
+      } else if (this.state.news.length > 0 || this.state.personalUnapprovedNews.length > 0) {
         content = <NewsList 
           news={this.state.filteredNews} 
           personalUnapprovedNews={this.state.personalUnapprovedNews}


### PR DESCRIPTION
Adds a simple logical condition so that unapproved news shows if it exists rather than just "No news to show"