### PR TITLE
Update Class Years of Developers

### DIFF
--- a/src/views/About/contributors.json
+++ b/src/views/About/contributors.json
@@ -41,7 +41,7 @@
   },
   {
     "title": "Software Development Team, 2020/2021",
-    "body": "Aidan Perez '22, Benjamin Abbett '21, Bethany Ruggerio '23, Cameron Abbot '22, Gahngnin Kim '21, Hudson Finn '22, Hyungyu Park '22, Joshua Peters '23, Joshua Rogers '21, Matheus Ramos '22\nBennett Forkner, Evan Platzer '20, Information Systems Group"
+    "body": "Aidan Perez '22, Benjamin Abbett '21, Bethany Ruggerio '23, Cameron Abbot '23, Gahngnin Kim '21, Hudson Finn '22, Hyungyu Park '22, Joshua Peters '23, Joshua Rogers '21, Matheus Ramos '22\nBennett Forkner, Evan Platzer '20, Information Systems Group"
   },
   {
     "title": "Beneficent Philanthropes",

--- a/src/views/About/contributors.json
+++ b/src/views/About/contributors.json
@@ -41,7 +41,7 @@
   },
   {
     "title": "Software Development Team, 2020/2021",
-    "body": "Aidan Perez '22, Benjamin Abbett '21, Bethany Ruggerio '23, Cameron Abbot '22, Gahngnin Kim '21, Hudson Finn '22, Hyungyu Park '22, Joshua Peters '22, Joshua Rogers '21, Matheus Ramos '22\nBennett Forkner, Evan Platzer '20, Information Systems Group"
+    "body": "Aidan Perez '22, Benjamin Abbett '21, Bethany Ruggerio '23, Cameron Abbot '22, Gahngnin Kim '21, Hudson Finn '22, Hyungyu Park '22, Joshua Peters '23, Joshua Rogers '21, Matheus Ramos '22\nBennett Forkner, Evan Platzer '20, Information Systems Group"
   },
   {
     "title": "Beneficent Philanthropes",


### PR DESCRIPTION
A few of the students who we just added to the about page as the 2020-21 SD group had incorrect class years. This pull request resolves that.