### PR TITLE
Update privacy

### DIFF
--- a/src/components/ProfileList/index.js
+++ b/src/components/ProfileList/index.js
@@ -154,7 +154,8 @@ class ProfileList extends Component {
     if (!this.props.myProf) {
       this.setState({
         campusLocationDisclaimer:
-          this.props.profile.KeepPrivate === 'S' || this.props.profile.KeepPrivate === 'P',
+          (this.props.profile.KeepPrivate === 'S' || this.props.profile.KeepPrivate === 'P') &&
+          this.props.profile.onoffcampus !== PRIVATE_INFO,
       });
       this.setState({
         mobilePhoneDisclaimer:

--- a/src/components/ProfileList/index.js
+++ b/src/components/ProfileList/index.js
@@ -107,6 +107,7 @@ class ProfileList extends Component {
     super(props);
     this.state = {
       myProf: false, //if my profile page
+      campusLocationDisclaimer: false,
       mobilePhoneDisclaimer: false,
       homePhoneDisclaimer: false,
       addressDisclaimer: false,
@@ -151,6 +152,10 @@ class ProfileList extends Component {
   async componentWillMount() {
     this.setState({ isMobilePhonePrivate: this.props.profile.IsMobilePhonePrivate });
     if (!this.props.myProf) {
+      this.setState({
+        campusLocationDisclaimer:
+          this.props.profile.KeepPrivate === 'S' || this.props.profile.KeepPrivate === 'P',
+      });
       this.setState({
         mobilePhoneDisclaimer:
           this.props.profile.IsMobilePhonePrivate === 1 &&
@@ -238,7 +243,12 @@ class ProfileList extends Component {
     let advisors = createAdvisorsListItem(this.props.profile, rowWidths, { gridStyle });
 
     // Creates the Residence List Item
-    let residence = createResidenceListItem(this.props.profile, rowWidths, { gridStyle });
+    let residence = createResidenceListItem(
+      this.props.profile,
+      rowWidths,
+      { gridStyle },
+      this.state.campusLocationDisclaimer,
+    );
 
     // Creates the Mailbox List Item
     let mailloc = createMailboxItem(this.props.profile, rowWidths, { gridStyle });
@@ -249,6 +259,7 @@ class ProfileList extends Component {
       rowWidths,
       { privateTextStyle, gridStyle },
       this.props.myProf,
+      this.state.campusLocationDisclaimer,
     );
 
     // Creates the Student ID List Item

--- a/src/components/ProfileList/listItems.js
+++ b/src/components/ProfileList/listItems.js
@@ -16,7 +16,7 @@ import LockIcon from '@material-ui/icons/Lock';
  * @param {String} privateInfo A string that determines if a piece of information is private
  * @param {Object} rowWidths Determines the grid lengths of this list item
  * @param {Object} styles An object of all styles that this list item uses
- * @param {Boolean} addressDisclaimer Determines if the declaimer style should be used
+ * @param {Boolean} addressDisclaimer Determines if the disclaimer style should be used
  *
  * @return {JSX} The JSX of the Home List Item
  */
@@ -382,10 +382,11 @@ function createAdvisorsListItem(profile, rowWidths, styles) {
  * @param {Object} profile The profile of a user containing all information about them
  * @param {Object} rowWidths Determines the grid lengths of this list item
  * @param {Object} styles An object of all styles that this list item uses
+ * @param {Boolean} campusLocationDisclaimer Determines whether the disclaimer style should be used
  *
  * @return {JSX} The JSX of the Residence List Item
  */
-function createResidenceListItem(profile, rowWidths, styles) {
+function createResidenceListItem(profile, rowWidths, styles, campusLocationDisclaimer) {
   if (String(profile.PersonType).includes('stu') && profile.OnOffCampus !== '') {
     // Gets the row item widths
     const rowItemOne = rowWidths.twoItems.itemOne;
@@ -403,7 +404,9 @@ function createResidenceListItem(profile, rowWidths, styles) {
               style={styles.gridStyle.item}
               alignItems="center"
             >
-              <Typography>On/Off Campus:</Typography>
+              <Typography className={campusLocationDisclaimer ? 'disclaimer' : ''}>
+                On/Off Campus:
+              </Typography>
             </Grid>
             <Grid
               container
@@ -414,7 +417,9 @@ function createResidenceListItem(profile, rowWidths, styles) {
               style={styles.gridStyle.lastItem}
               alignItems="center"
             >
-              <Typography>{profile.OnOffCampus}</Typography>
+              <Typography className={campusLocationDisclaimer ? 'disclaimer' : ''}>
+                {profile.OnOffCampus}
+              </Typography>
             </Grid>
           </Grid>
         </ListItem>
@@ -431,10 +436,11 @@ function createResidenceListItem(profile, rowWidths, styles) {
  * @param {Object} rowWidths Determines the grid lengths of this list item
  * @param {Object} styles An object of all styles that this list item uses
  * @param {Boolean} myProf Determines if the current page is the My Profile page
+ * @param {Boolean} campusLocationDisclaimer Determines whether the disclaimer style should be used
  *
  * @return {JSX} The JSX of the Dorimitory List Item
  */
-function createDormitoryListItem(profile, rowWidths, styles, myProf) {
+function createDormitoryListItem(profile, rowWidths, styles, myProf, campusLocationDisclaimer) {
   if (String(profile.PersonType).includes('stu') && (profile.BuildingDescription || profile.Hall)) {
     // Gets the row item widths
     const rowItemOne = rowWidths.twoItems.itemOne;
@@ -452,7 +458,9 @@ function createDormitoryListItem(profile, rowWidths, styles, myProf) {
               style={styles.gridStyle.item}
               alignItems="center"
             >
-              <Typography>Dormitory: </Typography>
+              <Typography className={campusLocationDisclaimer ? 'disclaimer' : ''}>
+                Dormitory:{' '}
+              </Typography>
             </Grid>
             <Grid
               container
@@ -463,7 +471,7 @@ function createDormitoryListItem(profile, rowWidths, styles, myProf) {
               style={styles.gridStyle.lastItem}
               alignItems="center"
             >
-              <Typography>
+              <Typography className={campusLocationDisclaimer ? 'disclaimer' : ''}>
                 {profile.BuildingDescription ? profile.BuildingDescription : profile.Hall}
                 {myProf && profile.OnCampusRoom ? (
                   <span style={styles.privateTextStyle}>, Room {profile.OnCampusRoom}</span>

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -210,7 +210,7 @@ function setOnOffCampus(data) {
       data.OnOffCampus = '';
       break;
     case 'P': //Private
-      data.OnOffCampus = '';
+      data.OnOffCampus = 'Private as requested.';
       break;
     default:
       data.OnOffCampus = 'On Campus';

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -168,7 +168,7 @@ import gordonEvent from './event';
  * @property {String} PersonType Type of person
  */
 
- /**
+/**
  * @global
  * @typedef StudentAdvisorInfo
  * @property {String} Firstname First Name for advisor
@@ -207,6 +207,9 @@ function setOnOffCampus(data) {
       data.OnOffCampus = 'Away';
       break;
     case 'D':
+      data.OnOffCampus = '';
+      break;
+    case 'P': //Private
       data.OnOffCampus = '';
       break;
     default:
@@ -450,7 +453,7 @@ const getAdvisor = async username => {
   let advisor;
   advisor = await http.get(`profiles/Advisors/${username}/`);
   return advisor;
-}
+};
 
 async function setMobilePhonePrivacy(makePrivate) {
   // 'Y' = private, 'N' = public

--- a/src/views/Profile/index.js
+++ b/src/views/Profile/index.js
@@ -12,6 +12,7 @@ import { socialMediaInfo } from '../../socialMedia';
 import GordonSchedulePanel from '../../components/SchedulePanel';
 import { Identification } from '../../components/Identification/index';
 import storage from '../../services/storage';
+import { Redirect } from 'react-router';
 
 import './profile.css';
 import '../../app.css';
@@ -189,6 +190,10 @@ export default class Profile extends Component {
 
   render() {
     if (this.props.Authentication) {
+      if (this.state.error && this.state.error.name === 'NotFoundError') {
+        return <Redirect to="/profilenotfound" />;
+      }
+
       // Creates the Public Profile page depending on the status of the network
       let PublicProfile;
       if (this.state.network === 'online') {


### PR DESCRIPTION
Fix privacy for students marked as semi-private - their on/off campus status and dorm should be hidden from other students.

Because this is an issue of privacy concerns, it can't wait for the features in develop to become stable, so this is being merged directly into master. It has been tested thoroughly locally.

This branch updates the front end to properly display the updated (obscured) info received from the backend. However, all obscuring of info is done in the backend, so the info will still display until the backend update is merged.

Semi-private students now have an on/off campus value of 'P' for private, and the front end will display 'Private as requested' when this is received. 

Furthermore, both private and semi-private students will show on/off campus status and dorm to FacStaff as sensitive info.

Finally, when a request is sent for which the profile returned is null (i.e. because the profile is private to the logged in user), the user will be redirected to the 404page at the url /profilenotfound, rather than hanging on the loading indicator.