### PR TITLE
Remove Box-Shadow from Help Cards

### DIFF
--- a/src/views/Help/help.scss
+++ b/src/views/Help/help.scss
@@ -4,11 +4,6 @@
 
 .help {
   
-  strong {
-    font-weight: bold;
-    margin-top: 20px;
-  }
-  
   margin: 1rem;
 
   li {

--- a/src/views/Help/help.scss
+++ b/src/views/Help/help.scss
@@ -3,7 +3,6 @@
 
 
 .help {
-  
   margin: 1rem;
 
   li {
@@ -13,7 +12,6 @@
   li li {
     list-style-type: '⮚ ';
   }
-
   //TODO: Remove this when timesheets bugs are resolved
   ul {
     text-align: start;
@@ -29,7 +27,7 @@
     color: $neutral-white;
   }
 
-  &-section {
-      box-shadow: none!important;
+  &-section.MuiCard-root {
+    box-shadow: none;
   }
 }

--- a/src/views/Help/help.scss
+++ b/src/views/Help/help.scss
@@ -28,4 +28,8 @@
     background-color: $primary-blue;
     color: $neutral-white;
   }
+
+  &-section {
+      box-shadow: none!important;
+  }
 }

--- a/src/views/Help/index.js
+++ b/src/views/Help/index.js
@@ -16,7 +16,7 @@ export default class Help extends Component {
                 titleTypographyProps={{ variant: 'h4' }}
               />
               <CardContent>
-                <Card>
+                <Card className="help-section">
                   <CardHeader
                     className="help-header"
                     title="LOGIN INSTRUCTIONS"
@@ -30,7 +30,7 @@ export default class Help extends Component {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="help-section">
                   <CardHeader
                     className="help-header"
                     title="SITE NAVIGATION"
@@ -94,7 +94,7 @@ export default class Help extends Component {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="help-section">
                   <CardHeader
                     className="help-header"
                     title="INVOLVEMENT USER LEVELS"
@@ -136,7 +136,7 @@ export default class Help extends Component {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="help-section">
                   <CardHeader
                     className="help-header"
                     title="MANAGEMENT & EDITING INVOLVEMENTS"
@@ -186,7 +186,7 @@ export default class Help extends Component {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="help-section">
                   <CardHeader
                     className="help-header"
                     title="ISSUES & TROUBLESHOOTING"
@@ -208,7 +208,7 @@ export default class Help extends Component {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="help-section">
                   <CardHeader
                     className="help-header"
                     title="SUPPORTED PLATFORMS"
@@ -227,7 +227,7 @@ export default class Help extends Component {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="help-section">
                   <CardHeader
                     className="help-header"
                     title="FAQ"


### PR DESCRIPTION
When I merged the pull request (#1111), the sections on the help page gained a box-shadow CSS property. This pull request adds a class to overwrite the box-shadow.