### PR TITLE
Apartapp fix isApplicantValid

### DIFF
--- a/src/services/housing.js
+++ b/src/services/housing.js
@@ -65,6 +65,8 @@ import user from './user';
  * @property {Number} AvgPoints The average application points per applicant
  */
 
+// const customErrorHandler = async () => {};
+
 /**
  * Check if the current user is authorized to view the housing staff page for applications
  *
@@ -76,6 +78,10 @@ const checkHousingAdmin = async () => {
   try {
     return await http.get(`housing/admin`);
   } catch (err) {
+    console.log(err);
+    console.log(err.response);
+    console.log(err.response.status);
+    console.log(err.status);
     // handle thrown 404 errors
     if (err.status === 404 || err.name.includes('NotFound')) {
       console.log('A 404 code indicates that current user was not found on the list of admins');

--- a/src/services/housing.js
+++ b/src/services/housing.js
@@ -201,18 +201,21 @@ const changeApartmentAppEditor = async (applicationID, newEditorUsername) => {
 /**
  * Helper function to fill in any missing properties of an applicant object's Profile, OffCampusProgram, etc.
  *
- * @async
  * @function setApplicantInfo
  * @param {ApartmentApplicant} applicant an object representing an apartment applicant
  * @return {ApartmentApplicant} Application details
  */
-const setApplicantInfo = async (applicant) => {
-  //! DEBUG: Temporary workaround for 'Profile.PersonType' being undefined
+const setApplicantInfo = (applicant) => {
+  //! DEBUG: Temporary workaround for an API bug that causes 'Profile.PersonType' to be undefined
   user.getProfileInfo(applicant.Username ?? applicant.Profile.Username).then((profile) => {
     applicant.Profile = profile;
   });
-  
-  //? Ideal solution, requires more testing once 'PersonType' issue is fixed
+
+  /**
+   * The following commented out commands are implicitly handled by `user.getProfileInfo()`,
+   * so these lines are not needed while the above workaround is still in place
+   */
+  //? This is the ideal solution. Requires more testing after the 'PersonType' issue is fixed in the API
   // applicant.Profile = user.setFullname(applicant.Profile);
   // applicant.Profile = user.setClass(applicant.Profile);
 
@@ -227,7 +230,9 @@ const setApplicationDetails = async (applicationDetails) => {
     NumApplicants: applicationDetails.Applicants?.length ?? 0,
     FirstHall: applicationDetails.ApartmentChoices[0]?.HallName ?? '',
   };
-  applicationDetails.Applicants = applicationDetails.Applicants.map((applicant) => setApplicantInfo(applicant));
+  applicationDetails.Applicants = applicationDetails.Applicants.map((applicant) =>
+    setApplicantInfo(applicant),
+  );
   return applicationDetails;
 };
 

--- a/src/services/housing.js
+++ b/src/services/housing.js
@@ -222,8 +222,8 @@ function setApplicantInfo(applicant) {
    * so these lines are not needed while the above workaround is still in place
    */
   //? This is the ideal solution. Requires more testing after the 'PersonType' issue is fixed in the API
-  // applicant.Profile = user.setFullname(applicant.Profile);
-  // applicant.Profile = user.setClass(applicant.Profile);
+  // user.setFullname(applicant.Profile);
+  // user.setClass(applicant.Profile);
 
   applicant.OffCampusProgram ??= '';
 
@@ -231,6 +231,7 @@ function setApplicantInfo(applicant) {
 }
 
 function setApplicationDetails(applicationDetails) {
+  console.debug(`formatting application # ${applicationDetails.ApplicationID}`);
   applicationDetails.Applicants ??= [];
   applicationDetails.Applicants = applicationDetails.Applicants.map((applicant) =>
     setApplicantInfo(applicant),
@@ -252,9 +253,7 @@ function setApplicationDetails(applicationDetails) {
 const getApartmentApplication = async (applicationID) => {
   try {
     let applicationResult = await http.get(`housing/apartment/applications/${applicationID}/`);
-    if (applicationResult) {
-      await setApplicationDetails(applicationResult);
-    }
+    setApplicationDetails(applicationResult);
     return applicationResult;
   } catch (err) {
     if (err?.status === 404 || err?.name?.includes('NotFound')) {
@@ -278,14 +277,9 @@ const getApartmentApplication = async (applicationID) => {
 const getAllApartmentApplications = async () => {
   try {
     let applicationDetailsArray = await http.get(`housing/admin/apartment/applications/`);
-    if (applicationDetailsArray?.length > 0) {
-      let newApplicationDetailsArray = await Promise.all(
-        applicationDetailsArray.map((applicationDetails) =>
-          setApplicationDetails(applicationDetails),
-        ),
-      );
-      applicationDetailsArray = newApplicationDetailsArray;
-    }
+    applicationDetailsArray.forEach((applicationDetails) =>
+      setApplicationDetails(applicationDetails),
+    );
     return applicationDetailsArray;
   } catch (err) {
     if (err?.status === 404 || err?.name?.includes('NotFound')) {

--- a/src/services/housing.js
+++ b/src/services/housing.js
@@ -225,6 +225,11 @@ function setApplicantInfo(applicant) {
   // user.setFullname(applicant.Profile);
   // user.setClass(applicant.Profile);
 
+  if (applicant.Class === null || Number(applicant.Class)) {
+    // Use converted Class from number ('1', '2', '3', ...) to words ('Freshman', 'Sophomore', ...)
+    applicant.Class = applicant.Profile.Class;
+  }
+
   applicant.OffCampusProgram ??= '';
 
   return applicant;
@@ -271,10 +276,10 @@ const getApartmentApplication = async (applicationID) => {
  * Get active apartment applications for the current semester
  *
  * @async
- * @function getAllApartmentApplications
+ * @function getSubmittedApartmentApplications
  * @return {Promise.<ApplicationDetails>[]} Application details
  */
-const getAllApartmentApplications = async () => {
+const getSubmittedApartmentApplications = async () => {
   try {
     let applicationDetailsArray = await http.get(`housing/admin/apartment/applications/`);
     applicationDetailsArray.forEach((applicationDetails) =>
@@ -313,6 +318,6 @@ export default {
   saveApartmentApplication,
   changeApartmentAppEditor,
   getApartmentApplication,
-  getAllApartmentApplications,
+  getSubmittedApartmentApplications,
   submitApplication,
 };

--- a/src/services/housing.js
+++ b/src/services/housing.js
@@ -65,7 +65,6 @@ import user from './user';
  * @property {Number} AvgPoints The average application points per applicant
  */
 
-// const customErrorHandler = async () => {};
 
 /**
  * Check if the current user is authorized to view the housing staff page for applications

--- a/src/services/housing.js
+++ b/src/services/housing.js
@@ -207,20 +207,16 @@ const changeApartmentAppEditor = async (applicationID, newEditorUsername) => {
  * @return {ApartmentApplicant} Application details
  */
 const setApplicantInfo = async (applicant) => {
-  if (applicant.Profile === null) {
-    if (applicant.Username) {
-      user.getProfileInfo(applicant.Username).then((profile) => {
-        applicant.Profile = profile;
-      });
-    }
-  } else {
-    applicant.Profile = user.setFullname(applicant.Profile);
-    applicant.Profile = user.setClass(applicant.Profile);
-  }
+  //! DEBUG: Temporary workaround for 'Profile.PersonType' being undefined
+  user.getProfileInfo(applicant.Username ?? applicant.Profile.Username).then((profile) => {
+    applicant.Profile = profile;
+  });
+  
+  //? Ideal solution, requires more testing once 'PersonType' issue is fixed
+  // applicant.Profile = user.setFullname(applicant.Profile);
+  // applicant.Profile = user.setClass(applicant.Profile);
 
-  if (applicant.OffCampusProgram === null) {
-    applicant.OffCampusProgram = '';
-  }
+  applicant.OffCampusProgram ??= '';
 
   return applicant;
 };
@@ -231,12 +227,7 @@ const setApplicationDetails = async (applicationDetails) => {
     NumApplicants: applicationDetails.Applicants?.length ?? 0,
     FirstHall: applicationDetails.ApartmentChoices[0]?.HallName ?? '',
   };
-  if (applicationDetails.NumApplicants > 0) {
-    let applicants = await Promise.all(
-      applicationDetails.Applicants.map((applicant) => setApplicantInfo(applicant)),
-    );
-    applicationDetails.Applicants = applicants;
-  }
+  applicationDetails.Applicants = applicationDetails.Applicants.map((applicant) => setApplicantInfo(applicant));
   return applicationDetails;
 };
 

--- a/src/services/housing.js
+++ b/src/services/housing.js
@@ -205,9 +205,9 @@ const changeApartmentAppEditor = async (applicationID, newEditorUsername) => {
  * @param {ApartmentApplicant} applicant an object representing an apartment applicant
  * @return {ApartmentApplicant} Application details
  */
-const setApplicantInfo = (applicant) => {
+function setApplicantInfo(applicant) {
   //! DEBUG: Temporary workaround for an API bug that causes 'Profile.PersonType' to be undefined
-  user.getProfileInfo(applicant.Username ?? applicant.Profile.Username).then((profile) => {
+  user.getProfileInfo(applicant.Username ?? applicant.Profile.AD_Username).then((profile) => {
     applicant.Profile = profile;
   });
 
@@ -222,19 +222,18 @@ const setApplicantInfo = (applicant) => {
   applicant.OffCampusProgram ??= '';
 
   return applicant;
-};
+}
 
-const setApplicationDetails = async (applicationDetails) => {
-  applicationDetails = {
-    ...applicationDetails,
-    NumApplicants: applicationDetails.Applicants?.length ?? 0,
-    FirstHall: applicationDetails.ApartmentChoices[0]?.HallName ?? '',
-  };
+function setApplicationDetails(applicationDetails) {
+  applicationDetails.Applicants ??= [];
   applicationDetails.Applicants = applicationDetails.Applicants.map((applicant) =>
     setApplicantInfo(applicant),
   );
+  applicationDetails.ApartmentChoices ??= [];
+  applicationDetails.NumApplicants = applicationDetails.Applicants?.length ?? 0;
+  applicationDetails.FirstHall = applicationDetails.ApartmentChoices[0]?.HallName ?? '';
   return applicationDetails;
-};
+}
 
 /**
  * Get active apartment application for given application ID number

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -181,10 +181,11 @@ import { socialMediaInfo } from 'socialMedia';
  * @property {String} CurrentBalance The current remaining meal plan balance
  */
 
-function formatName(profile) {
+function addFullnameToProfile(profile) {
   profile.fullName = `${profile.FirstName}  ${profile.LastName}`;
   return profile;
 }
+
 function setOnOffCampus(data) {
   switch (data.OnOffCampus) {
     case 'O':
@@ -204,12 +205,14 @@ function setOnOffCampus(data) {
   }
   return data;
 }
+
 function setClassYear(data) {
   if (data.PreferredClassYear) {
     data.ClassYear = data.PreferredClassYear;
   }
   return data;
 }
+
 function setMajorObject(data) {
   data.Majors = [];
   if (data.Major1Description) {
@@ -223,6 +226,7 @@ function setMajorObject(data) {
   }
   return data;
 }
+
 function setMinorObject(data) {
   data.Minors = [];
   if (data.Minor1Description) {
@@ -236,6 +240,7 @@ function setMinorObject(data) {
   }
   return data;
 }
+
 function formatCountry(profile) {
   if (profile.Country) {
     profile.Country = profile.Country.replace(/\w\S*/g, function (txt) {
@@ -250,6 +255,7 @@ function formatCountry(profile) {
   }
   return profile;
 }
+
 function setClass(profile) {
   if (String(profile.PersonType).includes('stu')) {
     switch (profile.Class) {
@@ -578,7 +584,7 @@ const getEmploymentInfo = async () => {
 
 const getProfileInfo = async (username) => {
   let profile = await getProfile(username);
-  formatName(profile);
+  addFullnameToProfile(profile);
   setClass(profile);
   setClassYear(profile);
   setMajorObject(profile);
@@ -636,6 +642,7 @@ function updateSocialLink(type, link) {
 }
 
 export default {
+  addFullnameToProfile,
   setMobilePhonePrivacy,
   setImagePrivacy,
   getMemberships,

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -181,7 +181,7 @@ import { socialMediaInfo } from 'socialMedia';
  * @property {String} CurrentBalance The current remaining meal plan balance
  */
 
-function addFullnameToProfile(profile) {
+function setFullname(profile) {
   profile.fullName = `${profile.FirstName}  ${profile.LastName}`;
   return profile;
 }
@@ -584,7 +584,7 @@ const getEmploymentInfo = async () => {
 
 const getProfileInfo = async (username) => {
   let profile = await getProfile(username);
-  addFullnameToProfile(profile);
+  setFullname(profile);
   setClass(profile);
   setClassYear(profile);
   setMajorObject(profile);
@@ -642,7 +642,7 @@ function updateSocialLink(type, link) {
 }
 
 export default {
-  addFullnameToProfile,
+  setFullname,
   setMobilePhonePrivacy,
   setImagePrivacy,
   getMemberships,

--- a/src/views/ApartmentApp/components/StaffMenu/index.js
+++ b/src/views/ApartmentApp/components/StaffMenu/index.js
@@ -10,9 +10,9 @@ import housing from '../../../../services/housing';
 import ApplicationsTable from './components/ApplicationTable';
 
 /**
- * @typedef { import('services/housing').ApplicationDetails } ApplicationDetails
  * @typedef { import('services/housing').ApartmentApplicant } ApartmentApplicant
  * @typedef { import('services/housing').ApartmentChoice } ApartmentChoice
+ * @typedef { import('services/housing').ApplicationDetails } ApplicationDetails
  */
 
 /**
@@ -44,7 +44,7 @@ const StaffMenu = ({ userProfile }) => {
    */
   const loadAllCurrentApplications = useCallback(async () => {
     setLoading(true);
-    let applicationDetailsArray = await housing.getAllApartmentApplications();
+    let applicationDetailsArray = await housing.getSubmittedApartmentApplications();
     setApplications(applicationDetailsArray);
     setLoading(false);
   }, []);

--- a/src/views/ApartmentApp/components/StudentApplication/index.js
+++ b/src/views/ApartmentApp/components/StudentApplication/index.js
@@ -163,7 +163,7 @@ const StudentApplication = ({ userProfile, authentication }) => {
     }
 
     if (applicant.Profile.fullName === null) {
-      applicant.Profile.fullName = user.addFullnameToProfile(applicant.Profile);
+      applicant.Profile.fullName = user.setFullname(applicant.Profile);
     }
 
     if (applicant?.OffCampusProgram === null) {

--- a/src/views/ApartmentApp/components/StudentApplication/index.js
+++ b/src/views/ApartmentApp/components/StudentApplication/index.js
@@ -163,7 +163,7 @@ const StudentApplication = ({ userProfile, authentication }) => {
     }
 
     if (applicant.Profile.fullName === null) {
-      applicant.Profile.fullName = user.formatName(applicant.Profile);
+      applicant.Profile.fullName = user.addFullnameToProfile(applicant.Profile);
     }
 
     if (applicant?.OffCampusProgram === null) {

--- a/src/views/ApartmentApp/components/StudentApplication/index.js
+++ b/src/views/ApartmentApp/components/StudentApplication/index.js
@@ -153,7 +153,7 @@ const StudentApplication = ({ userProfile, authentication }) => {
    * @param {ApartmentApplicant} applicant The applicant to be checked
    * @return {Boolean} True if valid, otherwise false
    */
-  const isApplicantValid = async (applicant) => {
+  const isApplicantValid = (applicant) => {
     // Check that the applicant contains the required fields
     if (applicant?.Profile === null) {
       setSnackbarText('Something went wrong while trying to add this person. Please try again.');
@@ -199,8 +199,7 @@ const StudentApplication = ({ userProfile, authentication }) => {
     }
 
     // Check if the selected user is already saved on an application in the database
-    try {
-      let existingAppID = await housing.getCurrentApplicationID(applicant.Profile.AD_Username);
+    housing.getCurrentApplicationID(applicant.Profile.AD_Username).then((existingAppID) => {
       if (existingAppID > 0 && existingAppID !== applicationDetails.ApplicationID) {
         // Display an error if the given applicant is already on a different application in the database
         setSnackbarText(
@@ -210,9 +209,7 @@ const StudentApplication = ({ userProfile, authentication }) => {
         setSnackbarOpen(true);
         return false;
       }
-    } catch {
-      // Do nothing
-    }
+    });
 
     return true;
   };
@@ -243,8 +240,7 @@ const StudentApplication = ({ userProfile, authentication }) => {
         setSnackbarText(String(newApplicantProfile.fullName) + ' is already in the list.');
         setSnackbarSeverity('info');
       } else {
-        let applicantIsValid = await isApplicantValid(newApplicantObject);
-        if (applicantIsValid) {
+        if (isApplicantValid(newApplicantObject)) {
           // Add the profile object to the list of applicants
           setApplicationDetails((prevApplicationDetails) => ({
             ...prevApplicationDetails,

--- a/src/views/ApartmentApp/components/StudentApplication/index.js
+++ b/src/views/ApartmentApp/components/StudentApplication/index.js
@@ -163,7 +163,7 @@ const StudentApplication = ({ userProfile, authentication }) => {
     }
 
     if (applicant.Profile.fullName === null) {
-      applicant.Profile = user.formatName(applicant.Profile);
+      applicant.Profile.fullName = user.formatName(applicant.Profile);
     }
 
     if (applicant?.OffCampusProgram === null) {


### PR DESCRIPTION
There were a couple of insidious bugs related to the function `isApplicantValid`.

1. Assigning an applicant's full name to the `applicant.Profile` property instead of `applicant.Profile.fullName`, accidentally overwriting all other Profile info
2. Calling `user.formatName(...)`, which is a function in `user.js` that wasn't exported (as therefore could not be called). 
3. Making it an async function means that calling it elsewhere is inconvenient, especially when you only want to extract the boolean result for a one-time comparison. I converted it to a synchronous version using `Promise.then()` syntax. This should fix present errors in places it was being used as-if it were synchronous, and also help prevent future bugs of a similar nature.