### PR TITLE
Fix date formatting for timezone bug

### DIFF
--- a/src/services/jobs.js
+++ b/src/services/jobs.js
@@ -5,6 +5,11 @@
 
 import http from './http';
 
+const dateFormat = new Intl.DateTimeFormat('en', {
+  timeStyle: 'medium',
+  dateStyle: 'short',
+});
+
 /**
  * Get Whether or not the user can use staff timesheets
  * @return {Promise.<Number>} User's employee ID
@@ -16,14 +21,20 @@ const getStaffPageForUser = async () => {
 /**
  * Get active jobs for current user
  * @param {Boolean} canUseStaff Whether user can use staff timesheets
- * @param {String} details The user's details
+ * @param {Date} shiftStart The start of the shift to get jobs for
+ * @param {Date} shiftEnd The end of the shift to get jobs for
  * @return {Promise.<String>} User's active jobs
  */
-const getActiveJobsForUser = (canUseStaff, details) => {
+const getJobs = (canUseStaff, shiftStart, shiftEnd) => {
+  const urlParams = `?shiftStart=${dateFormat.format(shiftStart)}&shiftEnd=${dateFormat.format(
+    shiftEnd,
+  )}`;
+
   if (canUseStaff) {
-    return http.post(`jobs/JobsStaff`, details); // Is a HttpPost, but says get?
+    return http.get('jobs/staff' + urlParams);
+  } else {
+    return http.get('jobs' + urlParams);
   }
-  return http.post(`jobs/getJobs`, details);
 };
 
 /**
@@ -58,33 +69,27 @@ const saveShiftForUser = async (
   hoursType,
   shiftNotes,
 ) => {
-  if (canUseStaff) {
-    let shiftDetails = {
-      EML: eml,
-      SHIFT_START_DATETIME: shiftStart,
-      SHIFT_END_DATETIME: shiftEnd,
-      HOURS_WORKED: hoursWorked,
-      HOURS_TYPE: hoursType,
-      SHIFT_NOTES: shiftNotes,
-    };
-    return await http.post(`jobs/saveShiftStaff/`, shiftDetails);
-  }
-  let shiftDetails = {
+  const shiftDetails = {
     EML: eml,
-    SHIFT_START_DATETIME: shiftStart,
-    SHIFT_END_DATETIME: shiftEnd,
+    SHIFT_START_DATETIME: dateFormat.format(shiftStart),
+    SHIFT_END_DATETIME: dateFormat.format(shiftEnd),
     HOURS_WORKED: hoursWorked,
+    HOURS_TYPE: canUseStaff ? hoursType : null,
     SHIFT_NOTES: shiftNotes,
   };
-  return await http.post(`jobs/saveShift/`, shiftDetails);
+  if (canUseStaff) {
+    return await http.post(`jobs/saveShiftStaff/`, shiftDetails);
+  } else {
+    return await http.post(`jobs/saveShift/`, shiftDetails);
+  }
 };
 
 const editShift = async (canUseStaff, rowID, newShiftStart, newShiftEnd, newHoursWorked) => {
   let newShiftDetails = {
     ID: rowID,
     EML: null,
-    SHIFT_START_DATETIME: newShiftStart.toLocaleString(),
-    SHIFT_END_DATETIME: newShiftEnd.toLocaleString(),
+    SHIFT_START_DATETIME: dateFormat.format(newShiftStart),
+    SHIFT_END_DATETIME: dateFormat.format(newShiftEnd),
     HOURS_WORKED: newHoursWorked,
     SHIFT_NOTES: null,
     LAST_CHANGED_BY: null,
@@ -109,31 +114,21 @@ const getSupervisorNameForJob = (canUseStaff, supervisorID) => {
   return http.get(`jobs/supervisorName/${supervisorID}`);
 };
 
-const submitShiftsForUser = (canUseStaff, shiftsToSubmit, submittedTo) => {
-  let shifts = [];
+const submitShiftsForUser = (canUseStaff, shifts, submittedTo) => {
+  const shiftDetails = (shift) => ({
+    ID_NUM: shift.ID_NUM,
+    EML: shift.EML,
+    SHIFT_END_DATETIME: dateFormat.format(new Date(shift.SHIFT_END_DATETIME)),
+    SUBMITTED_TO: submittedTo,
+    HOURS_TYPE: canUseStaff ? shift.HOURS_TYPE : null,
+    LAST_CHANGED_BY: shift.LAST_CHANGED_BY,
+  });
+
   if (canUseStaff) {
-    for (let i = 0; i < shiftsToSubmit.length; i++) {
-      shifts.push({
-        ID_NUM: shiftsToSubmit[i].ID_NUM,
-        EML: shiftsToSubmit[i].EML,
-        SHIFT_END_DATETIME: shiftsToSubmit[i].SHIFT_END_DATETIME,
-        SUBMITTED_TO: submittedTo,
-        HOURS_TYPE: shiftsToSubmit[i].HOURS_TYPE,
-        LAST_CHANGED_BY: shiftsToSubmit[i].LAST_CHANGED_BY,
-      });
-      return http.post(`jobs/submitShiftsStaff`, shifts);
-    }
+    return http.post(`jobs/submitShiftsStaff`, shifts.map(shiftDetails));
+  } else {
+    return http.post(`jobs/submitShifts`, shifts.map(shiftDetails));
   }
-  for (let i = 0; i < shiftsToSubmit.length; i++) {
-    shifts.push({
-      ID_NUM: shiftsToSubmit[i].ID_NUM,
-      EML: shiftsToSubmit[i].EML,
-      SHIFT_END_DATETIME: shiftsToSubmit[i].SHIFT_END_DATETIME,
-      SUBMITTED_TO: submittedTo,
-      LAST_CHANGED_BY: shiftsToSubmit[i].LAST_CHANGED_BY,
-    });
-  }
-  return http.post(`jobs/submitShifts`, shifts);
 };
 
 const clockIn = (data) => {
@@ -154,7 +149,7 @@ const getHourTypes = () => {
 
 export default {
   getStaffPageForUser,
-  getActiveJobsForUser,
+  getJobs,
   getSavedShiftsForUser,
   saveShiftForUser,
   editShift,

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -164,12 +164,8 @@ const Timesheets = (props) => {
   };
 
   if (props.authentication) {
-    const getActiveJobsForUser = (dateIn, dateOut) => {
-      let details = {
-        shift_start_datetime: dateIn.toISOString(),
-        shift_end_datetime: dateOut.toISOString(),
-      };
-      jobs.getActiveJobsForUser(canUseStaff, details).then((result) => {
+    const getJobs = (dateIn, dateOut) => {
+      jobs.getJobs(canUseStaff, dateIn, dateOut).then((result) => {
         setUserJobs(result);
       });
     };
@@ -186,7 +182,7 @@ const Timesheets = (props) => {
         setIsOverlappingShift(false);
         handleTimeErrors(date, selectedDateOut);
         if (selectedDateOut !== null) {
-          getActiveJobsForUser(date, selectedDateOut);
+          getJobs(date, selectedDateOut);
         }
       }
     };
@@ -199,7 +195,7 @@ const Timesheets = (props) => {
         setIsOverlappingShift(false);
         handleTimeErrors(selectedDateIn, date);
         if (selectedDateIn !== null) {
-          getActiveJobsForUser(selectedDateIn, date);
+          getJobs(selectedDateIn, date);
         }
       }
     };
@@ -230,8 +226,8 @@ const Timesheets = (props) => {
         if (calculatedTimeDiff2 > 0) {
           saveShift(
             selectedJob.EMLID,
-            timeIn2.toLocaleString(),
-            timeOut2.toLocaleString(),
+            timeIn2,
+            timeOut2,
             roundedHourDifference2,
             selectedHourType,
             userShiftNotes,
@@ -269,8 +265,8 @@ const Timesheets = (props) => {
 
       saveShift(
         selectedJob.EMLID,
-        timeIn.toLocaleString(),
-        timeOut.toLocaleString(),
+        timeIn,
+        timeOut,
         roundedHourDifference,
         selectedHourType,
         userShiftNotes,


### PR DESCRIPTION
Sending dates as ISO strings to the backend caused an unforeseen problem in that dates were being parsed by the backend as UTC and stored in the database as such, but then compared to local time without adjusting for the timezone difference. Instead, we will send the date in a custom format that approximates ISO but is in the user's local time zone. This fixes the above error and preserves the fix from using toLocaleString that caused issues for user's with browsers that had different locales.

Depends on https://github.com/gordon-cs/gordon-360-api/pull/475