### PR TITLE
Add network status hook

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,12 +7,10 @@ import MomentUtils from '@date-io/moment';
 import './app.css';
 import analytics from './services/analytics';
 import { isAuthenticated } from './services/auth';
-//import GordonError from './components/Error';
+import NetworkContextProvider from './contexts/NetworkContext';
 import GordonHeader from './components/Header';
 import GordonNav from './components/Nav';
 import OfflineBanner from './components/OfflineBanner';
-//import { AuthError } from './services/error';
-//import Login from './views/Login';
 import theme from './theme';
 import routes from './routes';
 
@@ -63,45 +61,47 @@ export default class App extends Component {
     return (
       <MuiThemeProvider theme={theme}>
         <MuiPickersUtilsProvider utils={MomentUtils}>
-          <Router history={this.history}>
-            <section className="app-wrapper">
-              <GordonHeader
-                onDrawerToggle={this.onDrawerToggle}
-                onSignOut={this.onAuthChange}
-                authentication={this.state.authentication}
-              />
-              <GordonNav
-                onDrawerToggle={this.onDrawerToggle}
-                drawerOpen={this.state.drawerOpen}
-                onSignOut={this.onAuthChange}
-                authentication={this.state.authentication}
-              />
-              <main className="app-main">
-                <Switch>
-                  {routes.map((route) => (
-                    <Route
-                      key={route.path}
-                      path={route.path}
-                      exact={route.exact}
-                      render={(props) => (
-                        <div className="app-main-container">
-                          <OfflineBanner
-                            currentPath={route.path}
-                            authentication={this.state.authentication}
-                          />
-                          <route.component
-                            onLogIn={this.onAuthChange}
-                            authentication={this.state.authentication}
-                            {...props}
-                          />
-                        </div>
-                      )}
-                    />
-                  ))}
-                </Switch>
-              </main>
-            </section>
-          </Router>
+          <NetworkContextProvider>
+            <Router history={this.history}>
+              <section className="app-wrapper">
+                <GordonHeader
+                  onDrawerToggle={this.onDrawerToggle}
+                  onSignOut={this.onAuthChange}
+                  authentication={this.state.authentication}
+                />
+                <GordonNav
+                  onDrawerToggle={this.onDrawerToggle}
+                  drawerOpen={this.state.drawerOpen}
+                  onSignOut={this.onAuthChange}
+                  authentication={this.state.authentication}
+                />
+                <main className="app-main">
+                  <Switch>
+                    {routes.map((route) => (
+                      <Route
+                        key={route.path}
+                        path={route.path}
+                        exact={route.exact}
+                        render={(props) => (
+                          <div className="app-main-container">
+                            <OfflineBanner
+                              currentPath={route.path}
+                              authentication={this.state.authentication}
+                            />
+                            <route.component
+                              onLogIn={this.onAuthChange}
+                              authentication={this.state.authentication}
+                              {...props}
+                            />
+                          </div>
+                        )}
+                      />
+                    ))}
+                  </Switch>
+                </main>
+              </section>
+            </Router>
+          </NetworkContextProvider>
         </MuiPickersUtilsProvider>
       </MuiThemeProvider>
     );

--- a/src/contexts/NetworkContext.js
+++ b/src/contexts/NetworkContext.js
@@ -1,0 +1,61 @@
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import storage from '../services/storage';
+
+const NetworkContext = createContext();
+
+/**
+ * Custom hook to subscribe to network status.
+ *
+ * Value is retrieved from local storage initially and updated by service worker firing events
+ *
+ * Can be used by any functional component under the NetworkContextProvider in App.js
+ *
+ * @returns {boolean} true if connected to the network, false otherwise.
+ */
+export const useNetworkStatus = () => {
+  const context = useContext(NetworkContext);
+  if (context === undefined) {
+    throw new Error(`useNetworkStatus must be called within NetworkContextProvider`);
+  }
+
+  return context;
+};
+
+const NetworkContextProvider = ({ children }) => {
+  const [isOnline, setIsOnline] = useState('online');
+
+  useEffect(() => {
+    // Retrieve network status from local storage or default to online
+    try {
+      const networkStatus = storage.get('network-status');
+      setIsOnline(networkStatus === 'online');
+    } catch (error) {
+      console.error(error);
+      setIsOnline(true);
+    }
+
+    /* Used to re-render the page when the network connection changes.
+     * The origin of the message is checked to prevent cross-site scripting attacks
+     */
+    const updateNetworkStatus = (event) => {
+      setIsOnline((prevStatus) => {
+        if (
+          event.origin === window.location.origin &&
+          (event.data === 'online' || event.data === 'offline')
+        ) {
+          return event.data === 'online';
+        } else {
+          return prevStatus;
+        }
+      });
+    };
+
+    window.addEventListener('message', updateNetworkStatus);
+
+    return () => window.removeEventListener('message', updateNetworkStatus);
+  }, []);
+
+  return <NetworkContext.Provider value={isOnline}>{children}</NetworkContext.Provider>;
+};
+
+export default NetworkContextProvider;

--- a/src/contexts/NetworkContext.js
+++ b/src/contexts/NetworkContext.js
@@ -1,25 +1,7 @@
-import React, { createContext, useState, useEffect, useContext } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
 import storage from '../services/storage';
 
-const NetworkContext = createContext();
-
-/**
- * Custom hook to subscribe to network status.
- *
- * Value is retrieved from local storage initially and updated by service worker firing events
- *
- * Can be used by any functional component under the NetworkContextProvider in App.js
- *
- * @returns {boolean} true if connected to the network, false otherwise.
- */
-export const useNetworkStatus = () => {
-  const context = useContext(NetworkContext);
-  if (context === undefined) {
-    throw new Error(`useNetworkStatus must be called within NetworkContextProvider`);
-  }
-
-  return context;
-};
+export const NetworkContext = createContext();
 
 const NetworkContextProvider = ({ children }) => {
   const [isOnline, setIsOnline] = useState('online');

--- a/src/hooks/useNetworkStatus.js
+++ b/src/hooks/useNetworkStatus.js
@@ -1,0 +1,21 @@
+import { useContext } from 'react';
+import { NetworkContext } from '../contexts/NetworkContext.js';
+
+/**
+ * Custom hook to subscribe to network status.
+ *
+ * Value is retrieved from local storage initially and updated by service worker firing events
+ *
+ * Can be used by any functional component under the NetworkContextProvider in App.js
+ *
+ * @returns {boolean} true if connected to the network, false otherwise.
+ */
+const useNetworkStatus = () => {
+  const context = useContext(NetworkContext);
+  if (context === undefined) {
+    throw new Error(`useNetworkStatus must be called within NetworkContextProvider`);
+  }
+
+  return context;
+};
+export default useNetworkStatus;


### PR DESCRIPTION
This commit introduces the NetworkContext, which uses React's Context API to track the online/offline status of the user's network. The goal is to have network-aware component's subscribe to this context provider so that the network is tracked in only one place, rather than having eventListeners in every component that needs to know the network status.

This may result in minimal performace gains (having only one event listener attached to the window instead of >10 at once), but I would guess that the rerendering takes significantly more processing than the eventlisteners themselves. The real advantage to this technique is the separation of concerns. Now, the NetworkContextProvider is the only component responsible for the logic of tracking network changes. Every ther network-aware component simply subscribes to these changes with the very minmial hook useNetworkStatus - e.g. const isOnline = useNetworkStatus(), rather than having a large block of logic duplicated across many components with a useEffect hook and window listeners that obscures the component's more natural responsibilities.

This first PR merely introduces the hook. Subsequent PRs will include refactors of network-aware components to make optimal use of the hook.