### PR TITLE
Use automated tool to update MUI imports

### DIFF
--- a/src/components/AdvisorList/index.js
+++ b/src/components/AdvisorList/index.js
@@ -1,8 +1,5 @@
-import Divider from '@material-ui/core/Divider';
 import React, { Component } from 'react';
-import ListItem from '@material-ui/core/ListItem';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
+import { Divider, ListItem, Typography, Grid } from '@material-ui/core';
 
 export default class Advisors extends Component {
   constructor(props) {

--- a/src/components/Error/index.js
+++ b/src/components/Error/index.js
@@ -1,9 +1,9 @@
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import './error.css';
+
+import { Grid, Typography } from '@material-ui/core';
 
 export default class GordonError extends Component {
   render() {

--- a/src/components/EventList/components/CollapsableEventItem/index.js
+++ b/src/components/EventList/components/CollapsableEventItem/index.js
@@ -1,10 +1,8 @@
 import PropTypes from 'prop-types';
-import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
-import CardContent from '@material-ui/core/CardContent';
-import Collapse from '@material-ui/core/Collapse';
-import Grid from '@material-ui/core/Grid';
 import './collapsable-event-item.css';
+
+import { Typography, CardContent, Collapse, Grid } from '@material-ui/core';
 
 //Switched to table rows
 export default class GordonCollapsableEventItem extends Component {

--- a/src/components/EventList/components/EventItem/index.js
+++ b/src/components/EventList/components/EventItem/index.js
@@ -1,10 +1,8 @@
 import PropTypes from 'prop-types';
-import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
-import CardContent from '@material-ui/core/CardContent';
-import Collapse from '@material-ui/core/Collapse';
-import Grid from '@material-ui/core/Grid';
 import './event-item.css';
+
+import { Typography, CardContent, Collapse, Grid } from '@material-ui/core';
 
 //Switched to table rows
 export default class GordonEventItem extends Component {

--- a/src/components/EventList/index.js
+++ b/src/components/EventList/index.js
@@ -1,13 +1,11 @@
 import React, { Component } from 'react';
-import List from '@material-ui/core/List';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import Card from '@material-ui/core/Card';
 import CollapsableEventItem from './components/CollapsableEventItem';
 import EventItem from './components/EventItem';
 import { gordonColors } from '../../theme';
 
 import './event-list.css';
+
+import { List, Grid, Typography, Card } from '@material-ui/core';
 
 export default class EventList extends Component {
   constructor(props) {

--- a/src/components/GordonDialogBox/index.js
+++ b/src/components/GordonDialogBox/index.js
@@ -1,10 +1,13 @@
 import React, { Component } from 'react';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Button from '@material-ui/core/Button';
+
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button,
+} from '@material-ui/core';
 
 // Learn more about Dialog's API at https://material-ui.com/api/dialog/
 

--- a/src/components/Header/components/NavButtonsRightCorner/index.js
+++ b/src/components/Header/components/NavButtonsRightCorner/index.js
@@ -11,13 +11,13 @@ import {
   createMyProfileButton,
   createSignInOutButton,
 } from './navButtons';
-import Popover from '@material-ui/core/Popover';
-import List from '@material-ui/core/List';
 import PropTypes from 'prop-types';
 import QuickLinksDialog from '../../../QuickLinksDialog';
 import { gordonColors } from '../../../../theme';
 import storage from '../../../../services/storage';
 import './index.css';
+
+import { Popover, List } from '@material-ui/core';
 
 export const GordonNavButtonsRightCorner = (props) => {
   const [linkOpen, setLinkOpen] = useState(false);

--- a/src/components/Header/components/NavButtonsRightCorner/navButtons.js
+++ b/src/components/Header/components/NavButtonsRightCorner/navButtons.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
 import { NavLink } from 'react-router-dom';
 import user from '../../../../services/user';
+
+import { ListItem, ListItemText } from '@material-ui/core';
 
 /**
  * Creates the Links button.

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -1,20 +1,24 @@
 import Downshift from 'downshift';
-import TextField from '@material-ui/core/TextField';
-import InputAdornment from '@material-ui/core/InputAdornment';
 import SearchIcon from '@material-ui/icons/Search';
-import Paper from '@material-ui/core/Paper';
-import MenuItem from '@material-ui/core/MenuItem';
-import Typography from '@material-ui/core/Typography';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Button from '@material-ui/core/Button';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import './people-search.css';
 import peopleSearch from '../../../../services/people-search';
+
+import {
+  TextField,
+  InputAdornment,
+  Paper,
+  MenuItem,
+  Typography,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button,
+} from '@material-ui/core';
+
 const MIN_QUERY_LENGTH = 2;
 
 //  TextBox Input Field

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,7 +1,3 @@
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
-import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import HomeIcon from '@material-ui/icons/Home';
 import LocalActivityIcon from '@material-ui/icons/LocalActivity';
@@ -9,9 +5,6 @@ import EventIcon from '@material-ui/icons/Event';
 import PeopleIcon from '@material-ui/icons/People';
 import WorkIcon from '@material-ui/icons/Work';
 import WellnessIcon from '@material-ui/icons/LocalHospital';
-import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
-import Button from '@material-ui/core/Button';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import DocumentTitle from 'react-document-title';
@@ -25,6 +18,8 @@ import { projectName } from '../../project-name';
 import storage from '../../services/storage';
 import GordonDialogBox from '../GordonDialogBox/index';
 import { windowBreakWidths } from '../../theme';
+
+import { AppBar, Toolbar, Typography, IconButton, Tabs, Tab, Button } from '@material-ui/core';
 
 const getRouteName = (route) => {
   if (route.name) {

--- a/src/components/Identification/index.js
+++ b/src/components/Identification/index.js
@@ -1,15 +1,5 @@
-import Grid from '@material-ui/core/Grid';
-import CardHeader from '@material-ui/core/CardHeader';
 import React, { useState, useEffect, useRef } from 'react';
-import Button from '@material-ui/core/Button';
-import Tooltip from '@material-ui/core/Tooltip';
 import Dropzone from 'react-dropzone';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Typography from '@material-ui/core/Typography';
 import EmailIcon from '@material-ui/icons/Email';
 import user from '../../services/user';
 import { gordonColors } from '../../theme';
@@ -22,12 +12,25 @@ import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import ErrorIcon from '@material-ui/icons/Error';
 import WarningIcon from '@material-ui/icons/Warning';
 import CloseIcon from '@material-ui/icons/Close';
-import Snackbar from '@material-ui/core/Snackbar';
-import IconButton from '@material-ui/core/IconButton';
 import defaultGordonImage from './defaultGordonImage';
 import GordonLoader from '../Loader/index';
 import { windowBreakWidths } from '../../theme';
 import './index.css';
+
+import {
+  Grid,
+  CardHeader,
+  Button,
+  Tooltip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Typography,
+  Snackbar,
+  IconButton,
+} from '@material-ui/core';
 
 export const Identification = (props) => {
   const CROP_DIM = 200; // pixels

--- a/src/components/Involvements/index.js
+++ b/src/components/Involvements/index.js
@@ -1,17 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import activity from '../../services/activity';
 import storage from '../../services/storage';
-import Button from '@material-ui/core/Button';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import CardHeader from '@material-ui/core/CardHeader';
-import Grid from '@material-ui/core/Grid';
 import { Link } from 'react-router-dom';
-import List from '@material-ui/core/List';
 import MyProfileActivityList from '../MyProfileActivityList/index';
 import ProfileActivityList from '../ProfileActivityList/index';
-import Typography from '@material-ui/core/Typography';
 import './index.css';
+
+import { Button, Card, CardContent, CardHeader, Grid, List, Typography } from '@material-ui/core';
 
 export const Involvements = (props) => {
   const [involvementsAndTheirPrivacy, setInvolvementsAndTheirPrivacy] = useState([]);

--- a/src/components/Loader/index.js
+++ b/src/components/Loader/index.js
@@ -1,8 +1,8 @@
-import Grid from '@material-ui/core/Grid';
-import CircularProgress from '@material-ui/core/CircularProgress';
 import React, { Component } from 'react';
 
 import './loader.css';
+
+import { Grid, CircularProgress } from '@material-ui/core';
 
 export default class GordonLoader extends Component {
   render() {

--- a/src/components/MajorList/index.js
+++ b/src/components/MajorList/index.js
@@ -1,8 +1,5 @@
-import Divider from '@material-ui/core/Divider';
 import React, { Component } from 'react';
-import ListItem from '@material-ui/core/ListItem';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
+import { Divider, ListItem, Typography, Grid } from '@material-ui/core';
 
 export default class Majors extends Component {
   constructor(props) {

--- a/src/components/MinorList/index.js
+++ b/src/components/MinorList/index.js
@@ -1,8 +1,5 @@
-import Divider from '@material-ui/core/Divider';
 import React, { Component } from 'react';
-import ListItem from '@material-ui/core/ListItem';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
+import { Divider, ListItem, Typography, Grid } from '@material-ui/core';
 
 export default class Minors extends Component {
   constructor(props) {

--- a/src/components/MyProfileActivityList/index.js
+++ b/src/components/MyProfileActivityList/index.js
@@ -1,22 +1,16 @@
-import Grid from '@material-ui/core/Grid';
 import PropTypes from 'prop-types';
-import Divider from '@material-ui/core/Divider';
 import React, { Component } from 'react';
-import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router-dom';
-import Switch from '@material-ui/core/Switch';
 import membership from './../../services/membership';
-import List from '@material-ui/core/List';
 import LockIcon from '@material-ui/icons/Lock';
-import ListItem from '@material-ui/core/ListItem';
-import Snackbar from '@material-ui/core/Snackbar';
 import ErrorIcon from '@material-ui/icons/Error';
 import CloseIcon from '@material-ui/icons/Close';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
-import IconButton from '@material-ui/core/IconButton';
 import '../ProfileList/profileList.css';
 import '../../app.css';
 import './index.css';
+
+import { Grid, Divider, Typography, Switch, List, ListItem, Snackbar, IconButton } from '@material-ui/core';
 
 export default class MyProfileActivityList extends Component {
   constructor(props) {

--- a/src/components/Nav/components/NavAvatar/index.js
+++ b/src/components/Nav/components/NavAvatar/index.js
@@ -1,13 +1,12 @@
 import { withStyles } from '@material-ui/core/styles';
-import Avatar from '@material-ui/core/Avatar';
-import Button from '@material-ui/core/Button';
-import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import './nav-avatar.css';
 import '../../../../app.css';
 import user from '../../../../services/user';
+
+import { Avatar, Button, Typography } from '@material-ui/core';
 
 const styles = (theme) => ({
   drawerHeader: theme.mixins.toolbar,

--- a/src/components/Nav/components/NavLinks/index.js
+++ b/src/components/Nav/components/NavLinks/index.js
@@ -1,6 +1,4 @@
-import List from '@material-ui/core/List';
 import GordonDialogBox from '../../../GordonDialogBox/index';
-import Divider from '@material-ui/core/Divider';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { signOut } from '../../../../services/auth';
@@ -21,6 +19,8 @@ import {
   createWellnessButton,
 } from './navButtons.js';
 import './nav-links.css';
+
+import { List, Divider } from '@material-ui/core';
 
 export default class GordonNavLinks extends Component {
   constructor(props) {

--- a/src/components/Nav/components/NavLinks/navButtons.js
+++ b/src/components/Nav/components/NavLinks/navButtons.js
@@ -1,7 +1,4 @@
 import React from 'react';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
 import { NavLink } from 'react-router-dom';
 import HomeIcon from '@material-ui/icons/Home';
 import LocalActivityIcon from '@material-ui/icons/LocalActivity';
@@ -10,6 +7,8 @@ import PeopleIcon from '@material-ui/icons/People';
 import user from '../../../../services/user';
 import WorkIcon from '@material-ui/icons/Work';
 import WellnessIcon from '@material-ui/icons/LocalHospital';
+
+import { ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
 
 /**
  * Creates the Links button.

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -1,12 +1,11 @@
-import Drawer from '@material-ui/core/Drawer';
-import Divider from '@material-ui/core/Divider';
-import Hidden from '@material-ui/core/Hidden';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import './nav.css';
 import GordonNavAvatar from './components/NavAvatar';
 import GordonNavLinks from './components/NavLinks';
+
+import { Drawer, Divider, Hidden } from '@material-ui/core';
 
 export default class GordonNav extends Component {
   render() {

--- a/src/components/OfficeList/index.js
+++ b/src/components/OfficeList/index.js
@@ -1,14 +1,8 @@
-import Divider from '@material-ui/core/Divider';
 import React, { Component } from 'react';
-import ListItem from '@material-ui/core/ListItem';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
-import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
-import CardContent from '@material-ui/core/CardContent';
-import List from '@material-ui/core/List';
 import '../../app.css';
 import './index.css';
+
+import { Divider, ListItem, Typography, Grid, Card, CardHeader, CardContent, List } from '@material-ui/core';
 
 // A list of grid row lengths to align all content depending on the amount of items per row
 const rowWidths = {

--- a/src/components/OfflineBanner/index.js
+++ b/src/components/OfflineBanner/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
 import { gordonColors } from '../../theme';
 import storage from '../../services/storage';
+
+import { Grid, Typography } from '@material-ui/core';
 
 export default class OfflineBanner extends Component {
   constructor() {

--- a/src/components/PWAInstructions/index.js
+++ b/src/components/PWAInstructions/index.js
@@ -1,15 +1,12 @@
 import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import Button from '@material-ui/core/Button';
-import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
 import GetAppIcon from '@material-ui/icons/GetApp';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
 import ToggleButton from '@material-ui/lab/ToggleButton';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 import { gordonColors } from '../../theme';
 import './index.css';
+
+import { Button, Dialog, DialogContent, Typography, Grid } from '@material-ui/core';
 
 // Button styles
 let styles = {

--- a/src/components/ProfileActivityList/index.js
+++ b/src/components/ProfileActivityList/index.js
@@ -1,13 +1,10 @@
-import Grid from '@material-ui/core/Grid';
 import PropTypes from 'prop-types';
-import Divider from '@material-ui/core/Divider';
 import React, { Component } from 'react';
-import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router-dom';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
 import '../../app.css';
 import './index.css';
+
+import { Grid, Divider, Typography, List, ListItem } from '@material-ui/core';
 
 export default class ProfileActivityList extends Component {
   render() {

--- a/src/components/ProfileList/index.js
+++ b/src/components/ProfileList/index.js
@@ -1,15 +1,8 @@
 import React, { Component } from 'react';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
 import user from './../../services/user';
-import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
-import CardContent from '@material-ui/core/CardContent';
-import Snackbar from '@material-ui/core/Snackbar';
 import ErrorIcon from '@material-ui/icons/Error';
 import CloseIcon from '@material-ui/icons/Close';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
-import IconButton from '@material-ui/core/IconButton';
 import './profileList.css';
 import { withStyles } from '@material-ui/core/styles';
 import { gordonColors } from '../../theme';
@@ -27,6 +20,8 @@ import {
   createSpouseItem,
 } from './listItems';
 import '../../app.css';
+
+import { Typography, Grid, Card, CardHeader, CardContent, Snackbar, IconButton } from '@material-ui/core';
 
 const PRIVATE_INFO = 'Private as requested.';
 

--- a/src/components/ProfileList/listItems.js
+++ b/src/components/ProfileList/listItems.js
@@ -1,13 +1,10 @@
 import React from 'react';
-import Typography from '@material-ui/core/Typography';
-import ListItem from '@material-ui/core/ListItem';
-import Grid from '@material-ui/core/Grid';
-import Switch from '@material-ui/core/Switch';
-import Divider from '@material-ui/core/Divider';
 import Majors from './../../components/MajorList';
 import Minors from './../../components/MinorList';
 import Advisors from './../../components/AdvisorList';
 import LockIcon from '@material-ui/icons/Lock';
+
+import { Typography, ListItem, Grid, Switch, Divider } from '@material-ui/core';
 
 /**
  * Creates the Home List Item

--- a/src/components/QuickLinksDialog/components/LinksList/index.js
+++ b/src/components/QuickLinksDialog/components/LinksList/index.js
@@ -1,12 +1,7 @@
 import React, { Component } from 'react';
-import ListItemText from '@material-ui/core/ListItemText';
-import ListSubheader from '@material-ui/core/ListSubheader';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
 import LinkIcon from '@material-ui/icons/InsertLink';
-import Typography from '@material-ui/core/Typography';
 
-import { ListItemIcon } from '@material-ui/core';
+import { ListItemIcon, ListItemText, ListSubheader, List, ListItem, Typography } from '@material-ui/core';
 
 import '../../../../app.css';
 

--- a/src/components/QuickLinksDialog/index.js
+++ b/src/components/QuickLinksDialog/index.js
@@ -1,15 +1,18 @@
 import React, { Component } from 'react';
 
-import GordonDialog from '@material-ui/core/Dialog';
-import MuiDialogTitle from '@material-ui/core/DialogTitle';
-import MuiDialogContent from '@material-ui/core/DialogContent';
 import { withStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
 
 import PropTypes from 'prop-types';
 
 import GordonLinksList from './components/LinksList';
 import './quicklinksdialog.css';
+
+import {
+  Dialog as GordonDialog,
+  DialogTitle as MuiDialogTitle,
+  DialogContent as MuiDialogContent,
+  Typography,
+} from '@material-ui/core';
 
 const styles = (theme) => ({
   root: {

--- a/src/components/SchedulePanel/components/EditDescriptionDialog/index.js
+++ b/src/components/SchedulePanel/components/EditDescriptionDialog/index.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import Dialog from '@material-ui/core/Dialog';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import DialogActions from '@material-ui/core/DialogActions';
-import Button from '@material-ui/core/Button';
-import TextField from '@material-ui/core/TextField';
 import { gordonColors } from '../../../../theme';
 import './editdescriptiondialog.css';
+
+import { Dialog, DialogTitle, DialogActions, Button, TextField } from '@material-ui/core';
 
 export default class EditDescriptionDialog extends React.Component {
   constructor(props) {

--- a/src/components/SchedulePanel/components/RemoveScheduleDialog/index.js
+++ b/src/components/SchedulePanel/components/RemoveScheduleDialog/index.js
@@ -1,9 +1,7 @@
 import React, { Fragment } from 'react';
-import Dialog from '@material-ui/core/Dialog';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import DialogActions from '@material-ui/core/DialogActions';
-import Button from '@material-ui/core/Button';
 import { gordonColors } from '../../../../theme';
+
+import { Dialog, DialogTitle, DialogActions, Button } from '@material-ui/core';
 
 export default class RemoveScheduleDialog extends React.Component {
   constructor(props) {

--- a/src/components/SchedulePanel/components/myScheduleDialog/index.js
+++ b/src/components/SchedulePanel/components/myScheduleDialog/index.js
@@ -1,19 +1,21 @@
 import React, { Fragment } from 'react';
 
-import Typography from '@material-ui/core/Typography';
-import Dialog from '@material-ui/core/Dialog';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import FormGroup from '@material-ui/core/FormGroup';
-import TextField from '@material-ui/core/TextField';
-import Button from '@material-ui/core/Button';
 import { gordonColors } from '../../../../theme';
-import Checkbox from '@material-ui/core/Checkbox';
 import myschedule from '../../../../services/myschedule';
-import FormControl from '@material-ui/core/FormControl';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { FormHelperText } from '@material-ui/core';
+import {
+  FormHelperText,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  FormGroup,
+  TextField,
+  Button,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+} from '@material-ui/core';
 import { KeyboardTimePicker } from '@material-ui/pickers';
 
 // Default values

--- a/src/components/SchedulePanel/index.js
+++ b/src/components/SchedulePanel/index.js
@@ -1,13 +1,6 @@
 import React, { Component, Fragment } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
-import Switch from '@material-ui/core/Switch';
 import GordonScheduleCalendar from './components/ScheduleCalendar';
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import { gordonColors } from '../../theme';
 import MyScheduleDialog from './components/myScheduleDialog';
@@ -21,6 +14,16 @@ import { Markup } from 'interweave';
 import myschedule from '../../services/myschedule';
 
 import GordonLoader from '../../components/Loader';
+
+import {
+  Grid,
+  Button,
+  Switch,
+  ExpansionPanel,
+  ExpansionPanelSummary,
+  ExpansionPanelDetails,
+  Typography,
+} from '@material-ui/core';
 
 // Default values
 const STARTHOUR = '08:00';

--- a/src/views/About/index.js
+++ b/src/views/About/index.js
@@ -1,12 +1,10 @@
-import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
-import Card from '@material-ui/core/Card';
 import { gordonColors } from '../../theme';
 import Version from '../../services/version';
 import { projectName } from '../../project-name';
 import './about.css';
+
+import { Typography, Grid, Button, Card } from '@material-ui/core';
 
 export default class About extends Component {
   constructor(props) {

--- a/src/views/ActivitiesAll/components/Requests/components/RequestSent/index.js
+++ b/src/views/ActivitiesAll/components/Requests/components/RequestSent/index.js
@@ -1,8 +1,5 @@
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
-import { Button } from '@material-ui/core';
+import { Button, Grid, Typography, Divider } from '@material-ui/core';
 import ClearIcon from '@material-ui/icons/Clear';
 
 import { gordonColors } from '../../../../../../theme';

--- a/src/views/ActivitiesAll/components/Requests/components/RequestsReceived/index.js
+++ b/src/views/ActivitiesAll/components/Requests/components/RequestsReceived/index.js
@@ -1,17 +1,20 @@
 import React, { Component } from 'react';
-import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-import Badge from '@material-ui/core/Badge';
 
 import { gordonColors } from '../../../../../../theme';
 import membership from '../../../../../../services/membership';
 import './requests.css';
+
+import {
+  Button,
+  Grid,
+  Typography,
+  Divider,
+  ExpansionPanel,
+  ExpansionPanelDetails,
+  ExpansionPanelSummary,
+  Badge,
+} from '@material-ui/core';
 
 export default class RequestReceived extends Component {
   constructor(props) {

--- a/src/views/ActivitiesAll/components/Requests/index.js
+++ b/src/views/ActivitiesAll/components/Requests/index.js
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import Card from '@material-ui/core/Card';
-import Collapse from '@material-ui/core/Collapse';
 import { CardContent } from '@material-ui/core';
-import { Button } from '@material-ui/core';
+import { Button, Grid, Typography, Card, Collapse } from '@material-ui/core';
 import { gordonColors } from '../../../../theme';
 import user from '../../../../services/user';
 import RequestsReceived from './components/RequestsReceived';

--- a/src/views/ActivityProfile/components/Advisors/index.js
+++ b/src/views/ActivityProfile/components/Advisors/index.js
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
 import Email from '@material-ui/icons/Email';
-import IconButton from '@material-ui/core/IconButton';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import Typography from '@material-ui/core/Typography';
 
 import GordonLoader from '../../../../components/Loader';
+
+import { IconButton, List, ListItem, Typography } from '@material-ui/core';
 
 export default class Advisors extends Component {
   constructor(props) {

--- a/src/views/ActivityProfile/components/GroupContacts/index.js
+++ b/src/views/ActivityProfile/components/GroupContacts/index.js
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
 import Email from '@material-ui/icons/Email';
-import IconButton from '@material-ui/core/IconButton';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import Typography from '@material-ui/core/Typography';
 
 import GordonLoader from '../../../../components/Loader';
+
+import { IconButton, List, ListItem, Typography } from '@material-ui/core';
 
 export default class GroupContacts extends Component {
   constructor(props) {

--- a/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
+++ b/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
@@ -1,31 +1,34 @@
 import React, { Component } from 'react';
-import Button from '@material-ui/core/Button';
-import Checkbox from '@material-ui/core/Checkbox';
-import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import FormControl from '@material-ui/core/FormControl';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Grid from '@material-ui/core/Grid';
-import MenuItem from '@material-ui/core/MenuItem';
 import PropTypes from 'prop-types';
-import Snackbar from '@material-ui/core/Snackbar';
-import Select from '@material-ui/core/Select';
-import TextField from '@material-ui/core/TextField';
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
 import CloseIcon from '@material-ui/icons/Close';
-import IconButton from '@material-ui/core/IconButton';
 import Error from '@material-ui/icons/Error';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 
 import { gordonColors } from '../../../../../../theme';
 import user from '../../../../../../services/user';
 import membership from '../../../../../../services/membership';
+
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  ExpansionPanel,
+  ExpansionPanelDetails,
+  ExpansionPanelSummary,
+  FormControl,
+  FormControlLabel,
+  Grid,
+  MenuItem,
+  Snackbar,
+  Select,
+  TextField,
+  Typography,
+  Divider,
+  IconButton,
+} from '@material-ui/core';
 
 export default class MemberList extends Component {
   constructor(props) {

--- a/src/views/ActivityProfile/components/Membership/components/RequestDetail/index.js
+++ b/src/views/ActivityProfile/components/Membership/components/RequestDetail/index.js
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
-import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
 
 import { gordonColors } from '../../../../../../theme';
 import membership from '../../../../../../services/membership';
+
+import { Button, Grid, Typography, Divider } from '@material-ui/core';
 
 export default class RequestReceived extends Component {
   constructor(props) {

--- a/src/views/ActivityProfile/components/Membership/index.js
+++ b/src/views/ActivityProfile/components/Membership/index.js
@@ -1,25 +1,9 @@
-import Button from '@material-ui/core/Button';
-import Card from '@material-ui/core/Card';
-import CardActions from '@material-ui/core/CardActions';
-import CardContent from '@material-ui/core/CardContent';
-import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Grid from '@material-ui/core/Grid';
-import FormControl from '@material-ui/core/FormControl';
-import MenuItem from '@material-ui/core/MenuItem';
-import Select from '@material-ui/core/Select';
-import TextField from '@material-ui/core/TextField';
-import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
-import Snackbar from '@material-ui/core/Snackbar';
 import activity from '../../../../services/activity';
 import '../../activity-profile.css';
 import GordonLoader from '../../../../components/Loader';
 import MemberList from './components/MemberList';
 import membership from '../../../../services/membership';
-import IconButton from '@material-ui/core/IconButton';
 import RequestDetail from './components/RequestDetail';
 import CloseIcon from '@material-ui/icons/Close';
 import user from '../../../../services/user';
@@ -28,7 +12,26 @@ import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import Error from '@material-ui/icons/Error';
 //import RequestsReceived from '../../../Home/components/Requests/components/RequestsReceived';
 import AddPersonIcon from '@material-ui/icons/PersonAdd';
-import Divider from '@material-ui/core/Divider';
+
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Dialog,
+  DialogContent,
+  DialogActions,
+  DialogTitle,
+  Grid,
+  FormControl,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+  Snackbar,
+  IconButton,
+  Divider,
+} from '@material-ui/core';
 
 export default class Membership extends Component {
   constructor(props) {

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -1,18 +1,7 @@
-import Button from '@material-ui/core/Button';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
 import Dropzone from 'react-dropzone';
-import Grid from '@material-ui/core/Grid';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
-import TextField from '@material-ui/core/TextField';
-import Typography from '@material-ui/core/Typography';
 import activity from '../../services/activity';
 import './activity-profile.css';
 import Cropper from 'react-cropper';
@@ -25,7 +14,20 @@ import emails from '../../services/emails';
 import session from '../../services/session';
 import { gordonColors } from '../../theme';
 import user from '../../services/user';
-import { CardHeader } from '@material-ui/core';
+import {
+  CardHeader,
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Grid,
+  TextField,
+  Typography,
+} from '@material-ui/core';
 //import '../../app.js';
 
 const CROP_DIM = 320; // pixels

--- a/src/views/Admin/components/InvolvementsStatus/components/InvolvementStatusList/index.js
+++ b/src/views/Admin/components/InvolvementsStatus/components/InvolvementStatusList/index.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router-dom';
-import Grid from '@material-ui/core/Grid';
 import session from '../../../../../../services/session';
 
 import '../../../../../../app.css';
+
+import { Typography, Grid } from '@material-ui/core';
 
 export default class InvolvementStatusList extends Component {
   constructor(props) {

--- a/src/views/Admin/components/InvolvementsStatus/index.js
+++ b/src/views/Admin/components/InvolvementsStatus/index.js
@@ -1,11 +1,9 @@
 import React, { Component } from 'react';
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
 import { gordonColors } from '../../../../theme';
 import GordonLoader from '../../../../components/Loader';
 import activity from '../../../../services/activity';
 import InvolvementStatusList from './components/InvolvementStatusList/index';
-import Card from '@material-ui/core/Card';
+import { Typography, Divider, Card } from '@material-ui/core';
 
 export default class InvolvementsStatus extends Component {
   constructor(props) {

--- a/src/views/Admin/components/SuperAdmins/components/SuperAdminList/index.js
+++ b/src/views/Admin/components/SuperAdmins/components/SuperAdminList/index.js
@@ -1,14 +1,17 @@
 import React, { Component } from 'react';
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
-import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
 import { gordonColors } from '../../../../../../theme';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
 import admin from '../../../../../../services/admin';
+
+import {
+  Typography,
+  Divider,
+  Grid,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from '@material-ui/core';
 
 export default class SuperAdminList extends Component {
   constructor(props) {

--- a/src/views/Admin/components/SuperAdmins/index.js
+++ b/src/views/Admin/components/SuperAdmins/index.js
@@ -1,17 +1,20 @@
 import React, { Component } from 'react';
 import SuperAdminList from './components/SuperAdminList';
-import Typography from '@material-ui/core/Typography';
-import Card from '@material-ui/core/Card';
 import GordonLoader from '../../../../components/Loader';
 import admin from '../../../../services/admin';
-import Button from '@material-ui/core/Button';
-import TextField from '@material-ui/core/TextField';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
 import { gordonColors } from '../../../../theme';
 import membership from '../../../../services/membership';
+
+import {
+  Typography,
+  Card,
+  Button,
+  TextField,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from '@material-ui/core';
 
 export default class SuperAdmin extends Component {
   constructor(props) {

--- a/src/views/Admin/index.js
+++ b/src/views/Admin/index.js
@@ -1,11 +1,8 @@
-import Grid from '@material-ui/core/Grid';
 import React, { Component } from 'react';
 import InvolvementsStatus from './components/InvolvementsStatus';
 import SuperAdmin from './components/SuperAdmins';
 import user from '../../services/user';
-import { Button } from '@material-ui/core';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
+import { Button, Grid, Card, CardContent } from '@material-ui/core';
 
 export default class Admin extends Component {
   constructor(props) {

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -1,12 +1,9 @@
-import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
 import { gordonColors } from '../../theme';
 import Version from '../../services/version';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
 import './banner.css';
+
+import { Typography, Grid, Button, Card, CardContent } from '@material-ui/core';
 
 export default class BannerSubmission extends Component {
   constructor(props) {

--- a/src/views/CoCurricularTranscript/index.js
+++ b/src/views/CoCurricularTranscript/index.js
@@ -1,15 +1,12 @@
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import Typography from '@material-ui/core/Typography';
 import { gordonColors } from '../../theme';
 import Activity from './Components/CoCurricularTranscriptActivity';
 import Experience from './Components/CoCurricularTranscriptExperience';
 import user from './../../services/user';
 import GordonLoader from './../../components/Loader';
 import './coCurricularTranscript.css';
+
+import { Grid, Button, Card, CardContent, Typography } from '@material-ui/core';
 
 //This component creates the overall interface for the CoCurricularTranscript (card, heading,
 //download button), and contains a InvolvementsList object for displaying the content

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -1,17 +1,12 @@
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import TextField from '@material-ui/core/TextField';
-import FormGroup from '@material-ui/core/FormGroup';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Checkbox from '@material-ui/core/Checkbox';
-import Button from '@material-ui/core/Button';
-import Collapse from '@material-ui/core/Collapse';
 import gordonEvent from './../../services/event';
 import EventList from '../../components/EventList';
 import GordonLoader from '../../components/Loader';
 import { gordonColors } from './../../theme';
 
 import './event.scss';
+
+import { Grid, TextField, FormGroup, FormControlLabel, Checkbox, Button, Collapse } from '@material-ui/core';
 
 const styles = {
   searchBar: {

--- a/src/views/EventsAttended/index.js
+++ b/src/views/EventsAttended/index.js
@@ -1,14 +1,10 @@
 import React, { Component } from 'react';
-import List from '@material-ui/core/List';
-import Grid from '@material-ui/core/Grid';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import Button from '@material-ui/core/Button';
-import Typography from '@material-ui/core/Typography';
 import event from './../../services/event';
 import GordonLoader from '../../components/Loader';
 import EventList from './../../components/EventList';
 import { gordonColors } from '../../theme';
+
+import { List, Grid, Card, CardContent, Button, Typography } from '@material-ui/core';
 
 export default class EventsAttended extends Component {
   constructor(props) {

--- a/src/views/Feedback/index.js
+++ b/src/views/Feedback/index.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
 
 import './feedback.css';
-import { Button, Grid } from '@material-ui/core';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
+import { Button, Grid, Card, CardContent } from '@material-ui/core';
 
 export default class Feedback extends Component {
   constructor(props) {

--- a/src/views/Help/index.js
+++ b/src/views/Help/index.js
@@ -1,10 +1,8 @@
-import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
-import Card from '@material-ui/core/Card';
 import { gordonColors } from '../../theme';
 import './help.css';
+
+import { Typography, Grid, Button, Card } from '@material-ui/core';
 
 export default class Help extends Component {
   render() {

--- a/src/views/Home/components/CLWCredits/index.js
+++ b/src/views/Home/components/CLWCredits/index.js
@@ -1,12 +1,11 @@
 import React, { Component } from 'react';
 import { Doughnut } from 'react-chartjs-2';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import CardHeader from '@material-ui/core/CardHeader';
 
 import { gordonColors } from '../../../../theme';
 import user from '../../../../services/user';
 import GordonLoader from '../../../../components/Loader';
+
+import { Card, CardContent, CardHeader } from '@material-ui/core';
 
 export default class ChapelProgress extends Component {
   constructor(props) {

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -1,11 +1,5 @@
 import React, { Component } from 'react';
-import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
-import CardContent from '@material-ui/core/CardContent';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
 import { Doughnut, defaults } from 'react-chartjs-2';
-import Button from '@material-ui/core/Button';
 
 import { gordonColors } from '../../../../theme';
 import user from '../../../../services/user';
@@ -13,6 +7,8 @@ import session from '../../../../services/session';
 import GordonLoader from '../../../../components/Loader';
 
 import './CLWChart.css';
+
+import { Card, CardHeader, CardContent, Typography, Grid, Button } from '@material-ui/core';
 
 export default class CLWCreditsDaysLeft extends Component {
   constructor(props) {

--- a/src/views/Home/components/DaysLeft/index.js
+++ b/src/views/Home/components/DaysLeft/index.js
@@ -1,14 +1,11 @@
 import React, { Component } from 'react';
-import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
-import CardContent from '@material-ui/core/CardContent';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
 import { Doughnut, defaults } from 'react-chartjs-2';
 
 import { gordonColors } from '../../../../theme';
 import session from '../../../../services/session';
 import GordonLoader from '../../../../components/Loader';
+
+import { Card, CardHeader, CardContent, Typography, Grid } from '@material-ui/core';
 
 export default class DaysLeft extends Component {
   constructor(props) {

--- a/src/views/Home/components/DiningBalance/index.js
+++ b/src/views/Home/components/DiningBalance/index.js
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
 import { Doughnut, defaults } from 'react-chartjs-2';
-import { Button } from '@material-ui/core';
+import { Button, Grid, Typography, Card, CardHeader } from '@material-ui/core';
 import GordonLoader from '../../../../components/Loader';
 import { gordonColors } from '../../../../theme';
 import user from '../../../../services/user';

--- a/src/views/Home/components/NewsCard/components/CategorizedNews/index.js
+++ b/src/views/Home/components/NewsCard/components/CategorizedNews/index.js
@@ -4,10 +4,7 @@
 // This file is being preserved for now as the news features are still in development
 
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import Collapse from '@material-ui/core/Collapse';
-import { Button } from '@material-ui/core';
+import { Button, Grid, Typography, Collapse } from '@material-ui/core';
 import { gordonColors } from '../../../../../../theme';
 import NewsService from '../../../../../../services/news';
 import NewsItem from '../NewsItem';

--- a/src/views/Home/components/NewsCard/index.js
+++ b/src/views/Home/components/NewsCard/index.js
@@ -5,12 +5,8 @@
 // May be a potential future feature, but not sure
 
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import CardHeader from '@material-ui/core/CardHeader';
-import Card from '@material-ui/core/Card';
-import Typography from '@material-ui/core/Typography';
 import { CardContent } from '@material-ui/core';
-import { Button } from '@material-ui/core';
+import { Button, Grid, CardHeader, Card, Typography } from '@material-ui/core';
 import { gordonColors } from '../../../../theme';
 import NewsService from '../../../../services/news';
 import NewsItem from '../../../News/components/NewsItem';

--- a/src/views/Home/index.js
+++ b/src/views/Home/index.js
@@ -1,4 +1,3 @@
-import Grid from '@material-ui/core/Grid';
 import React, { useState, useEffect } from 'react';
 import GordonLoader from '../../components/Loader';
 import WellnessQuestion from '../../components/WellnessQuestion';
@@ -12,6 +11,7 @@ import wellness from '../../services/wellness';
 import storage from '../../services/storage';
 import Login from '../Login';
 import './home.css';
+import { Grid } from '@material-ui/core';
 
 const Home = ({ authentication, onLogIn }) => {
   const [loading, setLoading] = useState(true);

--- a/src/views/Login/index.js
+++ b/src/views/Login/index.js
@@ -1,19 +1,9 @@
-// TODO: When login page hang/refresh issue is solved, remove all code marked "Login Hang"
-
-import Button from '@material-ui/core/Button';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import TextField from '@material-ui/core/TextField';
-import Typography from '@material-ui/core/Typography';
-import Grid from '@material-ui/core/Grid';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import DocumentTitle from 'react-document-title';
-import Snackbar from '@material-ui/core/Snackbar';
 import CloseIcon from '@material-ui/icons/Close';
-import IconButton from '@material-ui/core/IconButton';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import amber from '@material-ui/core/colors/amber'; // Login Hang
-import Fab from '@material-ui/core/Fab';
 import PWAInstructions from '../../components/PWAInstructions/index';
 import './login.css';
 import { authenticate } from '../../services/auth';
@@ -22,6 +12,17 @@ import session from '../../services/session';
 import GordonLogoVerticalWhite from './gordon-logo-vertical-white.svg';
 import { gordonColors } from '../../theme';
 import { projectName } from '../../project-name';
+
+import {
+  Button,
+  CircularProgress,
+  TextField,
+  Typography,
+  Grid,
+  Snackbar,
+  IconButton,
+  Fab,
+} from '@material-ui/core';
 
 // To temporarily disable the Login Hang message, set this boolean to false
 const LOGIN_BUG_MESSAGE = true; // Login Hang

--- a/src/views/MyProfile/Components/VictoryPromiseDisplay/index.js
+++ b/src/views/MyProfile/Components/VictoryPromiseDisplay/index.js
@@ -1,18 +1,13 @@
-import Grid from '@material-ui/core/Grid';
 import React from 'react';
-import CardHeader from '@material-ui/core/CardHeader';
-import Tooltip from '@material-ui/core/Tooltip';
 import { gordonColors } from '../../../../theme';
 import { Polar } from 'react-chartjs-2';
 import victory from '../../../../services/victory';
 import './VictoryPromise.css';
-import Button from '@material-ui/core/Button';
 import './VictoryPromise.css';
 import { withStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
 import './VictoryPromise.css';
+
+import { Grid, CardHeader, Tooltip, Button, Typography, Card, CardContent } from '@material-ui/core';
 
 export default class VictoryPromiseDisplay extends React.Component {
   constructor(props) {

--- a/src/views/MyProfile/index.js
+++ b/src/views/MyProfile/index.js
@@ -1,8 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import Button from '@material-ui/core/Button';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import Grid from '@material-ui/core/Grid';
 import GordonLoader from '../../components/Loader';
 import GordonSchedulePanel from '../../components/SchedulePanel';
 import { Identification } from '../../components/Identification/index';
@@ -15,6 +11,8 @@ import VictoryPromiseDisplay from './Components/VictoryPromiseDisplay/index.js';
 import '../../app.css';
 import './myProfile.css';
 import 'cropperjs/dist/cropper.css';
+
+import { Button, Card, CardContent, Grid } from '@material-ui/core';
 
 const MyProfile = (props) => {
   const [loading, setLoading] = useState(true);

--- a/src/views/News/components/NewsItem/index.js
+++ b/src/views/News/components/NewsItem/index.js
@@ -1,10 +1,5 @@
 import PropTypes from 'prop-types';
-import Typography from '@material-ui/core/Typography';
 import React, { Component } from 'react';
-import CardContent from '@material-ui/core/CardContent';
-import Collapse from '@material-ui/core/Collapse';
-import Grid from '@material-ui/core/Grid';
-import Button from '@material-ui/core/Button';
 import newsService from './../../../../services/news';
 import EditIcon from '@material-ui/icons/Edit';
 import storage from '../../../../services/storage';
@@ -12,6 +7,8 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import { Link } from 'react-router-dom';
 
 import './newsItem.scss';
+
+import { Typography, CardContent, Collapse, Grid, Button } from '@material-ui/core';
 
 export default class NewsItem extends Component {
   constructor(props) {

--- a/src/views/News/components/NewsList/index.js
+++ b/src/views/News/components/NewsList/index.js
@@ -1,12 +1,10 @@
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import Card from '@material-ui/core/Card';
-import List from '@material-ui/core/List';
 
 import NewsItem from '../NewsItem';
 import { gordonColors } from '../../../../theme';
 import './newsList.scss';
+
+import { Grid, Typography, Card, List } from '@material-ui/core';
 
 export default class NewsList extends Component {
   constructor(props) {

--- a/src/views/News/index.js
+++ b/src/views/News/index.js
@@ -1,22 +1,25 @@
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
-import TextField from '@material-ui/core/TextField';
-import Button from '@material-ui/core/Button';
-import Fab from '@material-ui/core/Fab';
 import PostAddIcon from '@material-ui/icons/PostAdd';
-import Typography from '@material-ui/core/Typography';
 import newsService from './../../services/news';
 import userService from './../../services/user';
 import NewsList from '../News/components/NewsList';
 import GordonLoader from '../../components/Loader';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import MenuItem from '@material-ui/core/MenuItem';
-import { Snackbar, IconButton } from '@material-ui/core';
+import {
+  Snackbar,
+  IconButton,
+  Grid,
+  TextField,
+  Button,
+  Fab,
+  Typography,
+  Card,
+  CardContent,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+} from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 // testing for future feature to upload image
 // import IDUploader from '../IDUploader';

--- a/src/views/Page404/index.js
+++ b/src/views/Page404/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import { Typography } from '@material-ui/core';
-import Grid from '@material-ui/core/Grid';
+import { Typography, Grid } from '@material-ui/core';
 import mascot from './mascot.svg';
 import ScottieDog from './components/ScottieDog';
 

--- a/src/views/PeopleSearch/components/MobilePeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/MobilePeopleSearchResult/index.js
@@ -1,10 +1,8 @@
 import React, { Component } from 'react';
-import Grid from '@material-ui/core/Grid';
 import IMG from 'react-graceful-image';
-import { Typography } from '@material-ui/core';
+import { Typography, Grid, Divider } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import user from '../../../../services/user';
-import Divider from '@material-ui/core/Divider';
 import { Link } from 'react-router-dom';
 
 import './mobilePeopleSearchResult.css';

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -1,10 +1,8 @@
 import React, { Component } from 'react';
 import IMG from 'react-graceful-image';
-import Grid from '@material-ui/core/Grid';
-import { Typography } from '@material-ui/core';
+import { Typography, Grid, Divider } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import user from '../../../../services/user';
-import Divider from '@material-ui/core/Divider';
 import { Link } from 'react-router-dom';
 
 import './peopleSearchResult.css';

--- a/src/views/Profile/index.js
+++ b/src/views/Profile/index.js
@@ -1,12 +1,8 @@
-import Grid from '@material-ui/core/Grid';
 import React, { Component } from 'react';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
 import user from './../../services/user';
 import ProfileList from './../../components/ProfileList';
 import Office from './../../components/OfficeList';
 import { Involvements } from '../../components/Involvements/index';
-import Button from '@material-ui/core/Button';
 import GordonLoader from './../../components/Loader';
 import { socialMediaInfo } from '../../socialMedia';
 import GordonSchedulePanel from '../../components/SchedulePanel';
@@ -16,6 +12,8 @@ import { Redirect } from 'react-router';
 
 import './profile.css';
 import '../../app.css';
+
+import { Grid, Card, CardContent, Button } from '@material-ui/core';
 
 //Public profile view
 export default class Profile extends Component {

--- a/src/views/ProfileNotFound/index.js
+++ b/src/views/ProfileNotFound/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import { Typography } from '@material-ui/core';
-import Grid from '@material-ui/core/Grid';
+import { Typography, Grid } from '@material-ui/core';
 
 export default class ProfileNotFound extends Component {
   render() {


### PR DESCRIPTION
The Material UI library allows you to import component as a default from their particular sub-folder, OR as a named import from the core folder. e.g. `import Component from '@material-ui/core/Component'` vs `import { Component } from '@material-ui/core'`.

The former, default import used to be standard in older versions of the material-ui library because it imported exlcusively that component's code, whereas the latter named import syntax would actually import the entire library.

This is *no longer true*, as of webpack version 4.x (our react-scripts dep currently runs webpack v4.3). The named imports are properly handled and only import the necessary code.

Furthermore, the named imports have the advantage of being more concise and easier to add to/remove from/maintain when multiple components are imported. e.g.
```
import { Component1, Component2, Component3 } from '@material-ui/core'
```

vs.

```
import Component1 from '@material-ui/core/Component1';
import Component2 from '@material-ui/core/Component2';
import Component3 from '@material-ui/core/Component3';
```

This pull request uses the [`codemod`](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-codemod/README.md#top-level-imports) tool provided by the Material-ui team to automatically switch all default imports to named imports. 