### PR TITLE
Fix Timesheets bug with Timezones

### DIFF
--- a/src/views/Timesheets/components/SavedShiftsList/index.js
+++ b/src/views/Timesheets/components/SavedShiftsList/index.js
@@ -43,12 +43,12 @@ export default class SavedShiftsList extends Component {
       let canUse = await jobs.getStaffPageForUser();
 
       if (canUse.length === 1) {
-        this.setState({getStaffPageForUser: true});
+        this.setState({ getStaffPageForUser: true });
       } else {
-        this.setState({getStaffPageForUser: false});
+        this.setState({ getStaffPageForUser: false });
       }
     } catch (error) {
-        //do nothing
+      //do nothing
     }
   }
 
@@ -61,7 +61,7 @@ export default class SavedShiftsList extends Component {
   };
 
   submitShiftsToSupervisor = (shifts, supervisorID) => {
-    jobs.submitShiftsForUser(this.state.getStaffPageForUser, shifts, supervisorID).then(response => {
+    jobs.submitShifts(this.state.getStaffPageForUser, shifts, supervisorID).then((response) => {
       this.setState({
         selectedSupervisor: null,
         showSubmissionConfirmation: false,
@@ -79,26 +79,30 @@ export default class SavedShiftsList extends Component {
   };
 
   getSupervisors() {
-    jobs.getSupervisorNameForJob(this.state.getStaffPageForUser, this.props.directSupervisor).then(response => {
-      let directSupervisor =
-        response[0].FIRST_NAME + ' ' + response[0].LAST_NAME + ' (Direct Supervisor)';
-      let directSupervisorObject = {
-        name: directSupervisor,
-        id: this.props.directSupervisor,
-      };
+    jobs
+      .getSupervisor(this.state.getStaffPageForUser, this.props.directSupervisor)
+      .then((response) => {
+        let directSupervisor =
+          response[0].FIRST_NAME + ' ' + response[0].LAST_NAME + ' (Direct Supervisor)';
+        let directSupervisorObject = {
+          name: directSupervisor,
+          id: this.props.directSupervisor,
+        };
 
-      jobs.getSupervisorNameForJob(this.state.getStaffPageForUser, this.props.reportingSupervisor).then(response => {
-        let supervisor =
-          response[0].FIRST_NAME + ' ' + response[0].LAST_NAME + ' (Reporting Supervisor)';
-        this.setState({
-          directSupervisor: directSupervisorObject,
-          reportingSupervisor: {
-            name: supervisor,
-            id: this.props.reportingSupervisor,
-          },
-        });
+        jobs
+          .getSupervisor(this.state.getStaffPageForUser, this.props.reportingSupervisor)
+          .then((response) => {
+            let supervisor =
+              response[0].FIRST_NAME + ' ' + response[0].LAST_NAME + ' (Reporting Supervisor)';
+            this.setState({
+              directSupervisor: directSupervisorObject,
+              reportingSupervisor: {
+                name: supervisor,
+                id: this.props.reportingSupervisor,
+              },
+            });
+          });
       });
-    });
   }
 
   componentDidMount() {
@@ -109,7 +113,8 @@ export default class SavedShiftsList extends Component {
       shouldGetSupervisors =
         this.props.cardTitle === 'Saved Shifts' &&
         (shifts[0].EML !== this.prevJob ||
-          !this.state.directSupervisor || !this.state.reportingSupervisor);
+          !this.state.directSupervisor ||
+          !this.state.reportingSupervisor);
       this.prevJob = shifts[0].EML;
     } else {
       shouldGetSupervisors =
@@ -132,7 +137,8 @@ export default class SavedShiftsList extends Component {
       shouldGetSupervisors =
         this.props.cardTitle === 'Saved Shifts' &&
         (shifts[0].EML !== this.prevJob ||
-          !this.state.directSupervisor || !this.state.reportingSupervisor);
+          !this.state.directSupervisor ||
+          !this.state.reportingSupervisor);
       this.prevJob = shifts[0].EML;
     } else {
       shouldGetSupervisors =
@@ -245,7 +251,7 @@ export default class SavedShiftsList extends Component {
         <InputLabel className="disable-select">Submit To</InputLabel>
         <Select
           value={this.state.selectedSupervisor}
-          onChange={e => {
+          onChange={(e) => {
             this.setState({
               selectedSupervisor: e.target.value,
             });

--- a/src/views/Timesheets/components/ShiftDisplay/index.js
+++ b/src/views/Timesheets/components/ShiftDisplay/index.js
@@ -34,12 +34,12 @@ export default class ShiftDisplay extends Component {
       let canUse = await jobs.getStaffPageForUser();
 
       if (canUse.length === 1) {
-        this.setState({getStaffPageForUser: true});
+        this.setState({ getStaffPageForUser: true });
       } else {
-        this.setState({getStaffPageForUser: false});
+        this.setState({ getStaffPageForUser: false });
       }
     } catch (error) {
-        //do nothing
+      //do nothing
     }
   }
 
@@ -67,7 +67,7 @@ export default class ShiftDisplay extends Component {
 
   loadShifts() {
     const { getSavedShiftsForUser } = this.props;
-    return getSavedShiftsForUser().then(data => {
+    return getSavedShiftsForUser().then((data) => {
       for (let i = 0; i < data.length; i++) {
         this.jobNamesSet.add(data[i].EML_DESCRIPTION);
       }
@@ -94,8 +94,14 @@ export default class ShiftDisplay extends Component {
   }
 
   editShift = (rowID, startTime, endTime, hoursWorked) => {
-    let promise = jobs.editShift(this.state.getStaffPageForUser, rowID, startTime, endTime, hoursWorked);
-    promise.then(response => {
+    let promise = jobs.editShift(
+      this.state.getStaffPageForUser,
+      rowID,
+      startTime,
+      endTime,
+      hoursWorked,
+    );
+    promise.then((response) => {
       this.loadShifts();
     });
     return promise;
@@ -103,7 +109,7 @@ export default class ShiftDisplay extends Component {
 
   deleteShiftForUser(rowID, emlDesc) {
     let result = jobs
-      .deleteShiftForUser(this.state.getStaffPageForUser, rowID)
+      .deleteShift(this.state.getStaffPageForUser, rowID)
       .then(() => {
         this.jobNamesSet.delete(emlDesc);
         this.loadShifts();
@@ -166,7 +172,7 @@ export default class ShiftDisplay extends Component {
 
     let theTabs = (
       <Media query="(min-width: 600px)">
-        {matches =>
+        {(matches) =>
           matches ? (
             <Tabs
               centered

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -99,7 +99,7 @@ const Timesheets = (props) => {
     // status is notted by either true or false. true being clocked in.
     async function getClockInOutStatus() {
       try {
-        let status = await jobs.clockOut();
+        let status = await jobs.getClockIns();
 
         if (status[0].currentState) {
           setClockInOut('Clock Out');
@@ -167,17 +167,11 @@ const Timesheets = (props) => {
 
   if (props.authentication) {
     const getActiveJobsForUser = (dateIn, dateOut) => {
-      let details = {
-        shift_start_datetime: dateIn.toISOString(),
-        shift_end_datetime: dateOut.toISOString(),
-      };
-      jobs.getActiveJobsForUser(canUseStaff, details).then((result) => {
-        setUserJobs(result);
-      });
+      jobs.getActiveJobs(canUseStaff, dateIn, dateOut).then((jobs) => setUserJobs(jobs));
     };
 
     const getSavedShiftsForUser = () => {
-      return jobs.getSavedShiftsForUser(canUseStaff);
+      return jobs.getShifts(canUseStaff);
     };
 
     const handleDateChangeIn = (date) => {
@@ -234,8 +228,8 @@ const Timesheets = (props) => {
         if (calculatedTimeDiff2 > 0) {
           saveShift(
             selectedJob.EMLID,
-            timeIn2.toLocaleString(),
-            timeOut2.toLocaleString(),
+            timeIn2,
+            timeOut2,
             roundedHourDifference2,
             selectedHourType,
             userShiftNotes,
@@ -275,8 +269,8 @@ const Timesheets = (props) => {
 
       saveShift(
         selectedJob.EMLID,
-        timeIn.toLocaleString(),
-        timeOut.toLocaleString(),
+        timeIn,
+        timeOut,
         roundedHourDifference,
         selectedHourType,
         userShiftNotes,
@@ -307,7 +301,7 @@ const Timesheets = (props) => {
     };
 
     const saveShift = async (eml, shiftStart, shiftEnd, hoursWorked, hoursType, shiftNotes) => {
-      await jobs.saveShiftForUser(
+      await jobs.saveShift(
         canUseStaff,
         eml,
         shiftStart,
@@ -442,13 +436,13 @@ const Timesheets = (props) => {
     const changeState = async () => {
       if (clockInOut === 'Clock In') {
         setClockInOut('Clock Out');
-        await jobs.clockIn(true);
+        await jobs.postClockIn(true);
         let clockInDate = new Date();
         handleDateChangeIn(clockInDate);
       }
       if (clockInOut === 'Clock Out') {
         setClockInOut('Reset');
-        await jobs.clockIn(false);
+        await jobs.postClockIn(false);
         let clockOutDate = new Date();
         handleDateChangeOut(clockOutDate);
         await jobs.deleteClockIn();


### PR DESCRIPTION
A fix to a previous timesheets bug (see issue #894 and pr #896), introduced a new bug wherein the backend was receiving ISO dates and parsing them correctly, but passing them to the database in UTC time, where the database was treating them as local time. 

The solution is to pass dates from the front end in the correct timezone of the user (which the API can then parse into local time), but formatted according to our rules. This has been accomplished by moving all date string formatting into the jobs service (rather than being handled inconsistently by the component calling service methods). 

In the process, it became obvious that a jobs refactor was necessary. Therefore, the fixed UI makes use of new, simplified routes which are consistent with the conventions of ASP.NET in general and the rest of the 360 API in particular. 