### PR TITLE
Fix error displaying Activity Profile when Advisors or GroupAdmins is null

### DIFF
--- a/src/views/ActivityProfile/components/Advisors/index.js
+++ b/src/views/ActivityProfile/components/Advisors/index.js
@@ -1,67 +1,31 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Email from '@material-ui/icons/Email';
-
-import GordonLoader from 'components/Loader';
 
 import { IconButton, List, ListItem, Typography } from '@material-ui/core';
 
-export default class Advisors extends Component {
-  constructor(props) {
-    super(props);
+const Advisors = ({ advisors }) => {
+  if (advisors.length > 0) {
+    return (
+      <>
+        <Typography variant="body2">
+          <strong>Advisors:</strong>
+        </Typography>
+        <List dense disablePadding>
+          {advisors.map((activityAdvisor) => (
+            <ListItem key={activityAdvisor.Email}>
+              <IconButton size="small" color="primary" href={`mailto:${activityAdvisor.Email}`}>
+                <Email color="primary" style={{ width: 16, height: 16 }} />
+              </IconButton>
+              <Typography>
+                &emsp;{activityAdvisor.FirstName} {activityAdvisor.LastName}
+              </Typography>
+            </ListItem>
+          ))}
+        </List>
+      </>
+    );
+  }
+  return null;
+};
 
-    this.state = {
-      activityAdvisors: [],
-    };
-  }
-  componentDidMount() {
-    this.loadAdvisors();
-  }
-  async loadAdvisors() {
-    this.setState({ loading: true });
-    try {
-      this.setState({ loading: false });
-    } catch (error) {
-      this.setState({ error });
-    }
-  }
-  render() {
-    const { advisors } = this.props;
-    if (this.state.error) {
-      throw this.state.error;
-    }
-
-    let content = null;
-    if (this.state.loading === true) {
-      content = <GordonLoader />;
-    } else {
-      if (advisors.length > 0) {
-        content = (
-          <section className="gordon-activity-profile">
-            <Typography variant="body2">
-              <strong>Advisors:</strong>
-            </Typography>
-            <List dense disablePadding>
-              {advisors.map((activityAdvisor) => (
-                <ListItem className="contacts" key={activityAdvisor.Email}>
-                  <IconButton
-                    classes={{ root: 'email-button' }}
-                    color="primary"
-                    href={`mailto:${activityAdvisor.Email}`}
-                    padding={0}
-                    edge="end"
-                  >
-                    <Email color="primary" style={{ width: 16, height: 16 }} />
-                  </IconButton>
-                  <Typography>
-                    &emsp;{activityAdvisor.FirstName} {activityAdvisor.LastName}
-                  </Typography>
-                </ListItem>
-              ))}
-            </List>
-          </section>
-        );
-      }
-    }
-    return content;
-  }
-}
+export default Advisors;

--- a/src/views/ActivityProfile/components/GroupContacts/index.js
+++ b/src/views/ActivityProfile/components/GroupContacts/index.js
@@ -1,67 +1,31 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Email from '@material-ui/icons/Email';
-
-import GordonLoader from 'components/Loader';
 
 import { IconButton, List, ListItem, Typography } from '@material-ui/core';
 
-export default class GroupContacts extends Component {
-  constructor(props) {
-    super(props);
+const GroupContacts = ({ groupAdmin: groupAdmins }) => {
+  if (groupAdmins.length > 0) {
+    return (
+      <>
+        <Typography variant="body2">
+          <strong>Group Contacts:</strong>
+        </Typography>
+        <List dense disablePadding>
+          {groupAdmins.map((activityGroupAdmin) => (
+            <ListItem key={activityGroupAdmin.Email}>
+              <IconButton size="small" color="primary" href={`mailto:${activityGroupAdmin.Email}`}>
+                <Email color="primary" style={{ width: 16, height: 16 }} />
+              </IconButton>
+              <Typography>
+                &emsp;{activityGroupAdmin.FirstName} {activityGroupAdmin.LastName}
+              </Typography>
+            </ListItem>
+          ))}
+        </List>
+      </>
+    );
+  }
+  return null;
+};
 
-    this.state = {
-      activityGroupAdmins: [],
-    };
-  }
-  componentDidMount() {
-    this.loadGroupContacts();
-  }
-  async loadGroupContacts() {
-    this.setState({ loading: true });
-    try {
-      this.setState({ loading: false });
-    } catch (error) {
-      this.setState({ error });
-    }
-  }
-  render() {
-    const { groupAdmin } = this.props;
-    if (this.state.error) {
-      throw this.state.error;
-    }
-
-    let content = null;
-    if (this.state.loading === true) {
-      content = <GordonLoader />;
-    } else {
-      if (groupAdmin.length > 0) {
-        content = (
-          <section className="gordon-activity-profile">
-            <Typography variant="body2">
-              <strong>Group Contacts:</strong>
-            </Typography>
-            <List dense disablePadding>
-              {groupAdmin.map((activityGroupAdmin) => (
-                <ListItem className="contacts" key={activityGroupAdmin.Email}>
-                  <IconButton
-                    classes={{ root: 'email-button' }}
-                    color="primary"
-                    href={`mailto:${activityGroupAdmin.Email}`}
-                    padding={0}
-                    edge="end"
-                  >
-                    <Email color="primary" style={{ width: 16, height: 16 }} />
-                  </IconButton>
-                  <Typography>
-                    &emsp;{activityGroupAdmin.FirstName} {activityGroupAdmin.LastName}
-                  </Typography>
-                </ListItem>
-              ))}
-            </List>
-          </section>
-        );
-      }
-    }
-    return content;
-  }
-}
+export default GroupContacts;

--- a/src/views/ActivityProfile/components/GroupContacts/index.js
+++ b/src/views/ActivityProfile/components/GroupContacts/index.js
@@ -30,7 +30,7 @@ export default class GroupContacts extends Component {
       throw this.state.error;
     }
 
-    let content;
+    let content = null;
     if (this.state.loading === true) {
       content = <GordonLoader />;
     } else {


### PR DESCRIPTION
The Advisors and GroupContacts components were not returning from `render()` when they had no data to display. React requires every component to return, so this was causing an error and getting the stuck in a perpetual loading loop.

I have fixed it so that these components return null when they have no data, and I have also refactored them, removing a great deal of unnecessary code for loading that didn't actually load any data.