### PR TITLE
Adjusted people search results alignment, changed type to description

### DIFF
--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -130,10 +130,10 @@ export default class PeopleSearchResult extends Component {
             <Grid item xs={2}>
               <Typography>{Person.LastName}</Typography>
             </Grid>
-            <Grid item xs={1}>
+            <Grid item xs={2}>
               <Typography>{Person.Type}</Typography>
             </Grid>
-            <Grid item xs={3}>
+            <Grid item xs={2}>
               <Typography>{personClassJobTitle}</Typography>
             </Grid>
             <Grid item xs={2}>

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -152,12 +152,12 @@ class PeopleSearch extends Component {
                     LAST NAME
                   </Typography>
                 </Grid>
-                <Grid item xs={1}>
-                  <Typography variant="body2" style={styles.headerStyle}>
-                    TYPE
+                <Grid item xs={2}>
+                  <Typography variant="body2" style={styles.headerStyle} noWrap>
+                    DESCRIPTION
                   </Typography>
                 </Grid>
-                <Grid item xs={3}>
+                <Grid item xs={2}>
                   <Typography variant="body2" style={styles.headerStyle}>
                     CLASS/JOB TITLE
                   </Typography>


### PR DESCRIPTION
Adjusted the people search results layout sizing so that way every column has an equal width; class/job title originally had a wider column because faculty/staff have longer titles but this is arguably not worth the inconsistency. Also changed type to description honestly just because it looked bad with a word as short as 'type' which also doesn't have very much significance anyway (type of what, is this telling me what type of person they are?).

Before:
![image](https://user-images.githubusercontent.com/17221652/119181090-261be380-ba3f-11eb-8be9-18908dbcf3fe.png)

After:
![image](https://user-images.githubusercontent.com/17221652/119180982-04baf780-ba3f-11eb-8f0b-5923a40dff60.png)
