### PR TITLE
Fix shift rounding error when shift was > 5 minutes

### DIFF
--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -140,9 +140,9 @@ const Timesheets = props => {
       let timeDiff = timeOut.getTime() - timeIn.getTime();
       let calculatedTimeDiff = timeDiff / 3600000; //3,600,000 milliseconds in an hour.
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
-      if (roundedHourDifference === 0.00) {
+      if (roundedHourDifference < 0.08) {
         roundedHourDifference = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
-      } 
+      }
       setHoursWorkedInDecimal(roundedHourDifference);
       let hoursWorked = Math.floor(calculatedTimeDiff);
       let minutesWorked = Math.round((calculatedTimeDiff - hoursWorked) * 60).toFixed(2);
@@ -222,9 +222,9 @@ const Timesheets = props => {
         let timeDiff2 = timeOut2.getTime() - timeIn2.getTime();
         let calculatedTimeDiff2 = timeDiff2 / 3600000; //3,600,000 milliseconds in an hour.
         let roundedHourDifference2 = (Math.round(calculatedTimeDiff2 * 12) / 12).toFixed(2);
-        if (roundedHourDifference2 === 0.00) {
+        if (roundedHourDifference2 < 0.08) {
           roundedHourDifference2 = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
-        } 
+        }
 
         // Do not save the shift if it has zero length
         if (calculatedTimeDiff2 > 0) {
@@ -263,9 +263,9 @@ const Timesheets = props => {
       let timeDiff1 = timeOut.getTime() - timeIn.getTime();
       let calculatedTimeDiff = timeDiff1 / 3600000; //3,600,000 milliseconds in an hour.
       let roundedHourDifference = (Math.round(calculatedTimeDiff * 12) / 12).toFixed(2);
-      if (roundedHourDifference === 0.00) {
+      if (roundedHourDifference < 0.08) {
         roundedHourDifference = 0.08; //minimum 1/12th hour (5 minutes) for working a shift.
-      } 
+      }
 
       saveShift(
         selectedJob.EMLID,


### PR DESCRIPTION
The math for rounding up student shifts was using strict equals but the hour difference variable was a string being compared to an integer, so it was always returning false. This way, we properly detect shifts that are less than 5 minutes and round them up to 5 minutes, which is the minimum length acceptable.