### PR TITLE
Fix attnd events sort

### DIFF
--- a/src/services/user.js
+++ b/src/services/user.js
@@ -396,7 +396,7 @@ const getLocalInfo = () => {
  * is non-null, since users would rather know when the event was
  * than when they got credit.
  * 
- * @param {JSON} event 
+ * @param {JSON} event : an event the user attended
  * @returns {DateTime} event.CHDate or event.Occurrences[0][0]
  * (since Occurences is a list of lists of start and end times
  * for each re-occurence of an event)
@@ -417,8 +417,9 @@ function getAtndEventTime(event) {
  * can sometimes be weeks after an event due to slow
  * processing.
  * 
- * @param {JSON} a 
- * @param {JSON} b 
+ * @param {JSON} a : an event
+ * @param {JSON} b : another event
+ * @returns {int} -1 if a's time is less than b's, 1 if it's more, 0 if they're equal
  */
 function sortAtndEventsByTime(a, b) {
 

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -390,17 +390,26 @@ const getLocalInfo = () => {
   }
 };
 
+function sortAtndEventsByTime(a, b) {
+  if (a.CHDate < b.CHDate) {
+    return -1;
+  }
+  if (a.CHDate > b.CHDate) {
+    return 1;
+  }
+  return 0;
+}
+
 //Call function to retrieve events from database then format them
 const getAttendedChapelEventsFormatted = async () => {
   const termCode = session.getTermCode();
   const attendedEvents = await getAttendedChapelEvents(termCode);
   const events = [];
-  attendedEvents.sort(gordonEvent.sortByTime);
   for (let i = 0; i < attendedEvents.length; i += 1) {
     events.push(attendedEvents[i]);
     gordonEvent.formatevent(attendedEvents[i]);
   }
-  return events.sort(gordonEvent.sortByTime);
+  return events.sort(sortAtndEventsByTime);
 };
 
 /**

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -390,21 +390,45 @@ const getLocalInfo = () => {
   }
 };
 
+/**
+ * Get the CHDate (the datetime when a user received CL&W credit)
+ * unless Occurrences (the actual datetime when the event occured)
+ * is non-null, since users would rather know when the event was
+ * than when they got credit.
+ * 
+ * @param {JSON} event 
+ * @returns {DateTime} event.CHDate or event.Occurrences[0][0]
+ * (since Occurences is a list of lists of start and end times
+ * for each re-occurence of an event)
+ */
+function getAtndEventTime(event) {
+  if (event.Occurrences[0]) {
+    return event.Occurrences[0][0];
+  }
+  return event.CHDate;
+}
+
+/**
+ * Determines in which order two JSON event objects
+ * should be sorted based on a time associated with them.
+ * Note that this does not necessarily sort events by 
+ * when they occurred, since getAtndEventTime
+ * may have to resort to using CHDate. CHDate
+ * can sometimes be weeks after an event due to slow
+ * processing.
+ * 
+ * @param {JSON} a 
+ * @param {JSON} b 
+ */
 function sortAtndEventsByTime(a, b) {
 
-  let timeA = a.CHDate;
-  if (a.Occurrences[0]) {
-    timeA = a.Occurrences[0][0];
-  }
-  let timeB = b.CHDate;
-  if (b.Occurrences[0]) {
-    timeB = b.Occurrences[0][0];
-  }
+  let tA = getAtndEventTime(a);
+  let tB = getAtndEventTime(b);
 
-  if (timeA < timeB) {
+  if (tA < tB) {
     return -1;
   }
-  if (timeA > timeB) {
+  if (tA > tB) {
     return 1;
   }
   return 0;

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -391,10 +391,20 @@ const getLocalInfo = () => {
 };
 
 function sortAtndEventsByTime(a, b) {
-  if (a.CHDate < b.CHDate) {
+
+  let timeA = a.CHDate;
+  if (a.Occurrences[0]) {
+    timeA = a.Occurrences[0][0];
+  }
+  let timeB = b.CHDate;
+  if (b.Occurrences[0]) {
+    timeB = b.Occurrences[0][0];
+  }
+
+  if (timeA < timeB) {
     return -1;
   }
-  if (a.CHDate > b.CHDate) {
+  if (timeA > timeB) {
     return 1;
   }
   return 0;


### PR DESCRIPTION
# Background

Because the `sortByTime` function was never exported from event.js, its use in user.js to sort attended chapel events never had any effect. Attended chapel events were not sorted. 
To make matters more complicated, a recent change in where chapel event data originates has left most chapel events without `Occurrences` values, which is what `sortByTime` uses to sort events.  
The goal of this fix was to make sure attended events are sorted for uses.

#  Solution

A new sorter function was created in user.js, `sortAtndEventsByTime`, that sorts based off of `Occurrences` only if it is non-null and by `CHDate` otherwise. `CHDate` works well as a default for sorting attended chapel events because it is the time when a student is awarded credit for the event and thus should never be null. (At least, based on how this time is always close to but rarely the same as the end time of the event, I assumed that is what `CHDate` is.) By calling `console.log()` on `events.sort(sortAtndEventsByTime)`, which is the same thing that the 'EventsAttended' component displays, it is clear that this new sorter works: (The datetimes with arrows pointing to them and the one crossed out are where `Occurrences` was used to sort, the remaining ones (bracketed) were where `CHDate` was used to sort.)
![Screenshot 1](https://user-images.githubusercontent.com/47014800/97095746-5c23f100-1631-11eb-8622-c00b9ca569fe.png)
By making some dummy-data, a single event that is just 1 minute later than a real event, you can also see that the time zone on the end `Occurences` datetime does not cause problems when comparing to `CHDate`, which is missing the time zone in its format:
![Screenshot 2](https://user-images.githubusercontent.com/47014800/97095798-fbe17f00-1631-11eb-9e88-73e984ecc778.png)

