### PR TITLE
Fix profile login message error

### DIFF
--- a/src/views/Profile/index.js
+++ b/src/views/Profile/index.js
@@ -189,7 +189,7 @@ export default class Profile extends Component {
   }
 
   render() {
-    if (this.props.Authentication) {
+    if (this.props.authentication) {
       if (this.state.error && this.state.error.name === 'NotFoundError') {
         return <Redirect to="/profilenotfound" />;
       }


### PR DESCRIPTION
The profile page is perpetually displaying the message "Please login to view this profile", even when logged in. This was because of a small error merging master into develop for a release. The Authentication prop had been refactored into lowercase authentication by a change in develop. However, this change got overwritten by a change from master to this one reference to that prop. This meant that the check for authentication was always failing on the profile page because the component has no Authentication prop.