### PR TITLE
Remove expo files

### DIFF
--- a/.expo/packager-info.json
+++ b/.expo/packager-info.json
@@ -1,3 +1,0 @@
-{
-  "devToolsPort": 19002
-}

--- a/.expo/settings.json
+++ b/.expo/settings.json
@@ -1,7 +1,0 @@
-{
-  "hostType": "lan",
-  "lanType": "ip",
-  "dev": true,
-  "minify": false,
-  "urlRandomness": null
-}


### PR DESCRIPTION
The .expo folder and it's contents were added in a strange [Git manipulation commit](https://github.com/gordon-cs/gordon-360-ui/commits/develop/.expo), and aren't actually referenced or used anywhere else in the project. We don't have or use Expo in this project at all. Removing these helps get rid of unnecessary bloat and tidy up our top-level files so that the meaningful things can be found and used more easily.