### PR TITLE
Refactor and Update Content on Help Page

### DIFF
--- a/src/views/Help/help.scss
+++ b/src/views/Help/help.scss
@@ -4,11 +4,6 @@
 
 .help {
   
-  strong {
-    font-weight: bold;
-    margin-top: 20px;
-  }
-  
   margin: 1rem;
 
   li {

--- a/src/views/Help/help.scss
+++ b/src/views/Help/help.scss
@@ -5,3 +5,34 @@ strong {
   font-weight: bold;
   margin-top: 20px;
 }
+
+.help {
+  margin: 1rem;
+
+  li {
+    list-style-type: '⮞ ';
+  }
+
+  & .MuiCard-root {
+    box-shadow: none;
+  }
+
+  &-title {
+    text-align: center;
+    padding: 1rem;
+  }
+
+  &-contributors.MuiTypography-root {
+    white-space: pre-wrap;
+    margin-left: 1rem;
+  }
+
+  &-header {
+    background-color: $primary-blue;
+    color: $neutral-white;
+  }
+  //TODO Issue #1098 - remove when timeshets.scss stops centering grid items
+  &-content {
+    text-align: start;
+  }
+}

--- a/src/views/Help/help.scss
+++ b/src/views/Help/help.scss
@@ -1,7 +1,6 @@
 @import '../../vars';
 
 strong {
-  font-size: 15px;
   font-weight: bold;
   margin-top: 20px;
 }
@@ -13,8 +12,13 @@ strong {
     list-style-type: '⮞ ';
   }
 
-  & .MuiCard-root {
-    box-shadow: none;
+  li li {
+    list-style-type: '⮚ ';
+  }
+
+  //TODO: Remove this when timesheets bugs are resolved
+  ul {
+    text-align: start;
   }
 
   &-title {
@@ -22,17 +26,8 @@ strong {
     padding: 1rem;
   }
 
-  &-contributors.MuiTypography-root {
-    white-space: pre-wrap;
-    margin-left: 1rem;
-  }
-
   &-header {
     background-color: $primary-blue;
     color: $neutral-white;
-  }
-  //TODO Issue #1098 - remove when timeshets.scss stops centering grid items
-  &-content {
-    text-align: start;
   }
 }

--- a/src/views/Help/help.scss
+++ b/src/views/Help/help.scss
@@ -1,11 +1,14 @@
 @import '../../vars';
 
-strong {
-  font-weight: bold;
-  margin-top: 20px;
-}
+
 
 .help {
+  
+  strong {
+    font-weight: bold;
+    margin-top: 20px;
+  }
+  
   margin: 1rem;
 
   li {

--- a/src/views/Help/index.js
+++ b/src/views/Help/index.js
@@ -48,14 +48,14 @@ export default class Help extends Component {
                           </li>
                           <li>
                             <strong>Faculty/Staff:</strong> Includes days remaining wheel and a separate Dining Dollars tracker.
-                            Also view your pending join requests for Involvements you’ve requested, as well
-                            as the requests that are pending for you approve if you are a Group Leader/Advisor.
                           </li>
                         </Typography>
                       </li>
                       <li>
                         <strong>Involvements</strong> &ndash; A list of available groups, clubs and organizations for the current
                         Academic Session. Change Academic Sessions in the drop down menu to view involvements in other sessions.
+                        You can view your pending join requests for Involvements you’ve requested, as well
+                        as the requests that are pending for you approve if you are a Group Leader/Advisor.
                       </li>
                       <li>
                         <strong>Events</strong> &ndash; A live list of events drawn from the campus master calendar including

--- a/src/views/Help/index.js
+++ b/src/views/Help/index.js
@@ -20,13 +20,13 @@ export default class Help extends Component {
                 <Card>
                   <CardHeader
                     className="help-header"
-                    title={`LOGIN INSTRUCTIONS`}
+                    title="LOGIN INSTRUCTIONS"
                     titleTypographyProps={{ variant: 'body1' }}
                   />
                   <CardContent>
-                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
-                      <li>Please use your 'firstname.lastname' username or your Gordon email address</li>
-                      <li>Use your current Gordon College account password here as well.</li>
+                    <Typography variant="body1" component="ul">
+                      <li>Username: 'firstname.lastname' or your Gordon email address</li>
+                      <li>Password: Your Gordon College account password</li>
                     </Typography>
                   </CardContent>
                 </Card>
@@ -34,27 +34,34 @@ export default class Help extends Component {
                 <Card>
                   <CardHeader
                     className="help-header"
-                    title={`SITE NAVIGATION`}
+                    title="SITE NAVIGATION"
                     titleTypographyProps={{ variant: 'body1' }}
                   />
                   <CardContent>
-                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                    <Typography variant="body1" component="ul">
                       <li>
-                        <strong>Home</strong> &ndash; Contains a chart displaying the number of days left in
-                        the current semester, alongside the number of Christian Life &amp; Worship Credits
-                        you have earned this semester. This chart can be clicked to view the CL&amp;W events
-                        you have attended. You can also view your pending requests to join Involvements, as
-                        well as requests to join your club, if you are a leader.
+                        <strong>Home</strong> &ndash; Contains various tiles with charts or information.
+                        <Typography variant="body1" component="ul">
+                          <li>
+                            <strong>Student:</strong> Includes your Dining “Meal Wheel’ tracker synced to days remaining in the
+                            semester and your Christian Life & Worship (CL&W) credits. You can click on the
+                            CL&W tracker to see which events are recorded for you.
+                          </li>
+                          <li>
+                            <strong>Faculty/Staff:</strong> Includes days remaining wheel and a separate Dining Dollars tracker.
+                            Also view your pending join requests for Involvements you’ve requested, as well
+                            as the requests that are pending for you approve if you are a Group Leader/Advisor.
+                          </li>
+                        </Typography>
                       </li>
                       <li>
-                        <strong>Involvements</strong> &ndash; Is a list of all the Current Involvements for this
-                        Academic Session. Pick the Academic Session in the drop down menu to view
-                        Involvements from other times of year.
+                        <strong>Involvements</strong> &ndash; A list of available groups, clubs and organizations for the current
+                        Academic Session. Change Academic Sessions in the drop down menu to view involvements in other sessions.
                       </li>
                       <li>
-                        <strong>Events</strong> &ndash; Displays a table of upcoming events on campus. You
-                        can search for specific events by name, location, or time. You can also filter by
-                        event type including those the offer CL&amp;W credit.
+                        <strong>Events</strong> &ndash; A live list of events drawn from the campus master calendar including
+                        CL&W events. You can search by event name, location and/or time. Use the filters to narrow your
+                        search (including CL&W events if you are looking for more).
                       </li>
                       <li>
                         <strong>People</strong> &ndash; Allows searching the campus community with more
@@ -62,18 +69,27 @@ export default class Help extends Component {
                         faculty by name or hall and by academic, home, and office info.
                       </li>
                       <li>
-                        <strong>Search Bar</strong> &ndash; Allows basic searching for Gordon students,
-                        faculty, and staff by name. (Just search by first or last name, don't include
-                        titles like Dr.)
+                        <strong>Quick Search</strong> &ndash; Quick searches by name of Gordon students, faculty and staff.
+                        Just first name or last name is needed.
                       </li>
                       <li>
-                        <strong>My Profile</strong> &ndash; Shows your personal information (such as your Student ID, and any
-                        Involvements you have been a part of) and your co-curricular transcript. This page is accessible from the profile image
-                        on the top right (on Desktop), or in the Navigation Drawer to the left (on Mobile). You
-                        can toggle what information is made visible to other students, as well as update or
-                        hide your profile photo (click on your photo for photo options). Anything with a
-                        lock is permanently private to only be seen by you. There is also an option to
-                        link your personal social media accounts which will be visible to other users.
+                        <strong>My Profile</strong> &ndash; Shows your own personal information – Student ID, current official
+                        ID photo and current personal photo (changeable), current and past involvements, other trackers and
+                        information, and your Experience Transcript (ET). Your ET displays a collection of your Honors and Leadership,
+                        Experience (work/jobs), Service Learning, and your Activities and Clubs in a resume-like format. You can
+                        also add links to your Social Media for others to connect with you in the My Profile photo section.
+                        On Mobile, access My Profile through the Navigation Drawer (three-line stack) or on Desktop by clicking your
+                        profile navitar picture on the top right of the navbar. Some settings have toggles to leave information public,
+                        or make it private. To view what others see about you, use the View My Public Profile feature near your photo
+                        on your My Profile view. For students, some key institutional contact information will remain visible to
+                        faculty and staff even if you make it private for student viewers. If you have a situation that requires
+                        additional privacy or security, please contact CTS,
+                        <a
+                          href='mailto:360@gordon.edu'
+                          style={{ color: gordonColors.primary.cyan }}>
+                          360@gordon.edu
+                        </a>
+                        , or the Registrar.
                       </li>
                     </Typography>
                   </CardContent>
@@ -82,24 +98,24 @@ export default class Help extends Component {
                 <Card>
                   <CardHeader
                     className="help-header"
-                    title={`INVOLVEMENT USER LEVELS`}
+                    title="INVOLVEMENT USER LEVELS"
                     titleTypographyProps={{ variant: 'body1' }}
                   />
                   <CardContent>
-                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                    <Typography variant="body1" component="ul">
                       <li>
                         <strong>Subscriber</strong> &ndash; Subscribers will receive Group emails. The
-                        Involvement will not appear on their Co-Curricular Transcript.
+                        Involvement will not appear on their Experience Transcript.
                       </li>
                       <li>
                         <strong>Member</strong> &ndash; Members appear on the roster and can see other
                         Members and Subscribers (Guests). Members receive group emails and have their role
-                        recorded in Memberships on the Co-Curricular Transcript, with a position title, if added.
+                        recorded in Memberships on the Experience Transcript, with a position title, if added.
                       </li>
                       <li>
                         <strong>Leader</strong> &ndash; Leaders appear on the roster with a title and with all
-                        the same privileges and Members. Leadership appears on Co-Curricular Transcript view
-                        and Official Co-Curricular Transcript, with their position title.
+                        the same privileges and Members. Leadership appears on Experience Transcript view
+                        and Official Experience Transcript, with their position title.
                       </li>
                       <li>
                         <strong>Advisor</strong> &ndash; Faculty or Staff Advisor have the same privileges
@@ -124,11 +140,11 @@ export default class Help extends Component {
                 <Card>
                   <CardHeader
                     className="help-header"
-                    title={`MANAGEMENT & EDITING INVOLVEMENTS`}
+                    title="MANAGEMENT & EDITING INVOLVEMENTS"
                     titleTypographyProps={{ variant: 'body1' }}
                   />
                   <CardContent>
-                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                    <Typography variant="body1" component="ul">
                       <li>
                         <strong>Group Email</strong> &ndash; Leaders/Advisors can email the full roster of
                         Members, plus any Subscribers to their Communications feed. Allows direct connection
@@ -149,9 +165,9 @@ export default class Help extends Component {
                       </li>
                       <li>
                         <strong>Title/Comment</strong> &ndash; Short but descriptive job or role title that
-                        will appear on the Roster and the Co-Curricular Transcript. Helps manage roles in
+                        will appear on the Roster and the Experience Transcript. Helps manage roles in
                         large rosters. Recommended for Leader and Advisors, can be used for anyone. These
-                        are public and appear as a detail for the Official Co-Curricular Transcript!
+                        are public and appear as a detail for the Official Experience Transcript!
                       </li>
                       <li>
                         <strong>Web link</strong> &ndash; Link to an Involvement&apos;s web page for more
@@ -174,11 +190,11 @@ export default class Help extends Component {
                 <Card>
                   <CardHeader
                     className="help-header"
-                    title={`ISSUES & TROUBLESHOOTING`}
+                    title="ISSUES & TROUBLESHOOTING"
                     titleTypographyProps={{ variant: 'body1' }}
                   />
                   <CardContent>
-                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                    <Typography variant="body1" component="ul">
                       <li>
                         <a
                           href="mailto:cts@gordon.edu?Subject=Gordon 360 Bug"
@@ -196,11 +212,11 @@ export default class Help extends Component {
                 <Card>
                   <CardHeader
                     className="help-header"
-                    title={`SUPPORTED PLATFORMS`}
+                    title="SUPPORTED PLATFORMS"
                     titleTypographyProps={{ variant: 'body1' }}
                   />
                   <CardContent>
-                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                    <Typography variant="body1" component="ul">
                       <li>
                         360 has been successfully tested on Windows (Firefox, Chrome), Mac (Safari,
                         Firefox, Chrome), and on Android and iPhone default browsers.
@@ -215,16 +231,16 @@ export default class Help extends Component {
                 <Card>
                   <CardHeader
                     className="help-header"
-                    title={`FAQ`}
+                    title="FAQ"
                     titleTypographyProps={{ variant: 'body1' }}
                   />
                   <CardContent>
-                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                    <Typography variant="body1" component="ul">
                       <li>
                         <strong>Do I have to rejoin an Involvement each semester?</strong> Yes. This allows
-                        each student to control their participation in Involvements for their Co-Curricular
-                        Transcript. Student Leaders and Advisors can ADD members and guests too! Some
-                        may do this to help maintain their team roster.
+                        each student to control their participation in Involvements for their Experience Transcript.
+                        Student Leaders and Advisors can ADD members and guests too! Some may do this to help
+                        maintain their team roster.
                       </li>
                       <li>
                         <strong>
@@ -239,7 +255,7 @@ export default class Help extends Component {
                         <strong>What if I leave an Involvement?</strong> Subscribership and Membership are
                         fluid during an academic session, and are confirmed at the conclusion of a session.
                         You can come and go over the semester, and your Membership will move to your
-                        official Co-Curricular Transcript only at the end of the semester.
+                        official Experience Transcript only at the end of the semester.
                       </li>
                       <li>
                         <strong>What if I am in an Involvement I don&apos;t want to be part of? </strong>

--- a/src/views/Help/index.js
+++ b/src/views/Help/index.js
@@ -7,7 +7,6 @@ import { Typography, Grid, Button, Card, CardHeader, CardContent } from '@materi
 export default class Help extends Component {
   render() {
     return (
-      <section>
         <Grid container justify="center">
           <Grid item xs={12} lg={8}>
             <Card className="help">
@@ -218,11 +217,11 @@ export default class Help extends Component {
                   <CardContent>
                     <Typography variant="body1" component="ul">
                       <li>
-                        360 has been successfully tested on Windows (Firefox, Chrome), Mac (Safari,
+                        360 has been successfully tested on Windows (Edge, Firefox, Chrome), Mac (Safari,
                         Firefox, Chrome), and on Android and iPhone default browsers.
                       </li>
                       <li>
-                        Currently, Gordon 360 is not supported on Microsoft Edge or Internet Explorer.
+                        Currently, Gordon 360 is not supported on Internet Explorer.
                       </li>
                     </Typography>
                   </CardContent>
@@ -283,7 +282,6 @@ export default class Help extends Component {
             </Typography>
           </Grid>
         </Grid>
-      </section>
     );
   }
 }

--- a/src/views/Help/index.js
+++ b/src/views/Help/index.js
@@ -2,256 +2,263 @@ import React, { Component } from 'react';
 import { gordonColors } from 'theme';
 import './help.css';
 
-import { Typography, Grid, Button, Card } from '@material-ui/core';
+import { Typography, Grid, Button, Card, CardHeader, CardContent } from '@material-ui/core';
 
 export default class Help extends Component {
   render() {
-    const headerStyle = {
-      backgroundColor: gordonColors.primary.blue,
-      color: '#FFF',
-      padding: '10px',
-    };
     return (
       <section>
         <Grid container justify="center">
-          <Grid item xs={12} md={12} lg={8}>
-            <Grid item>
-              <Card>
-                <div style={headerStyle}>
-                  <Typography variant="body2" style={headerStyle}>
-                    LOGIN
-                  </Typography>
-                </div>
-              </Card>
-            </Grid>
-            <Typography variant="body2" gutterBottom component="ul">
-              <br />
-              <li>Firstname.Lastname or Gordon email address</li>
-              <li>Normal Gordon password</li>
-            </Typography>
-            <br />
-            <Grid item>
-              <Card>
-                <div style={headerStyle}>
-                  <Typography variant="body2" style={headerStyle}>
-                    SITE NAVIGATION
-                  </Typography>
-                </div>
-              </Card>
-            </Grid>
-            <Typography variant="body2" gutterBottom component="ul">
-              <br />
-              <li>
-                <strong>Home</strong> &ndash; Contains a chart displaying the number of days left in
-                the current semester, alongside the number of Christian Life &amp; Worship Credits
-                you have earned this semester. This chart can be clicked to view the CL&amp;W events
-                you have attended. You can also view your pending requests to join Involvements, as
-                well as requests to join your club, if you are a leader.
-              </li>
-              <li>
-                <strong>Involvements</strong> &ndash; List of all the Current Involvements for this
-                Academic Session. Pick the Academic Session in the drop down menu to view
-                Involvements from other times of year.
-              </li>
-              <li>
-                <strong>Events</strong> &ndash; Displays a table of upcoming events on campus. You
-                can search for specific events by name, location, or time. You can also filter just
-                for events offering CL&amp;W credit.
-              </li>
-              <li>
-                <strong>Search Bar</strong> &ndash; You can search for students, faculty, and Gordon
-                staff. (Just search by first or last name, don't include titles like Dr.)
-              </li>
-              <li>
-                <strong>My Profile</strong> &ndash; This page is accessible from the profile image
-                on the top right (on Desktop), or in the Navigation Drawer to the left (on Mobile).
-                Here you can view your personal information (such as your Student ID, and any
-                Involvements you have been a part of) and access your co-curricular transcript. You
-                can toggle what information is made visible to other students, as well as update or
-                hide your profile photo (click on your photo for photo options). Anything with a
-                lock is permanently private and can only be seen by you. There is also an option to
-                link your personal social media accounts, that will be visible to other users.
-              </li>
-            </Typography>
-            <br />
-            <Grid item>
-              <Card>
-                <div style={headerStyle}>
-                  <Typography variant="body2" style={headerStyle}>
-                    USER LEVELS
-                  </Typography>
-                </div>
-              </Card>
-            </Grid>
-            <Typography variant="body2" gutterBottom component="ul">
-              <br />
-              <li>
-                <strong>Subscriber</strong> &ndash; Subscribers will receive Group emails. The
-                Involvement will not appear on your Co-Curricular Transcript.
-              </li>
-              <li>
-                <strong>Member</strong> &ndash; Members appear on the roster and can see other
-                Members and Subscribers (Guests). Members receive Group Emails and have their role
-                recorded in Memberships on the Co-Curricular Transcript, with a Title, if added.
-              </li>
-              <li>
-                <strong>Leader</strong> &ndash; Leaders appear on the roster with Title, with all
-                the same privileges and Members. Leadership appears on Co-Curricular Transcript view
-                and Official Co-Curricular Transcript, with Title.
-              </li>
-              <li>
-                <strong>Advisor</strong> &ndash; Faculty or Staff Advisor have the same privileges
-                as Leaders. It is recommended to give an Advisor a Title for the Roster.
-              </li>
-              <li>
-                <strong>Admin</strong> &ndash; can manage all Subscribers, Members and Leaders in
-                the Involvement. They can also manage join requests, Send Group Email, and Edit the
-                Involvement Information (photo, web link, Description). Admin privileges can be
-                granted to Members of any type.
-              </li>
-              <li>
-                <strong>Super-Admin</strong> &ndash; Administrative role for program and department
-                staff responsible for multiple Involvements. Super-Admins have admin privileges for
-                all Involvements, regardless if they have been added as members.
-              </li>
-            </Typography>
-            <br />
-            <Grid item>
-              <Card>
-                <div style={headerStyle}>
-                  <Typography variant="body2" style={headerStyle}>
-                    MANAGEMENT/EDITING FUNCTIONS
-                  </Typography>
-                </div>
-              </Card>
-            </Grid>
-            <Typography variant="body2" gutterBottom component="ul">
-              <br />
-              <li>
-                <strong>Group Email</strong> &ndash; Leaders/Advisors can email the full roster of
-                Members, plus any Subscribers to your Communications feed. Allows direct connection
-                emails.
-              </li>
-              <li>
-                <strong>Subscriber</strong> &ndash; Subscribes to the Email Feed from your Leader or
-                Advisor &ldquo;Email Group&rdquo; function. Subscribers cannot see Members on the
-                Roster, but can see Involvement Information.
-              </li>
-              <li>
-                <strong>Managing Requests</strong> &ndash; To receive a Subscriber or Membership
-                request, go to the home page, or open the Involvement you Lead/Advise. New requests
-                appear at the top of the roster. To modify a request to a different user level, use
-                the dropdown menu (Advisor, Leader, Member, Subscriber) to assign a different level.
-                Add an appropriate Title for Leaders and Advisors. You can add a Title to other
-                users, too.
-              </li>
-              <li>
-                <strong>Title/Comment</strong> &ndash; Short but descriptive job or role title that
-                will appear on the Roster and the Co-Curricular Transcript. Helps manage roles in
-                large rosters. Recommended for Leader and Advisors, can be used for anyone. These
-                are public and appear as a detail for the Official Co-Curricular Transcript!
-              </li>
-              <li>
-                <strong>Web link</strong> &ndash; Link to an Involvement&apos;s web page for more
-                information.
-              </li>
-              <li>
-                <strong>Description</strong> &ndash; Recommended 1-2 sentence Involvement
-                description, and place for updating Meeting Times and Locations for Involvement
-                Seekers, Subscribers and Members.
-              </li>
-              <li>
-                <strong>Image</strong> &ndash; 72DPI, no larger than 320x320 pixels and 100KB or
-                less. Recommend a square image for clearest quality. Default image will fill where
-                there is no Image loaded.
-              </li>
-            </Typography>
-            <br />
-            <Grid item>
-              <Card>
-                <div style={headerStyle}>
-                  <Typography variant="body2" style={headerStyle}>
-                    TROUBLESHOOTING/ISSUES
-                  </Typography>
-                </div>
-              </Card>
-            </Grid>
-            <Typography variant="body2" gutterBottom component="ul">
-              <br />
-              <li>
-                <a
-                  href="mailto:cts@gordon.edu?Subject=Gordon 360 Bug"
-                  style={{ color: gordonColors.primary.cyan }}
-                >
-                  Contact CTS
-                </a>
-                &nbsp;for issues using the portal on your device, or for login issues, or any
-                peculiar behaviors.
-              </li>
-            </Typography>
-            <br />
-            <Grid item>
-              <Card>
-                <div style={headerStyle}>
-                  <Typography variant="body2" style={headerStyle}>
-                    PLATFORMS
-                  </Typography>
-                </div>
-              </Card>
-            </Grid>
-            <Typography variant="body2" gutterBottom component="ul">
-              <br />
-              <li>
-                Tested successfully on Windows (Firefox, Chrome), Mac (Safari, Firefox, Chrome), and
-                on Android and iPhone default browsers. Currently not working on Edge or Internet
-                Explorer.
-              </li>
-            </Typography>
-            <br />
-            <Grid item>
-              <Card>
-                <div style={headerStyle}>
-                  <Typography variant="body2" style={headerStyle}>
-                    FAQ
-                  </Typography>
-                </div>
-              </Card>
-            </Grid>
-            <Typography variant="body2" gutterBottom component="ul">
-              <br />
-              <li>
-                <strong>Do I have to rejoin an Involvement each semester?</strong> Yes. This allows
-                each student to control their inclusion in Involvements for their Co-Curricular
-                Transcript. Student Leaders and Advisors can ADD members and guests, too, and some
-                may do this to help maintain their team roster.
-              </li>
-              <li>
-                <strong>
-                  What&apos;s the difference between subscribing to, and joining an Involvement?{' '}
-                </strong>
-                Subscribing to an Involvement allows you to receive emails from the Involvement, but
-                not to view other members of the Involvement. Joining a Involvement means you're a
-                member of the Involvement, and can view other members in the Involvement, in
-                addition to getting emails.
-              </li>
-              <li>
-                <strong>What if I leave an Involvement?</strong> Subscribership and Membership are
-                fluid during an academic session, and are confirmed at the conclusion of a session.
-                You can come and go over the semester, and your Membership will move to your
-                official Co-Curricular Transcript only at the end of the semester.
-              </li>
-              <li>
-                <strong>What if I am in an Involvement I don&apos;t want to be part of? </strong>
-                No problem. Contact the Involvement leaders or advisor.
-              </li>
-              <li>
-                <strong>
-                  I&apos;m an alumna or alumnus. Why do I not see the join button anymore?{' '}
-                </strong>
-                Sorry, but alumni cannot join new Involvements. You could still subscribe to
-                Involvements to receive emails!
-              </li>
-            </Typography>
+          <Grid item xs={12} lg={8}>
+            <Card className="help">
+              <CardHeader
+                className="help-title"
+                title="Gordon 360 Help"
+                titleTypographyProps={{ variant: 'h4' }}
+              />
+              <CardContent>
+                <Card>
+                  <CardHeader
+                    className="help-header"
+                    title={`LOGIN INSTRUCTIONS`}
+                    titleTypographyProps={{ variant: 'body1' }}
+                  />
+                  <CardContent>
+                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                      <li>Please use your 'firstname.lastname' username or your Gordon email address</li>
+                      <li>Use your current Gordon College account password here as well.</li>
+                    </Typography>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader
+                    className="help-header"
+                    title={`SITE NAVIGATION`}
+                    titleTypographyProps={{ variant: 'body1' }}
+                  />
+                  <CardContent>
+                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                      <li>
+                        <strong>Home</strong> &ndash; Contains a chart displaying the number of days left in
+                        the current semester, alongside the number of Christian Life &amp; Worship Credits
+                        you have earned this semester. This chart can be clicked to view the CL&amp;W events
+                        you have attended. You can also view your pending requests to join Involvements, as
+                        well as requests to join your club, if you are a leader.
+                      </li>
+                      <li>
+                        <strong>Involvements</strong> &ndash; Is a list of all the Current Involvements for this
+                        Academic Session. Pick the Academic Session in the drop down menu to view
+                        Involvements from other times of year.
+                      </li>
+                      <li>
+                        <strong>Events</strong> &ndash; Displays a table of upcoming events on campus. You
+                        can search for specific events by name, location, or time. You can also filter by
+                        event type including those the offer CL&amp;W credit.
+                      </li>
+                      <li>
+                        <strong>People</strong> &ndash; Allows searching the campus community with more
+                        in-depth filters than the normal search bar. You can filter students, staff, and
+                        faculty by name or hall and by academic, home, and office info.
+                      </li>
+                      <li>
+                        <strong>Search Bar</strong> &ndash; Allows basic searching for Gordon students,
+                        faculty, and staff by name. (Just search by first or last name, don't include
+                        titles like Dr.)
+                      </li>
+                      <li>
+                        <strong>My Profile</strong> &ndash; Shows your personal information (such as your Student ID, and any
+                        Involvements you have been a part of) and your co-curricular transcript. This page is accessible from the profile image
+                        on the top right (on Desktop), or in the Navigation Drawer to the left (on Mobile). You
+                        can toggle what information is made visible to other students, as well as update or
+                        hide your profile photo (click on your photo for photo options). Anything with a
+                        lock is permanently private to only be seen by you. There is also an option to
+                        link your personal social media accounts which will be visible to other users.
+                      </li>
+                    </Typography>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader
+                    className="help-header"
+                    title={`INVOLVEMENT USER LEVELS`}
+                    titleTypographyProps={{ variant: 'body1' }}
+                  />
+                  <CardContent>
+                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                      <li>
+                        <strong>Subscriber</strong> &ndash; Subscribers will receive Group emails. The
+                        Involvement will not appear on their Co-Curricular Transcript.
+                      </li>
+                      <li>
+                        <strong>Member</strong> &ndash; Members appear on the roster and can see other
+                        Members and Subscribers (Guests). Members receive group emails and have their role
+                        recorded in Memberships on the Co-Curricular Transcript, with a position title, if added.
+                      </li>
+                      <li>
+                        <strong>Leader</strong> &ndash; Leaders appear on the roster with a title and with all
+                        the same privileges and Members. Leadership appears on Co-Curricular Transcript view
+                        and Official Co-Curricular Transcript, with their position title.
+                      </li>
+                      <li>
+                        <strong>Advisor</strong> &ndash; Faculty or Staff Advisor have the same privileges
+                        as Leaders. It is recommended to give an Advisor a position title for the Roster.
+                      </li>
+                      <li>
+                        <strong>Admin</strong> &ndash; Admins can manage all Subscribers, Members and Leaders in
+                        the Involvement. They can also manage join requests, Send Group Email, and Edit the
+                        Involvement Information (photo, web link, description, etc.). Admin privileges can be
+                        granted to Members of any type.
+                      </li>
+                      <li>
+                        <strong>Super-Admin</strong> &ndash; Super-Admins have admin privileges for
+                        all Involvements, regardless if they have been added as Members. This is an
+                        administrative role for program and department staff, responsible for multiple
+                        Involvements.
+                      </li>
+                    </Typography>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader
+                    className="help-header"
+                    title={`MANAGEMENT & EDITING INVOLVEMENTS`}
+                    titleTypographyProps={{ variant: 'body1' }}
+                  />
+                  <CardContent>
+                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                      <li>
+                        <strong>Group Email</strong> &ndash; Leaders/Advisors can email the full roster of
+                        Members, plus any Subscribers to their Communications feed. Allows direct connection
+                        emails.
+                      </li>
+                      <li>
+                        <strong>Subscriber</strong> &ndash; Subscribers receive the email feed from their Leader or
+                        Advisor &ldquo;Email Group&rdquo; function. Subscribers cannot see Members on the
+                        Roster, but can see Involvement Information.
+                      </li>
+                      <li>
+                        <strong>Managing Requests</strong> &ndash; To manager a Subscriber or Membership
+                        request, go to the home page, or open the Involvement you Lead/Advise. New requests
+                        appear at the top of the roster. To modify a request to a different user level, use
+                        the dropdown menu (Advisor, Leader, Member, Subscriber) to assign a different level.
+                        Add an appropriate position title for Leaders and Advisors. You can add a title to other
+                        users as well.
+                      </li>
+                      <li>
+                        <strong>Title/Comment</strong> &ndash; Short but descriptive job or role title that
+                        will appear on the Roster and the Co-Curricular Transcript. Helps manage roles in
+                        large rosters. Recommended for Leader and Advisors, can be used for anyone. These
+                        are public and appear as a detail for the Official Co-Curricular Transcript!
+                      </li>
+                      <li>
+                        <strong>Web link</strong> &ndash; Link to an Involvement&apos;s web page for more
+                        information.
+                      </li>
+                      <li>
+                        <strong>Description</strong> &ndash; Recommended 1-2 sentence Involvement
+                        description, and place for updating meeting times and locations for Involvement
+                        seekers, Subscribers, and Members.
+                      </li>
+                      <li>
+                        <strong>Involvement Image</strong> &ndash; 72DPI, no larger than 320x320 pixels and 100KB or
+                        less. Recommend a square image for clearest quality. Default image will fill where
+                        there is no Image loaded.
+                      </li>
+                    </Typography>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader
+                    className="help-header"
+                    title={`ISSUES & TROUBLESHOOTING`}
+                    titleTypographyProps={{ variant: 'body1' }}
+                  />
+                  <CardContent>
+                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                      <li>
+                        <a
+                          href="mailto:cts@gordon.edu?Subject=Gordon 360 Bug"
+                          style={{ color: gordonColors.primary.cyan }}
+                        >
+                          Contact CTS
+                        </a>
+                        &nbsp;for issues using the portal on your device, or for login issues, or any
+                        peculiar behaviors.
+                      </li>
+                    </Typography>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader
+                    className="help-header"
+                    title={`SUPPORTED PLATFORMS`}
+                    titleTypographyProps={{ variant: 'body1' }}
+                  />
+                  <CardContent>
+                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                      <li>
+                        360 has been successfully tested on Windows (Firefox, Chrome), Mac (Safari,
+                        Firefox, Chrome), and on Android and iPhone default browsers.
+                      </li>
+                      <li>
+                        Currently, Gordon 360 is not supported on Microsoft Edge or Internet Explorer.
+                      </li>
+                    </Typography>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader
+                    className="help-header"
+                    title={`FAQ`}
+                    titleTypographyProps={{ variant: 'body1' }}
+                  />
+                  <CardContent>
+                    <Typography variant="body1" component="ul" style={{ textAlign: 'start' }}>
+                      <li>
+                        <strong>Do I have to rejoin an Involvement each semester?</strong> Yes. This allows
+                        each student to control their participation in Involvements for their Co-Curricular
+                        Transcript. Student Leaders and Advisors can ADD members and guests too! Some
+                        may do this to help maintain their team roster.
+                      </li>
+                      <li>
+                        <strong>
+                          What&apos;s the difference between subscribing to, and joining an Involvement?{' '}
+                        </strong>
+                        Subscribing to an Involvement allows you to receive emails from the Involvement, but
+                        not to view other members of the Involvement. Joining a Involvement means you're an
+                        active member of the Involvement. You can view other members in the Involvement in
+                        addition to getting group emails.
+                      </li>
+                      <li>
+                        <strong>What if I leave an Involvement?</strong> Subscribership and Membership are
+                        fluid during an academic session, and are confirmed at the conclusion of a session.
+                        You can come and go over the semester, and your Membership will move to your
+                        official Co-Curricular Transcript only at the end of the semester.
+                      </li>
+                      <li>
+                        <strong>What if I am in an Involvement I don&apos;t want to be part of? </strong>
+                        No problem. Contact the Involvement leaders or advisor and they will be able to
+                        remove you from the list.
+                      </li>
+                      <li>
+                        <strong>
+                          I&apos;m an alumna or alumnus. Why do I not see the join button anymore?{' '}
+                        </strong>
+                        We apologize, but alumni cannot join new Involvements. You could still subscribe to
+                        Involvements to receive emails!
+                      </li>
+                    </Typography>
+                  </CardContent>
+                </Card>
+
+              </CardContent>
+            </Card>
             <Typography variant="subtitle1" gutterBottom>
               <br /> Found a bug?
               <a href="mailto:cts@gordon.edu?Subject=Gordon 360 Bug">


### PR DESCRIPTION
Opened as a new version of #1110 because of merging issues.

The Help page, similar to the About page, has needed a refactor for design and readability when users are looking for easily-accessible assistance.

Current page:
![image](https://user-images.githubusercontent.com/43764277/117031063-39ece900-acce-11eb-92ff-52f31c6320f3.png)


After changes:
![image](https://user-images.githubusercontent.com/43764277/117075763-5b1bfc80-ad03-11eb-82af-1a8ab84e392d.png)

Similar to #1099 , "The main elements of the redesign were to put the content on a card and make consistent use of Material UI design."