### PR TITLE
Involvements UI Improvements and Bug Fixes

### DIFF
--- a/src/views/InvolvementsAll/components/Requests/components/RequestSent/index.js
+++ b/src/views/InvolvementsAll/components/Requests/components/RequestSent/index.js
@@ -7,7 +7,7 @@ import membership from 'services/membership';
 
 const RequestSent = ({ member, onCancel }) => {
   const handleCancel = () => {
-    membership.cancelRequest(member.requestID);
+    membership.cancelRequest(member.RequestID);
     onCancel(member); // Updates state of parent component to cause rerender
   };
 

--- a/src/views/InvolvementsAll/components/Requests/index.js
+++ b/src/views/InvolvementsAll/components/Requests/index.js
@@ -95,7 +95,7 @@ const Requests = () => {
     return (
       <Grid item xs={12} lg={8}>
         <Card className="requests">
-          <Accordion defaultExpanded="true">
+          <Accordion defaultExpanded>
             <AccordionSummary
               aria-controls="received-requests-content"
               expandIcon={<ExpandMore style={{ color: 'white' }} />}
@@ -131,7 +131,7 @@ const Requests = () => {
       </Grid>
     );
   }
-  // otherwise hide since we have no requests
+  // otherwise hide component entirely since we have no requests
   return null;
 };
 

--- a/src/views/InvolvementsAll/components/Requests/index.js
+++ b/src/views/InvolvementsAll/components/Requests/index.js
@@ -33,59 +33,106 @@ const Requests = () => {
     setRequestsSent((prevRequestsSent) => prevRequestsSent.filter((r) => r !== request));
   };
 
-  return (
-    <Card className="requests">
-      <CardHeader title="Membership Requests" className="requests-header" />
-
-      <CardContent>
-        {involvementsLeading?.length > 0 && (
-          <Accordion>
+  // if leading involvements, show two dropdowns for requests received/sent
+  if(involvementsLeading?.length > 0) {
+    return (
+      <Grid item xs={12} lg={8}>
+          <Card className="requests">
+            <CardHeader title="Membership Requests" className="requests-header" />
+            
+            <CardContent>
+              <Accordion>
+                <AccordionSummary
+                  aria-controls="received-requests-content"
+                  expandIcon={<ExpandMore style={{ color: 'white' }} />}
+                  className="requests-header"
+                >
+                  <Typography variant="h6">Requests Received</Typography>
+                </AccordionSummary>
+                <AccordionDetails style={{ flexDirection: 'column' }}>
+                  {involvementsLeading.map((involvement) => (
+                    <RequestReceived
+                      key={involvement.ActivityCode + involvement.SessioinCode}
+                      involvement={involvement}
+                    />
+                  ))}
+                </AccordionDetails>
+              </Accordion>
+    
+              <Accordion>
+                <AccordionSummary
+                  aria-controls="sent-requests-content"
+                  expandIcon={<ExpandMore style={{ color: 'white' }} />}
+                  className="requests-header"
+                >
+                  <Typography variant="h6">Requests Sent</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Grid container align="right" direction="row">
+                    {requestsSent?.length > 0 ? (
+                      requestsSent
+                        .sort((a, b) => parseISO(b.DateSent) - parseISO(a.DateSent))
+                        .map((request) => (
+                          <RequestSent
+                            member={request}
+                            key={request.RequestID}
+                            onCancel={handleCancelRequest}
+                          />
+                        ))
+                    ) : (
+                      <Typography variant="h6">You haven't sent any requests</Typography>
+                    )}
+                  </Grid>
+                </AccordionDetails>
+              </Accordion>
+            </CardContent>
+          </Card>
+      </Grid>
+    );
+  }
+  // otherwise just show the requests sent (if there are any)
+  else if(requestsSent?.length > 0) {
+    return (
+      <Grid item xs={12} lg={8}>
+        <Card className="requests">
+          <Accordion defaultExpanded="true">
             <AccordionSummary
               aria-controls="received-requests-content"
               expandIcon={<ExpandMore style={{ color: 'white' }} />}
               className="requests-header"
             >
-              <Typography variant="h6">Requests Received</Typography>
+              <CardHeader 
+                title="Membership Requests"
+                className="requests-header"
+                  style={{padding: 0}} 
+              />
             </AccordionSummary>
             <AccordionDetails style={{ flexDirection: 'column' }}>
-              {involvementsLeading.map((involvement) => (
-                <RequestReceived
-                  key={involvement.ActivityCode + involvement.SessioinCode}
-                  involvement={involvement}
-                />
-              ))}
+              <CardContent>
+                <Grid container align="right" direction="row">
+                  {requestsSent?.length > 0 ? (
+                    requestsSent
+                      .sort((a, b) => parseISO(b.DateSent) - parseISO(a.DateSent))
+                      .map((request) => (
+                        <RequestSent
+                          member={request}
+                          key={request.RequestID}
+                          onCancel={handleCancelRequest}
+                        />
+                      ))
+                  ) : (
+                    <Typography variant="h6">You haven't sent any requests</Typography>
+                  )}
+                </Grid>
+              </CardContent>
             </AccordionDetails>
           </Accordion>
-        )}
-        <Accordion>
-          <AccordionSummary
-            aria-controls="sent-requests-content"
-            expandIcon={<ExpandMore style={{ color: 'white' }} />}
-            className="requests-header"
-          >
-            <Typography variant="h6">Requests Sent</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Grid container align="right" direction="row">
-              {requestsSent?.length > 0 ? (
-                requestsSent
-                  .sort((a, b) => parseISO(b.DateSent) - parseISO(a.DateSent))
-                  .map((request) => (
-                    <RequestSent
-                      member={request}
-                      key={request.RequestID}
-                      onCancel={handleCancelRequest}
-                    />
-                  ))
-              ) : (
-                <Typography variant="h6">You haven't sent any requests</Typography>
-              )}
-            </Grid>
-          </AccordionDetails>
-        </Accordion>
-      </CardContent>
-    </Card>
-  );
+        </Card>
+      </Grid>
+    );
+  }
+  // otherwise hide since we have no requests
+  return null;
 };
 
 export default Requests;

--- a/src/views/InvolvementsAll/index.js
+++ b/src/views/InvolvementsAll/index.js
@@ -170,9 +170,7 @@ const InvolvementsAll = ({ authentication, history }) => {
       </Grid>
 
       {isOnline && authentication && (
-        <Grid item xs={12} lg={8}>
-          <Requests />
-        </Grid>
+        <Requests />
       )}
 
       <Grid item xs={12} lg={8}>
@@ -191,12 +189,11 @@ const InvolvementsAll = ({ authentication, history }) => {
                     noInvolvementsText={myInvolvementsNoneText}
                   />
                 )}
+                <br></br>
+                <hr width="70%"></hr>
+                <br></br>
               </>
             )}
-
-            <br></br>
-            <hr width="70%"></hr>
-            <br></br>
 
              {/* All Involvements (public) */}
             {loading ? (

--- a/src/views/InvolvementsAll/index.js
+++ b/src/views/InvolvementsAll/index.js
@@ -104,17 +104,15 @@ const InvolvementsAll = ({ location, authentication, history }) => {
 
   let myInvolvementsHeadingText;
   let myInvolvementsNoneText;
+  let involvementSessionText = (selectedSession 
+    ? sessions.find((s) => s.SessionCode === selectedSession)?.SessionDescription
+    : '');
   if (selectedSession === currentAcademicSession && selectedSession !== '') {
     myInvolvementsHeadingText = 'Current';
     myInvolvementsNoneText = 
-      "It looks like you're not currently a member of any Involvements. Get connected below!";
+      "It looks like you're not currently a member of any involvements. Get connected below!";
   } else {
-    let involvementDescription = (selectedSession ? 
-      sessions.find((s) => s.SessionCode === selectedSession)
-        ?.SessionDescription
-      : 
-        '');
-    myInvolvementsHeadingText = involvementDescription;
+    myInvolvementsHeadingText = involvementSessionText;
     myInvolvementsNoneText = 'No personal involvements found for this term';
   }
 
@@ -177,13 +175,12 @@ const InvolvementsAll = ({ location, authentication, history }) => {
         <Requests />
       )}
 
-      <Grid item xs={12} lg={8}>
-        <Card>
-          <CardHeader title={`${myInvolvementsHeadingText} Involvements`} className="involvements-header" />
-          <CardContent>
-            {/* My Involvements (private) */}
-            {authentication && (
-              <>
+      {/* My Involvements (private) */}
+      {authentication && (
+        <Grid item xs={12} lg={8}>
+          <Card>
+            <CardHeader title={`My ${myInvolvementsHeadingText} Involvements`} className="involvements-header" />
+            <CardContent>
                 {loading ? (
                   <GordonLoader />
                 ) : (
@@ -193,13 +190,16 @@ const InvolvementsAll = ({ location, authentication, history }) => {
                     noInvolvementsText={myInvolvementsNoneText}
                   />
                 )}
-                <br></br>
-                <hr width="70%"></hr>
-                <br></br>
-              </>
-            )}
+            </CardContent>
+          </Card>
+        </Grid>
+      )}
 
-             {/* All Involvements (public) */}
+      {/* All Involvements (public) */}
+      <Grid item xs={12} lg={8}>
+        <Card>
+          <CardHeader title={`${involvementSessionText} Involvements`} className="involvements-header" />
+          <CardContent>
             {loading ? (
               <GordonLoader />
             ) : (

--- a/src/views/InvolvementsAll/index.js
+++ b/src/views/InvolvementsAll/index.js
@@ -104,7 +104,7 @@ const InvolvementsAll = ({ location, authentication, history }) => {
 
   let myInvolvementsHeadingText;
   let myInvolvementsNoneText;
-  if (selectedSession === currentAcademicSession) {
+  if (selectedSession === currentAcademicSession && selectedSession !== '') {
     myInvolvementsHeadingText = 'Current';
     myInvolvementsNoneText = 
       "It looks like you're not currently a member of any Involvements. Get connected below!";

--- a/src/views/InvolvementsAll/index.js
+++ b/src/views/InvolvementsAll/index.js
@@ -111,7 +111,7 @@ const InvolvementsAll = ({ authentication, history }) => {
     let involvementDescription = sessions.find((s) => s.SessionCode === selectedSession)
       ?.SessionDescription;
     myInvolvementsHeadingText = involvementDescription;
-    myInvolvementsNoneText = 'No Involvements found for ' + involvementDescription;
+    myInvolvementsNoneText = 'No personal involvements found for this term';
   }
 
   return (
@@ -149,7 +149,7 @@ const InvolvementsAll = ({ authentication, history }) => {
           </Grid>
           <Grid item xs={12} md={6} lg={3}>
             <FormControl fullWidth>
-              <InputLabel htmlFor="activity-type">Type of Involvement</InputLabel>
+              <InputLabel htmlFor="activity-type">Type</InputLabel>
               <Select
                 value={type}
                 onChange={(event) => setType(event.target.value)}
@@ -175,15 +175,13 @@ const InvolvementsAll = ({ authentication, history }) => {
         </Grid>
       )}
 
-      {authentication && (
-        <>
-          <Grid item xs={12} lg={8}>
-            <Card>
-              <CardHeader
-                title={`My ${myInvolvementsHeadingText} Involvements`}
-                className="involvements-header"
-              />
-              <CardContent>
+      <Grid item xs={12} lg={8}>
+        <Card>
+          <CardHeader title={`${myInvolvementsHeadingText} Involvements`} className="involvements-header" />
+          <CardContent>
+            {/* My Involvements (private) */}
+            {authentication && (
+              <>
                 {loading ? (
                   <GordonLoader />
                 ) : (
@@ -193,16 +191,14 @@ const InvolvementsAll = ({ authentication, history }) => {
                     noInvolvementsText={myInvolvementsNoneText}
                   />
                 )}
-              </CardContent>
-            </Card>
-          </Grid>
-        </>
-      )}
+              </>
+            )}
 
-      <Grid item xs={12} lg={8}>
-        <Card>
-          <CardHeader title={`All ${myInvolvementsHeadingText} Involvements`} className="involvements-header" />
-          <CardContent>
+            <br></br>
+            <hr width="70%"></hr>
+            <br></br>
+
+             {/* All Involvements (public) */}
             {loading ? (
               <GordonLoader />
             ) : (

--- a/src/views/InvolvementsAll/index.js
+++ b/src/views/InvolvementsAll/index.js
@@ -79,10 +79,7 @@ const InvolvementsAll = ({ location, authentication, history }) => {
   useEffect(() => {
     const updateInvolvements = async () => {
       setLoading(true);
-      let allInvolvements;
-      allInvolvements = await involvementService.getAll(selectedSession);
-      
-      setAllInvolvements(allInvolvements);
+      setAllInvolvements(await involvementService.getAll(selectedSession));
       setTypes(await involvementService.getTypes(selectedSession));
       if (authentication) {
         const { id } = await userService.getLocalInfo();
@@ -107,6 +104,10 @@ const InvolvementsAll = ({ location, authentication, history }) => {
   let involvementSessionText = (selectedSession 
     ? sessions.find((s) => s.SessionCode === selectedSession)?.SessionDescription
     : '');
+  if(involvementSessionText.includes("Academic Year")) {
+    involvementSessionText = involvementSessionText.substring(0, 
+      involvementSessionText.indexOf("Academic Year"));
+  }
   if (selectedSession === currentAcademicSession && selectedSession !== '') {
     myInvolvementsHeadingText = 'Current';
     myInvolvementsNoneText = 

--- a/src/views/InvolvementsAll/index.js
+++ b/src/views/InvolvementsAll/index.js
@@ -130,7 +130,7 @@ const InvolvementsAll = ({ authentication, history }) => {
           </Grid>
           <Grid item xs={12} md={6} lg={3}>
             <FormControl fullWidth>
-              <InputLabel htmlFor="activity-session">Session</InputLabel>
+              <InputLabel htmlFor="activity-session">Term</InputLabel>
               <Select
                 value={selectedSession}
                 onChange={(e) => setSelectedSession(e.target.value)}
@@ -201,7 +201,7 @@ const InvolvementsAll = ({ authentication, history }) => {
 
       <Grid item xs={12} lg={8}>
         <Card>
-          <CardHeader title="All Involvements" className="involvements-header" />
+          <CardHeader title={`All ${myInvolvementsHeadingText} Involvements`} className="involvements-header" />
           <CardContent>
             {loading ? (
               <GordonLoader />


### PR DESCRIPTION
## Involvements UI Visual Lift
### Language:
- Changed "session" to "term" because this makes more sense to a college student, for whom this is primarily targeting
- Changed "type of involvement" to "type" for the same reasons we do not say "search involvements" or "term/session of involvement" (to reduce redundancy, improve consistency, and also to prevent the label from overflowing the input dropdown field)
- Change "no involvements for `term name here (e.g. Spring 20-21 Academic Year) `" to simply "no involvements for this term" because the header already specifies the appropriate term and so this is redundant.
- Changed "All Involvements" header to specify the term, like we had done with the personal involvements

### Membership requests:
_Note: this is not the most elegant code and should probably be improved in future, but I think the direction is good_
- The average student on the average day will not have an membership requests sent nor received, so the page now hides the card entirely if there are no membership requests.
- For students who are not leading any activities, they now see a collapsible card (default open) of their current sent requests. This is better UX than before when they would see a "Membership Requests" header and inside a seemingly redundant "Requests Sent" header (redundant to the user that generally isn't aware of "Requests Received").
- For students who _are_ leading activities, they see the same card as before with two dropdowns - one for requests sent and one for requests received.

### Bug Fixes:
- Before the selectedSession was loaded properly, the session text for the headers was left undefined; this was changed to default to blank text so the user potentially sees for example "Involvements" -> "Current Involvements" instead of "undefined Involvements" -> "Current Involvements"
- Issue #1126 explains a bug that occurred in using browser back/forward buttons. This happened essentially because we used a UseEffect that had dependencies [selectedSession, history]. When a session was selected, this function pushed it onto the history, which then essentially called the function again since history was changed. This second call then messed up the browser history the same way that if you hit 'undo' and then type something, you can no longer 'redo'. Instead, this was changed to a select handler function rather than UseEffect.
- Issue #1127 explains a bug where membership requests were not being cancelled successfully. This ended up being a simple error where `member.RequestID` needed a capital `R`

### Notes for further improvement:
- I'm not sure if it looks good to have the involvements search area 'fixed' because a material design background should never overlap the foregrounded card, and also especially since this is inconsistent with the events page. That being said, I can understand the functionality and will leave it for now. Created issue #1129.
- There is a separate cancel icon depending if a request has been approved, which makes sense functionally but might be poor visual design. Created issue #1130.
![image](https://user-images.githubusercontent.com/17221652/118860664-ac9ebc80-b8a9-11eb-92cd-e257bf647d8d.png)


Resolves #1126, 
Resolves #1127