### PR TITLE
Remove deprecated lifecycle method componentWillMount

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -47,7 +47,7 @@ export default class App extends Component {
 
     this.setState({ error, errorInfo });
   }
-  componentWillMount() {
+  componentDidMount() {
     let authentication = isAuthenticated();
     this.setState({ authentication });
   }

--- a/src/app.js
+++ b/src/app.js
@@ -33,7 +33,7 @@ export default class App extends Component {
       error: null,
       errorInfo: null,
       drawerOpen: false,
-      authentication: false,
+      authentication: isAuthenticated(),
     };
   }
   onDrawerToggle() {
@@ -46,10 +46,6 @@ export default class App extends Component {
     }
 
     this.setState({ error, errorInfo });
-  }
-  componentDidMount() {
-    let authentication = isAuthenticated();
-    this.setState({ authentication });
   }
 
   onAuthChange() {

--- a/src/components/ProfileList/index.js
+++ b/src/components/ProfileList/index.js
@@ -151,7 +151,7 @@ class ProfileList extends Component {
       return tele;
     }
   }
-  async componentWillMount() {
+  async componentDidMount() {
     this.setState({ isMobilePhonePrivate: this.props.profile.IsMobilePhonePrivate });
     if (!this.props.myProf) {
       this.setState({

--- a/src/components/SchedulePanel/components/ScheduleCalendar/index.js
+++ b/src/components/SchedulePanel/components/ScheduleCalendar/index.js
@@ -43,7 +43,7 @@ export default class GordonScheduleCalendar extends Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadData(this.props.profile);
   }
 

--- a/src/components/SchedulePanel/index.js
+++ b/src/components/SchedulePanel/index.js
@@ -78,7 +78,7 @@ class GordonSchedulePanel extends Component {
     this.reloadHandler = this.reloadHandler.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadData(this.props.profile);
   }
 

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -73,7 +73,7 @@ const authenticate = (username, password) =>
 /**
  * Check if current session is authenticated
  * @description This is a naive check. The session is considered authenticated if
- * @return {Promise.<boolean>} Whether session is authenticated or not
+ * @return {boolean} Whether session is authenticated or not
  */
 const isAuthenticated = () => {
   try {

--- a/src/views/About/index.js
+++ b/src/views/About/index.js
@@ -15,7 +15,7 @@ export default class About extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadData();
   }
 

--- a/src/views/ActivitiesAll/components/Requests/components/RequestsReceived/index.js
+++ b/src/views/ActivitiesAll/components/Requests/components/RequestsReceived/index.js
@@ -28,7 +28,7 @@ export default class RequestReceived extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadRequests();
   }
 

--- a/src/views/ActivitiesAll/components/Requests/index.js
+++ b/src/views/ActivitiesAll/components/Requests/index.js
@@ -19,7 +19,7 @@ export default class Requests extends Component {
       open: false,
     };
   }
-  componentWillMount() {
+  componentDidMount() {
     this.loadRequests();
   }
 

--- a/src/views/ActivitiesAll/index.js
+++ b/src/views/ActivitiesAll/index.js
@@ -171,9 +171,7 @@ export default class GordonActivitiesAll extends Component {
       currentAcademicSession:
         this.state.currentAcademicSession === '' ? sessionCode : this.state.currentAcademicSession,
     });
-  }
 
-  componentDidMount() {
     /* Used to re-render the page when the network connection changes.
      *  this.state.network is compared to the message received to prevent
      *  multiple re-renders that creates extreme performance lost.

--- a/src/views/ActivitiesAll/index.js
+++ b/src/views/ActivitiesAll/index.js
@@ -49,7 +49,7 @@ export default class GordonActivitiesAll extends Component {
     };
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     // this.setState({ loading: true });
     const { SessionCode: sessionCode } = await session.getCurrent();
     const [activities, types, sessions] = await Promise.all([

--- a/src/views/ActivityProfile/components/Advisors/index.js
+++ b/src/views/ActivityProfile/components/Advisors/index.js
@@ -13,7 +13,7 @@ export default class Advisors extends Component {
       activityAdvisors: [],
     };
   }
-  componentWillMount() {
+  componentDidMount() {
     this.loadAdvisors();
   }
   async loadAdvisors() {

--- a/src/views/ActivityProfile/components/GroupContacts/index.js
+++ b/src/views/ActivityProfile/components/GroupContacts/index.js
@@ -13,7 +13,7 @@ export default class GroupContacts extends Component {
       activityGroupAdmins: [],
     };
   }
-  componentWillMount() {
+  componentDidMount() {
     this.loadGroupContacts();
   }
   async loadGroupContacts() {

--- a/src/views/ActivityProfile/components/Membership/components/MemberDetail/index.js
+++ b/src/views/ActivityProfile/components/Membership/components/MemberDetail/index.js
@@ -43,7 +43,7 @@ export default class MemberDetail extends Component {
     this.onRemove = this.onRemove.bind(this);
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     this.setState({
       admin: this.props.admin,
       groupAdmin: this.props.groupAdmin,

--- a/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
+++ b/src/views/ActivityProfile/components/Membership/components/MemberList/index.js
@@ -56,7 +56,7 @@ export default class MemberList extends Component {
     this.breakpointWidth = 810;
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     this.setState({
       admin: this.props.admin,
       groupAdmin: this.props.groupAdmin,

--- a/src/views/ActivityProfile/components/Membership/components/RequestDetail/index.js
+++ b/src/views/ActivityProfile/components/Membership/components/RequestDetail/index.js
@@ -17,7 +17,7 @@ export default class RequestReceived extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadRequests();
   }
 

--- a/src/views/ActivityProfile/components/Membership/index.js
+++ b/src/views/ActivityProfile/components/Membership/index.js
@@ -69,7 +69,7 @@ export default class Membership extends Component {
     this.breakpointWidth = 810;
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     this.getMembership();
     this.loadMembers();
   }

--- a/src/views/ActivityProfile/components/Membership/index.js
+++ b/src/views/ActivityProfile/components/Membership/index.js
@@ -60,7 +60,6 @@ export default class Membership extends Component {
       isAdmin: this.props.isAdmin,
       isSuperAdmin: this.props.isSuperAdmin,
       participationDetail: [],
-      id: this.props.id,
       addEmail: '',
       addGordonID: '',
       requests: [],
@@ -72,6 +71,8 @@ export default class Membership extends Component {
   async componentDidMount() {
     this.getMembership();
     this.loadMembers();
+
+    window.addEventListener('resize', this.resize);
   }
 
   //Has to rerender on screen resize in order for table to switch to the mobile view
@@ -88,10 +89,6 @@ export default class Membership extends Component {
     if (this.isMobileView && window.innerWidth > this.breakpointWidth) return true;
     if (!this.isMobileView && window.innerWidth < this.breakpointWidth) return true;
     else return false;
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize', this.resize);
   }
 
   componentWillUnmount() {
@@ -127,7 +124,7 @@ export default class Membership extends Component {
   }
 
   async getMembership() {
-    let memberships = await user.getCurrentMemberships(this.state.id);
+    let memberships = await user.getCurrentMemberships(this.props.id);
     let membership;
     for (let i = 0; i < memberships.length; i += 1) {
       if (memberships[i].ActivityCode === this.props.activityCode) {
@@ -215,7 +212,7 @@ export default class Membership extends Component {
     let data = {
       ACT_CDE: this.props.activityCode,
       SESS_CDE: this.state.sessionInfo.SessionCode,
-      ID_NUM: user.getLocalInfo().id,
+      ID_NUM: this.props.id,
       PART_CDE: this.state.participationCode,
       DATE_SENT: date.toLocaleString(),
       COMMENT_TXT: this.state.titleComment,
@@ -232,7 +229,7 @@ export default class Membership extends Component {
     let data = {
       ACT_CDE: this.props.activityCode,
       SESS_CDE: this.state.sessionInfo.SessionCode,
-      ID_NUM: user.getLocalInfo().id,
+      ID_NUM: this.props.id,
       PART_CDE: 'GUEST',
       COMMENT_TXT: 'Subscriber',
       GRP_ADMIN: false,
@@ -251,16 +248,12 @@ export default class Membership extends Component {
   async loadMembers() {
     this.setState({ loading: true });
     try {
-      const [id, participationDetail] = await Promise.all([
-        user.getLocalInfo().id,
-        membership.search(
-          this.state.id,
-          this.props.sessionInfo.SessionCode,
-          this.props.activityCode,
-        ),
-      ]);
+      const participationDetail = await membership.search(
+        this.props.id,
+        this.props.sessionInfo.SessionCode,
+        this.props.activityCode,
+      );
       this.setState({
-        id,
         participationDetail,
         activityDescription: this.props.activityDescription,
         participationCode: '',

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -57,6 +57,7 @@ class ActivityProfile extends Component {
       activityStatus: '',
       sessionInfo: null,
       id: '', // User's id
+      loading: true,
       tempActivityBlurb: '', // For editing activity
       tempActivityJoinInfo: '', // For editing activity
       tempActivityURL: '', // For editing activity
@@ -100,10 +101,8 @@ class ActivityProfile extends Component {
         membership.checkAdmin(user.getLocalInfo().id, sessionCode, activityCode),
         membership.search(user.getLocalInfo().id, sessionCode, activityCode),
       ]);
-      if (this.state.isAdmin) {
-        const emailList = await emails.get(activityCode);
-        this.setState({ emailList });
-      }
+      const emailList = isAdmin ? await emails.get(activityCode) : null;
+      const isSuperAdmin = college_role === 'god';
       this.setState({
         activityInfo,
         activityAdvisors,
@@ -113,28 +112,26 @@ class ActivityProfile extends Component {
         activityStatus,
         sessionInfo,
         id,
-        isAdmin: isAdmin || college_role === 'god',
-        isSuperAdmin: college_role === 'god' ? true : false,
+        isAdmin: isAdmin || isSuperAdmin,
+        isSuperAdmin,
         participationDescription,
         tempActivityBlurb: activityInfo.ActivityBlurb,
         tempActivityJoinInfo: activityInfo.ActivityJoinInfo,
         tempActivityURL: activityInfo.ActivityURL,
+        emailList,
+        loading: false,
       });
-      if (this.state.isAdmin) {
-        const [emailList] = await Promise.all([emails.get(activityCode)]);
-        this.setState({ emailList });
-      }
+
       if (
-        (this.state.participationDescription[0] &&
-          this.state.participationDescription[1] !== 'Guest') ||
-        this.state.isSuperAdmin
+        (participationDescription[0] && participationDescription[1] !== 'Guest') ||
+        isSuperAdmin
       ) {
         // Only if the user is in the activity and not a guest can this get called (unless user is
         // a superadmin [god mode])
         // else Unauthorized error
         const activityMembers = await membership.get(
-          this.state.activityInfo.ActivityCode,
-          this.state.sessionInfo.SessionCode,
+          activityInfo.ActivityCode,
+          sessionInfo.SessionCode,
         );
         this.setState({ activityMembers });
       }
@@ -148,9 +145,9 @@ class ActivityProfile extends Component {
         activityInfo,
         activityStatus,
         sessionInfo,
+        loading: false,
       });
     }
-    this.setState({ loading: false });
   }
 
   onDropAccepted(fileList) {
@@ -339,7 +336,7 @@ class ActivityProfile extends Component {
     // Creates the content of an activity's profile depending on the status of the network found in local storage
     if (networkStatus === 'online') {
       if (this.props.authentication) {
-        if (this.state.loading === true) {
+        if (this.state.loading) {
           content = <GordonLoader />;
         } else {
           let editActivity;
@@ -348,13 +345,6 @@ class ActivityProfile extends Component {
             color: 'white',
           };
 
-          const {
-            ActivityDescription: activityDescription,
-            ActivityBlurb: activityBlurb,
-            ActivityJoinInfo: activityJoinInfo,
-            ActivityURL: activityURL,
-            ActivityImagePath: activityImagePath,
-          } = this.state.activityInfo;
           const { preview } = this.state;
 
           if (this.state.isAdmin) {
@@ -380,12 +370,12 @@ class ActivityProfile extends Component {
                 </CardContent>
 
                 <Dialog open={this.state.openEditActivity} fullWidth>
-                  <DialogTitle> Edit {activityDescription}</DialogTitle>
+                  <DialogTitle> Edit {this.state.activityInfo?.ActivityDescription}</DialogTitle>
                   <DialogContent>
                     <Grid align="center" className="activity-image" item>
                       <img
                         alt={activity.activityDescription}
-                        src={this.state.image || activityImagePath}
+                        src={this.state.image || this.state.activityInfo?.ActivityImagePath}
                         className="rounded-corners"
                       />
                     </Grid>
@@ -436,7 +426,7 @@ class ActivityProfile extends Component {
                                     <input {...getInputProps()} />
                                     <img
                                       className="rounded-corners"
-                                      src={activityImagePath}
+                                      src={this.state.activityInfo?.ActivityImagePath}
                                       alt=""
                                       style={{ 'max-width': '320px', 'max-height': '320px' }}
                                     />
@@ -538,7 +528,7 @@ class ActivityProfile extends Component {
                             margin="dense"
                             multiline
                             fullWidth
-                            defaultValue={activityBlurb}
+                            defaultValue={this.state.activityInfo?.ActivityBlurb}
                             onChange={this.handleChange('tempActivityBlurb')}
                           />
                         </Grid>
@@ -549,7 +539,7 @@ class ActivityProfile extends Component {
                             margin="dense"
                             multiline
                             fullWidth
-                            defaultValue={activityJoinInfo}
+                            defaultValue={this.state.activityInfo?.ActivityJoinInfo}
                             onChange={this.handleChange('tempActivityJoinInfo')}
                           />
                         </Grid>
@@ -560,7 +550,7 @@ class ActivityProfile extends Component {
                             margin="dense"
                             multiline
                             fullWidth
-                            defaultValue={activityURL}
+                            defaultValue={this.state.activityInfo?.ActivityURL}
                             onChange={this.handleChange('tempActivityURL')}
                           />
                         </Grid>
@@ -582,16 +572,21 @@ class ActivityProfile extends Component {
           }
           const { SessionDescription: sessionDescription } = this.state.sessionInfo;
           let description;
-          if (activityBlurb.length !== 0) {
-            description = <Typography variant="body2">{activityBlurb}</Typography>;
+          if (this.state.activityInfo?.ActivityBlurb?.length !== 0) {
+            description = (
+              <Typography variant="body2">{this.state.activityInfo?.ActivityBlurb}</Typography>
+            );
           }
           let website;
-          if (activityURL.length !== 0) {
+          if (this.state.activityInfo?.ActivityURL?.length !== 0) {
             website = (
               <Typography variant="body2">
-                <a href={activityURL} className="gc360-text-link" style={{ fontWeight: 'bold' }}>
-                  {' '}
-                  {activityURL}
+                <a
+                  href={this.state.activityInfo?.ActivityURL}
+                  className="gc360-text-link"
+                  style={{ fontWeight: 'bold' }}
+                >
+                  {this.state.activityInfo?.ActivityURL}
                 </a>
               </Typography>
             );
@@ -628,11 +623,14 @@ class ActivityProfile extends Component {
             <section className="gordon-activity-profile">
               <Card>
                 <CardContent>
-                  <CardHeader title={activityDescription} subheader={sessionDescription} />
+                  <CardHeader
+                    title={this.state.activityInfo?.ActivityDescription}
+                    subheader={sessionDescription}
+                  />
                   <Grid align="center" className="activity-image" item>
                     <img
                       alt={activity.activityDescription}
-                      src={activityImagePath}
+                      src={this.state.activityInfo?.ActivityImagePath}
                       className="rounded-corners"
                     />
                   </Grid>
@@ -674,29 +672,25 @@ class ActivityProfile extends Component {
         } else {
           let editActivity;
 
-          const {
-            ActivityDescription: activityDescription,
-            ActivityBlurb: activityBlurb,
-            ActivityURL: activityURL,
-            ActivityImagePath: activityImagePath,
-          } = this.state.activityInfo;
-
           const { SessionDescription: sessionDescription } = this.state.sessionInfo;
           let description;
-          if (activityBlurb.length !== 0) {
+          if (this.state.activityInfo?.ActivityBlurb?.length !== 0) {
             description = (
               <Typography variant="body1">
                 <strong>Description: </strong>
-                {activityBlurb}
+                {this.state.activityInfo?.ActivityBlurb}
               </Typography>
             );
           }
           let website;
-          if (activityURL.length !== 0) {
+          if (this.state.activityinfo?.ActivityURL?.length !== 0) {
             website = (
               <Typography variant="body2">
                 <strong>Website: </strong>
-                <a href={activityURL}> {activityURL}</a>
+                <a href={this.state.activityinfo?.ActivityURL}>
+                  {' '}
+                  {this.state.activityinfo?.ActivityURL}
+                </a>
               </Typography>
             );
           }
@@ -705,12 +699,12 @@ class ActivityProfile extends Component {
               <Card>
                 <CardContent>
                   <Typography align="center" variant="display1">
-                    {activityDescription}
+                    {this.state.activityInfo?.ActivityDescription}
                   </Typography>
                   <Grid align="center" className="activity-image" item>
                     <img
                       alt={activity.activityDescription}
-                      src={activityImagePath}
+                      src={this.state.activityInfo?.ActivityImagePath}
                       className="rounded-corners"
                     />
                   </Grid>

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -71,7 +71,7 @@ class ActivityProfile extends Component {
     this.cropperRef = React.createRef();
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     this.setState({ loading: true });
     const { sessionCode, activityCode } = this.props.match.params;
     if (this.props.authentication) {

--- a/src/views/Admin/components/InvolvementsStatus/components/InvolvementStatusList/index.js
+++ b/src/views/Admin/components/InvolvementsStatus/components/InvolvementStatusList/index.js
@@ -11,7 +11,7 @@ export default class InvolvementStatusList extends Component {
     this.state = { currentSession: '' };
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     const { SessionCode: sessionCode } = await session.getCurrent();
     this.setState({ currentSession: sessionCode });
   }

--- a/src/views/Admin/components/InvolvementsStatus/index.js
+++ b/src/views/Admin/components/InvolvementsStatus/index.js
@@ -14,7 +14,7 @@ export default class InvolvementsStatus extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadInvolvementsOfThisStatus();
   }
 

--- a/src/views/Admin/components/SuperAdmins/components/SuperAdminList/index.js
+++ b/src/views/Admin/components/SuperAdmins/components/SuperAdminList/index.js
@@ -24,7 +24,7 @@ export default class SuperAdminList extends Component {
     };
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     this.setState({});
   }
 

--- a/src/views/Admin/components/SuperAdmins/index.js
+++ b/src/views/Admin/components/SuperAdmins/index.js
@@ -30,7 +30,7 @@ export default class SuperAdmin extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadAdmins();
   }
 

--- a/src/views/Admin/index.js
+++ b/src/views/Admin/index.js
@@ -16,7 +16,7 @@ export default class Admin extends Component {
     };
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     if (this.props.authentication) {
       const college_role = await user.getLocalInfo().college_role;
       this.setState({ isSuperAdmin: college_role === 'god' ? true : false });

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -14,7 +14,7 @@ export default class BannerSubmission extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadData();
   }
 

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -1,82 +1,62 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { gordonColors } from 'theme';
-import Version from 'services/version';
 import './banner.css';
 
 import { Typography, Grid, Button, Card, CardContent } from '@material-ui/core';
 
-export default class BannerSubmission extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      loading: true,
-      version: null,
-    };
-  }
+const style = {
+  color: gordonColors.primary.blue,
 
-  componentDidMount() {
-    this.loadData();
-  }
+  uploadButton: {
+    background: gordonColors.primary.cyan,
+    color: 'white',
+    marginTop: '20px',
+  },
+};
 
-  async loadData() {
-    const versionPromise = Version.getVersion();
-    const version = await versionPromise;
-
-    this.setState({ loading: false, version });
-  }
-
-  render() {
-    const style = {
-      color: gordonColors.primary.blue,
-
-      uploadButton: {
-        background: gordonColors.primary.cyan,
-        color: 'white',
-        marginTop: '20px',
-      },
-    };
-
-    return (
-      <section>
-        <Grid container justify="center">
-          <Grid item xs={12} md={12} lg={8}>
-            <br />
-            <hr style={style} />
-            <Typography variant="h4" gutterBottom align="center">
-              Advertise your club or event on the 360 Homepage!
-            </Typography>
-            <hr style={style} />
-            <br />
-            <Card>
-              <CardContent>
-                <Grid container justify="center" direction="column">
-                  <Grid item align="center">
-                    <Typography align="center" variant="h6">
-                      Banner Image Guidelines
-                    </Typography>
-                    <Typography align="left" variant="body2" style={style.instructionsText}>
-                      <br />
-                      1. Attach JPG image with a resolution of 1500 by 600 <br />
-                      2. Text must be clearly legible <br />
-                      3. Include a url that you would like the banner image to link to in your
-                      email. <br />
-                      4. All banner images must be approved. There is limited space, so not all
-                      images will be.
-                    </Typography>
-                  </Grid>
-                  <Grid item align="center">
-                    <a href="mailto:360@gordon.edu?Subject=Banner Image Submission">
-                      <Button variant="contained" style={style.uploadButton}>
-                        Email the 360 Team
-                      </Button>
-                    </a>
-                  </Grid>
+const BannerSubmission = () => {
+  return (
+    <section>
+      <Grid container justify="center">
+        <Grid item xs={12} md={12} lg={8}>
+          <br />
+          <hr style={style} />
+          <Typography variant="h4" gutterBottom align="center">
+            Advertise your club or event on the 360 Homepage!
+          </Typography>
+          <hr style={style} />
+          <br />
+          <Card>
+            <CardContent>
+              <Grid container justify="center" direction="column">
+                <Grid item align="center">
+                  <Typography align="center" variant="h6">
+                    Banner Image Guidelines
+                  </Typography>
+                  <Typography align="left" variant="body2" style={style.instructionsText}>
+                    <br />
+                    1. Attach JPG image with a resolution of 1500 by 600 <br />
+                    2. Text must be clearly legible <br />
+                    3. Include a url that you would like the banner image to link to in your email.{' '}
+                    <br />
+                    4. All banner images must be approved. There is limited space, so not all images
+                    will be.
+                  </Typography>
                 </Grid>
-              </CardContent>
-            </Card>
-          </Grid>
+                <Grid item align="center">
+                  <a href="mailto:360@gordon.edu?Subject=Banner Image Submission">
+                    <Button variant="contained" style={style.uploadButton}>
+                      Email the 360 Team
+                    </Button>
+                  </a>
+                </Grid>
+              </Grid>
+            </CardContent>
+          </Card>
         </Grid>
-      </section>
-    );
-  }
-}
+      </Grid>
+    </section>
+  );
+};
+
+export default BannerSubmission;

--- a/src/views/CoCurricularTranscript/index.js
+++ b/src/views/CoCurricularTranscript/index.js
@@ -29,7 +29,7 @@ export default class Transcript extends Component {
     window.print();
   }
 
-  componentWillMount() {
+  componentDidMount() {
     if (this.props.authentication) {
       this.loadTranscript();
     }

--- a/src/views/EventsAttended/index.js
+++ b/src/views/EventsAttended/index.js
@@ -15,7 +15,7 @@ export default class EventsAttended extends Component {
       loading: true,
     };
   }
-  componentWillMount() {
+  componentDidMount() {
     if (this.props.authentication) {
       this.loadEvents();
     }

--- a/src/views/Home/components/CLWCredits/index.js
+++ b/src/views/Home/components/CLWCredits/index.js
@@ -19,7 +19,7 @@ export default class ChapelProgress extends Component {
       chapelCredits: {},
     };
   }
-  componentWillMount() {
+  componentDidMount() {
     this.loadChapel();
   }
   async loadChapel() {

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -26,7 +26,7 @@ export default class CLWCreditsDaysLeft extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadData();
   }
 

--- a/src/views/Home/components/Carousel/index.js
+++ b/src/views/Home/components/Carousel/index.js
@@ -18,7 +18,7 @@ export default class GordonCarousel extends Component {
 
     this.linkArray = [];
   }
-  componentWillMount() {
+  componentDidMount() {
     this.loadCarousel();
   }
   async loadCarousel() {

--- a/src/views/Home/components/DaysLeft/index.js
+++ b/src/views/Home/components/DaysLeft/index.js
@@ -20,7 +20,7 @@ export default class DaysLeft extends Component {
       loading: true,
     };
   }
-  componentWillMount() {
+  componentDidMount() {
     this.loadDaysLeft();
   }
   async loadDaysLeft() {

--- a/src/views/Home/components/DiningBalance/index.js
+++ b/src/views/Home/components/DiningBalance/index.js
@@ -22,7 +22,7 @@ export default class DiningBalance extends Component {
     this.balanceTypes = ['Dining Dollars', 'Swipes', 'Guest Swipes'];
     this.facStaffBalance = '';
   }
-  componentWillMount() {
+  componentDidMount() {
     this.loadData();
   }
 

--- a/src/views/Home/components/NewsCard/components/CategorizedNews/index.js
+++ b/src/views/Home/components/NewsCard/components/CategorizedNews/index.js
@@ -24,7 +24,7 @@ export default class CategorizedNews extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadNews();
   }
 

--- a/src/views/Home/components/NewsCard/index.js
+++ b/src/views/Home/components/NewsCard/index.js
@@ -24,7 +24,7 @@ export default class DailyNews extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadNews();
   }
 

--- a/src/views/MyProfile/Components/VictoryPromiseDisplay/index.js
+++ b/src/views/MyProfile/Components/VictoryPromiseDisplay/index.js
@@ -67,7 +67,7 @@ export default class VictoryPromiseDisplay extends React.Component {
     });
   };
 
-  componentWillMount() {
+  componentDidMount() {
     this.getVPScores();
   }
 

--- a/src/views/News/index.js
+++ b/src/views/News/index.js
@@ -73,7 +73,7 @@ export default class StudentNews extends Component {
     this.callFunction = this.callFunction.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.setState({ loading: false });
     this.loadNews();
     this.loadUsername();

--- a/src/views/News/index.js
+++ b/src/views/News/index.js
@@ -77,6 +77,7 @@ export default class StudentNews extends Component {
     this.setState({ loading: false });
     this.loadNews();
     this.loadUsername();
+    window.addEventListener('resize', this.resize);
   }
 
   async loadUsername() {
@@ -255,10 +256,6 @@ export default class StudentNews extends Component {
     if (this.isMobileView && window.innerWidth > this.breakpointWidth) return true;
     if (!this.isMobileView && window.innerWidth < this.breakpointWidth) return true;
     else return false;
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize', this.resize);
   }
 
   componentWillUnmount() {

--- a/src/views/PeopleSearch/components/MobilePeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/MobilePeopleSearchResult/index.js
@@ -24,7 +24,7 @@ export default class PeopleSearchResult extends Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadAvatar();
   }
 

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -24,7 +24,7 @@ export default class PeopleSearchResult extends Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadAvatar();
   }
 

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -287,7 +287,7 @@ class PeopleSearch extends Component {
     }
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     if (this.props.authentication) {
       try {
         const profile = await user.getProfileInfo();

--- a/src/views/Profile/Components/ActivityList/index.js
+++ b/src/views/Profile/Components/ActivityList/index.js
@@ -10,7 +10,7 @@ export default class Activities extends Component {
 
     this.state = {};
   }
-  componentWillMount() {
+  componentDidMount() {
     this.loadProfile();
   }
   async loadProfile() {}


### PR DESCRIPTION
The React lifecycle method `componentWillMount` has been deprecated since React 16.3 because of it's potential for misunderstanding and misuse leading to common bugs. React now produces a console warning about `componentWillMount`, and it will be removed in a coming update.

For this reason, it has been refactored - most commonly to use `componentDidMount` in it's place. In some cases (e.g. loading authentication state in app.js), all that is needed is loading the initial state, which is done in the constructor. 

Solves #962 