### PR TITLE
Use simple wellness routes

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -75,7 +75,13 @@ export default class GordonHeader extends Component {
     let currentPath = window.location.pathname;
     // Tab url regular expressions must be listed in the same order as the tabs, since the
     // indices of the elements in the array on the next line are mapped to the indices of the tabs
-    let urls = [/^\/$/, /^\/involvements\/?$|^\/activity/, /^\/events\/?$/, /^\/people$/];
+    let urls = [
+      /^\/$/,
+      /^\/involvements\/?$|^\/activity/,
+      /^\/events\/?$/,
+      /^\/people$/,
+      /^\/wellness$/,
+    ];
     this.value = false;
     for (let i = 0; i < urls.length; i++) {
       if (urls[i].test(currentPath)) {

--- a/src/services/wellness.js
+++ b/src/services/wellness.js
@@ -30,8 +30,7 @@ export const StatusColors = {
  * @typedef WellnessStatus
  * @property {StatusColor} Status The user's status
  * @property {Date} Created when the status was created
- * @property {boolean} IsValid whether the status is still valid
- * @property {boolean} IsOverride whether the status is an administrative override
+ * @property {boolean} IsValid whether the status has expired
  *
  */
 
@@ -50,18 +49,18 @@ export const StatusColors = {
  * returns current status of student
  * @returns {Promise<WellnessStatus>} Response
  */
-const getStatus = async () => {
-  return await http.get('wellness/status');
+const getStatus = () => {
+  return http.get('wellness');
 };
 
 /**
  * add answer to the wellness question to the back end
  * @param {StatusColor} status status to be recorded
- * @return {Promise<WellnessStatus>} Response
+ * @return {Promise<WellnessStatus>} The status that was posted, if successful
  */
-const postAnswer = async (status) => {
+const postAnswer = (status) => {
   try {
-    return http.post('wellness/status', status);
+    return http.post('wellness', status);
   } catch (error) {
     return console.log(error);
   }
@@ -72,8 +71,8 @@ const postAnswer = async (status) => {
  * @returns {Promise<WellnessQuestion>} list of questions from backend
  */
 const getQuestion = async () => {
-  const question = await http.get('wellness/status/question');
-  return await formatQuestion(question);
+  const question = await http.get('wellness/question');
+  return formatQuestion(question);
 };
 
 /**

--- a/src/views/Home/index.js
+++ b/src/views/Home/index.js
@@ -80,7 +80,7 @@ const Home = ({ authentication, onLogIn }) => {
       </div>
     );
   } else if (networkStatus === 'online' && !hasAnswered) {
-    return <WellnessQuestion setStatus={setHasAnswered} />;
+    return <WellnessQuestion setStatus={() => setHasAnswered(true)} />;
   } else {
     let doughnut = personType.includes('stu') ? <CLWCreditsDaysLeft /> : <DaysLeft />;
 


### PR DESCRIPTION
Refactor wellness service to use simple routes ('/wellness' instead of '/wellness/status'). These routes access the refactored and simpler API.