### PR TITLE
Re-centered Elements

### DIFF
--- a/src/components/Profile/components/MembershipsList/components/MembershipInfoCard/index.js
+++ b/src/components/Profile/components/MembershipsList/components/MembershipInfoCard/index.js
@@ -59,7 +59,7 @@ const MembershipInfoCard = ({ myProf, membership, onTogglePrivacy }) => {
 
           {myProf && (
             <Grid container item xs={4} alignItems="center">
-              <Grid item xs={12}>
+              <Grid item xs={12} align="center">
                 {isOnline &&
                   (membership.IsInvolvementPrivate ? (
                     <LockIcon className="lock-icon" />
@@ -72,7 +72,7 @@ const MembershipInfoCard = ({ myProf, membership, onTogglePrivacy }) => {
                     />
                   ))}
               </Grid>
-              <Grid item xs={12}>
+              <Grid item xs={12} align="center">
                 <Typography>
                   {membership.Privacy || membership.IsInvolvementPrivate ? 'Private' : 'Public'}
                 </Typography>

--- a/src/views/ActivityProfile/index.js
+++ b/src/views/ActivityProfile/index.js
@@ -621,6 +621,7 @@ class ActivityProfile extends Component {
                   <CardHeader
                     title={this.state.activityInfo?.ActivityDescription}
                     subheader={sessionDescription}
+                    align='center'
                   />
                   <Grid align="center" className="activity-image" item>
                     <img
@@ -629,8 +630,8 @@ class ActivityProfile extends Component {
                       className="rounded-corners"
                     />
                   </Grid>
-                  <Grid item>{editActivity}</Grid>
-                  <Grid item style={{ padding: '16px' }}>
+                  <Grid item align='center'>{editActivity}</Grid>
+                  <Grid item align='center' style={{ padding: '16px' }}>
                     {activityBlurb && <Typography variant="body2">{activityBlurb}</Typography>}
                     <Typography variant="subtitle1">{website}</Typography>
                   </Grid>

--- a/src/views/Page404/index.js
+++ b/src/views/Page404/index.js
@@ -44,7 +44,7 @@ export default class Page404 extends Component {
           </Typography>
         </Grid>
         {/* Gordon mascot image */}
-        <Grid item style={styles.image}>
+        <Grid item align="center" style={styles.image}>
           <img src={mascot} alt="Gordon Mascot" style={styles.mascot}></img>
         </Grid>
         {/* Scottie dog walking across bottom animation */}

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -785,7 +785,7 @@ class PeopleSearch extends Component {
       // Creates the PeopleSearch page depending on the status of the network found in local storage
       let PeopleSearch;
       let searchPageTitle = (
-        <div>
+        <div align='center'>
           Search the
           <b style={{ color: gordonColors.primary.cyan }}> Gordon </b>
           Community


### PR DESCRIPTION
Re-centered a few elements affected by change in global styling.
Centered people search, 404 mascot, activity profile title, and lock icon for private profile memberships.