### PR TITLE
Created UseQueryState Hook

### DIFF
--- a/src/components/EventList/index.js
+++ b/src/components/EventList/index.js
@@ -58,13 +58,11 @@ export default class EventList extends Component {
       padding: '10px',
     };
 
-    /****** HEADER ******/
-    // Show single "events" column on narrow viewports
-    if (window.innerWidth < this.breakpointWidth) {
-      content = events.map((currEvent) => (
-        <CollapsableEventItem event={currEvent} key={currEvent.Event_ID} />
-      ));
-
+    if (events.length === 0) {
+      content = <Typography variant="h5">No Events To Show</Typography>;
+    }
+    // MOBILE - Single Column Layout
+    else if (window.innerWidth < this.breakpointWidth) {
       header = (
         <div style={headerStyle}>
           <Grid container direction="row">
@@ -76,38 +74,40 @@ export default class EventList extends Component {
           </Grid>
         </div>
       );
-    } else if (events.length > 0) {
-      content = events.map((currEvent) => <EventItem event={currEvent} key={currEvent.Event_ID} />);
-    } else if (events.length === 0) {
-      content = <Typography variant="h5">No Events To Show</Typography>;
+      content = events.map((currEvent) => (
+        <CollapsableEventItem event={currEvent} key={currEvent.Event_ID} />
+      ));
     }
-
-    header = (
-      <div style={headerStyle}>
-        <Grid container direction="row">
-          <Grid item xs={4}>
-            <Typography variant="body2" style={headerStyle}>
-              EVENT
-            </Typography>
+    // DESKTOP - Multi-Column Layout
+    else {
+      header = (
+        <div style={headerStyle}>
+          <Grid container direction="row">
+            <Grid item xs={4}>
+              <Typography variant="body2" style={headerStyle}>
+                EVENT
+              </Typography>
+            </Grid>
+            <Grid item xs={4}>
+              <Typography variant="body2" style={headerStyle}>
+                LOCATION
+              </Typography>
+            </Grid>
+            <Grid item xs={2}>
+              <Typography variant="body2" style={headerStyle}>
+                DATE
+              </Typography>
+            </Grid>
+            <Grid item xs={2}>
+              <Typography variant="body2" style={headerStyle}>
+                TIME
+              </Typography>
+            </Grid>
           </Grid>
-          <Grid item xs={4}>
-            <Typography variant="body2" style={headerStyle}>
-              LOCATION
-            </Typography>
-          </Grid>
-          <Grid item xs={2}>
-            <Typography variant="body2" style={headerStyle}>
-              DATE
-            </Typography>
-          </Grid>
-          <Grid item xs={2}>
-            <Typography variant="body2" style={headerStyle}>
-              TIME
-            </Typography>
-          </Grid>
-        </Grid>
-      </div>
-    );
+        </div>
+      );
+      content = events.map((currEvent) => <EventItem event={currEvent} key={currEvent.Event_ID} />);
+    }
 
     return (
       <section>

--- a/src/hooks/useQueryState.js
+++ b/src/hooks/useQueryState.js
@@ -1,6 +1,17 @@
 import { useState, useCallback, useEffect, useLayoutEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
+export const types = {
+  SingleValue: 'SingleValue',
+  Array: 'Array',
+  Boolean: 'Boolean',
+};
+const defaultValues = {
+  SingleValue: '',
+  Array: [],
+  Boolean: false,
+};
+
 /**
  * Custom hook to useState synced with URL query parameters.
  * Inspiration from François Best https://github.com/47ng/next-usequerystate/tree/next/src
@@ -26,24 +37,13 @@ import { useHistory } from 'react-router-dom';
  * we cannot set to an initial value or else we might load (and overwrite the state) from the url
  * before we can set the url
  *
- * @param {String} keyParam - key of the QueryState variable
+ * @param {String} key - key of the QueryState variable
  * @param {String} typeString - the type of variable (must correspond with a types enum value)
  * @param {String} initial - initial value of the QueryState variable (optional)
  *          *** DOES NOT currently work because of loading from URL before URL gets set
  * @returns {[var, Callback]} - the state variable, the setQueryState callback function
  */
-function useQueryState(keyParam, typeString, initial) {
-  const key = keyParam; // we should never change the particular key once we start using it
-  const types = {
-    SingleValue: 'SingleValue',
-    Array: 'Array',
-    Boolean: 'Boolean',
-  };
-  const defaultValues = {
-    SingleValue: '',
-    Array: [],
-    Boolean: false,
-  };
+function useQueryState(key, typeString, initial) {
   const type = types[typeString];
   if (type === undefined)
     throw new Error(`type must be one of the given types: ${Object.values(types)}`);

--- a/src/hooks/useQueryState.js
+++ b/src/hooks/useQueryState.js
@@ -19,9 +19,17 @@ import { useHistory } from 'react-router-dom';
  * that prevents issues like setting the state unnecessarily after clicking the browser back
  * arrow, preventing you from going forward (and other similar browsing history issues).
  *
+ * Current Implementation Issues:
+ * - UseLayoutEffect is not a perfect solution to the race condition issue. Symptoms of this
+ * possibly poor design are evident when the browser 'back'/'forward' arrows are tested heavily
+ * which can skip queryStates (likely not a practical use case), as well as the fact that
+ * we cannot set to an initial value or else we might load (and overwrite the state) from the url
+ * before we can set the url
+ *
  * @param {String} keyParam - key of the QueryState variable
  * @param {String} typeString - the type of variable (must correspond with a types enum value)
  * @param {String} initial - initial value of the QueryState variable (optional)
+ *          *** DOES NOT currently work because of loading from URL before URL gets set
  * @returns {[var, Callback]} - the state variable, the setQueryState callback function
  */
 function useQueryState(keyParam, typeString, initial) {
@@ -65,7 +73,10 @@ function useQueryState(keyParam, typeString, initial) {
       else urlParams.set(key, state.toString());
 
       // boolean keys set to true don't need '=value'
-      urlParams = (urlParams.toString()).replace(/=true|=$/g, '').replace(/=&/,'&');
+      urlParams = urlParams
+        .toString()
+        .replace(/=true|=$/g, '')
+        .replace(/=&/, '&');
 
       history.push('?' + urlParams);
     };

--- a/src/hooks/useQueryState.js
+++ b/src/hooks/useQueryState.js
@@ -1,0 +1,127 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+
+/**
+ * Custom hook to useState synced with URL query parameters.
+ * Inspiration from François Best https://github.com/47ng/next-usequerystate/tree/next/src
+ *
+ * useQueryState can be used in the place of useState for any variables that should be
+ * stored and synced in the url. Supports the use of single value variables, array variables,
+ * and boolean variables.
+ * -- Single Value Variable: key='key', state/value='theValue' -> URL='&value=theValue'
+ * -- Array Variable: key='key', state/value='[one,two]' -> URL='&value=one%2Ctwo'
+ * -- Boolean Variable: key='isKeyValue', state/value='true' -> URL='&isKeyValue'
+ *
+ * Important note on this hook's philosophy: We are making the state value primary and the
+ * URL value secondary. Meaning the following:
+ * setQueryState sets the state, which updates the URL automatically. Only when the URL is updated
+ * *and is out of sync with the state* do we update the state. This is a critical design choice
+ * that prevents issues like setting the state unnecessarily after clicking the browser back
+ * arrow, preventing you from going forward (and other similar browsing history issues).
+ *
+ * @param {String} keyParam - key of the QueryState variable
+ * @param {String} initial - initial value of the QueryState variable TODO
+ * @returns {boolean} true if connected to the network, false otherwise. TODO
+ */
+function useQueryState(keyParam, initial) {
+  const [state, setState] = useState(initial);
+  const key = keyParam; // we should never change the particular key once we start using it
+  const defaultVal = initial; // so we can go back to it
+  // ^^^ NOTE: issue this probably has to be reset on url load
+  let history = useHistory();
+
+  /**
+   * TODO
+   */
+  useEffect(() => {
+    const setURLParam = async () => {
+      console.log('setURLParam', key, state);
+      let urlParams = new URLSearchParams(history.location.search);
+      console.log("urlParams", urlParams.toString(),
+       "key", urlParams.get(key),
+       "defaultVal", defaultVal,
+       "state", state.toString(), 
+       "action", (urlParams.get(key) ?? defaultVal) === state.toString());
+
+      // if the url value is already the same as the state value -> don't set the url again
+      if ((urlParams.get(key) ?? defaultVal.toString()) === state.toString()) return;
+
+      // key with no value OR boolean key set to false -> absent from url, push empty
+      if (!state || state === '' || state.length === 0 || state === false) urlParams.delete(key);
+      // boolean key set to true -> present in url, doesn't need '=value'
+      else if (state === true) {
+          console.log("boolean");
+          urlParams.delete(key);
+          urlParams += `&${encodeURIComponent(key)}`;
+      } else {
+        // value key is present in url with its current value
+        urlParams.set(key, state.toString());
+      }
+
+      history.push('?' + urlParams);
+    };
+    setURLParam();
+  }, [state]);
+
+  /**
+   * Anytime the url is changed, loadURLParams is invoked
+   * This function pulls the value of the key from the url
+   *   and updates the state with it (if changed)
+   */
+  useEffect(() => {
+    const loadURLParams = async () => {
+      const urlParams = new URLSearchParams(history.location.search);
+      /*** Boolean Key Logic ***/
+      // using boolean key -> load true if present, false if absent from url
+      if(defaultVal === true || defaultVal === false) {
+          setState(urlParams.has(key));
+          return;
+      }
+      let urlValue = urlParams.get(key);
+
+      /*** Array Key Logic ***/
+      // different logic if we are working with an array than with single value
+      // because setState will not do deep array comparison
+      if (Array.isArray(defaultVal)) {
+        // if the same value (or unset and state array is empty) -> do nothing
+        // this check is necessary because [] -> [] are different memory objects
+        if (urlValue === state.toString() || (!urlValue && state.length === 0)) return;
+        else if (!urlValue) setState(defaultVal);
+        else setState(urlValue.split(','));
+      }
+      /*** Single Value Key Logic ***/
+      else {
+        setState(urlValue ?? defaultVal);
+      }
+    };
+    console.log('loadURLParams', key, history.location.search);
+    loadURLParams();
+    /*********************** ESLint Disable Justification: *******************************/
+    // ESLint wants to include `defaultVal, key, state` as dependencies but to prevent
+    // extra loops of ~ url setting state setting the url ~ we do not include.
+    // It makes good sense that the only time we should pull the URL is the URL changes
+    /*************************************************************************************/
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [history.location.search]);
+
+  /**
+   * Callback function to allow user component to setQueryState just like one would use setState
+   */
+  const setQueryState = useCallback((val) => {
+    // this check prevents unnecessary array setting
+    // ([] -> [] are technically different memory objects)
+    // this is safe to deep compare because the array value should not have very many values
+    // (ex. 'filters' array has a few different possible filter values)
+    if (Array.isArray(defaultVal) && !JSON.stringify(state) === JSON.stringify(val)) return;
+    setState(val);
+    /*********************** ESLint Disable Justification: *******************************/
+    // We do not want the defaultVal or state dependencies here because they were simply added to
+    // prevent unecessarily setting the value array. We do not want any dependencies that might
+    // change the state after the initial setQueryState is called from the user function.
+    /*************************************************************************************/
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return [state, setQueryState];
+}
+export default useQueryState;

--- a/src/hooks/useQueryState.js
+++ b/src/hooks/useQueryState.js
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useLayoutEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 /**
@@ -38,12 +38,14 @@ function useQueryState(keyParam, initial) {
       console.log('setURLParam', key, state);
       let urlParams = new URLSearchParams(history.location.search);
       console.log("urlParams", urlParams.toString(),
-       "key", urlParams.get(key),
+       "url param", urlParams.get(key),
        "defaultVal", defaultVal,
        "state", state.toString(), 
        "action", (urlParams.get(key) ?? defaultVal) === state.toString());
 
       // if the url value is already the same as the state value -> don't set the url again
+      // note: must include toString in defaultVal.toString() in order to check empty arrays
+      // TODO: check defaultVal usage, might just change this to ''
       if ((urlParams.get(key) ?? defaultVal.toString()) === state.toString()) return;
 
       // key with no value OR boolean key set to false -> absent from url, push empty
@@ -60,6 +62,7 @@ function useQueryState(keyParam, initial) {
 
       history.push('?' + urlParams);
     };
+    console.log("state changed -> comparing with this url", history.location.search);
     setURLParam();
   }, [state]);
 
@@ -68,7 +71,7 @@ function useQueryState(keyParam, initial) {
    * This function pulls the value of the key from the url
    *   and updates the state with it (if changed)
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     const loadURLParams = async () => {
       const urlParams = new URLSearchParams(history.location.search);
       /*** Boolean Key Logic ***/

--- a/src/hooks/useQueryState.js
+++ b/src/hooks/useQueryState.js
@@ -29,6 +29,14 @@ const defaultValues = {
  * *and is out of sync with the state* do we update the state. This is a critical design choice
  * that prevents issues like setting the state unnecessarily after clicking the browser back
  * arrow, preventing you from going forward (and other similar browsing history issues).
+ * 
+ * Alternative approaches to try, should implementation change or issues arise:
+ * - Remove the loadStateFromURL from UseEffect and instead only set the state with the URL value
+ * when the page is first loaded (useEffect with []) or when the browser navigation is used
+ * (usePopState to detect browser back/forward arrows); this way the problem of oversetting is
+ * avoided without the use of checks that this approach uses
+ * - URL First Approach: Rather than being state-first and updating the URL as needed,
+ * this approach would be to use the URL as the ~ source of truth ~ so to speak
  *
  * Current Implementation Issues:
  * - UseLayoutEffect is not a perfect solution to the race condition issue. Symptoms of this

--- a/src/services/event.js
+++ b/src/services/event.js
@@ -178,7 +178,7 @@ export const EVENT_FILTERS = Object.freeze([
  * @param {Event[]} events the events to filter
  * @param {string[]} filters the list of filters to use
  * @param {string} search the string to search against
- * @returns {Event[]} The filtered list of events
+ * @returns {Promise<Event[]>} The filtered list of events
  */
 const getFilteredEvents = (events, filters, search) => {
   const matchesSearch = makeMatchesSearch(search);

--- a/src/services/event.js
+++ b/src/services/event.js
@@ -178,7 +178,7 @@ export const EVENT_FILTERS = Object.freeze([
  * @param {Event[]} events the events to filter
  * @param {string[]} filters the list of filters to use
  * @param {string} search the string to search against
- * @returns {Promise<Event[]>} The filtered list of events
+ * @returns {Event[]} The filtered list of events
  */
 const getFilteredEvents = (events, filters, search) => {
   const matchesSearch = makeMatchesSearch(search);

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -29,8 +29,6 @@ const Events = (props) => {
   const [filters, setFilters] = useQueryState('filters', 'Array');
   const futureEvents = useMemo(() => gordonEvent.getFutureEvents(allEvents), [allEvents]);
 
-  const [searchTest, setSearchTest] = useQueryState('search', 'SingleValue');
-
   useEffect(() => {
     // Single use - Loads events data on page load / authentication
     const loadEventsPage = async () => {
@@ -125,8 +123,8 @@ const Events = (props) => {
           <TextField
             id="search"
             label="Search"
-            value={searchTest}
-            onChange={(event) => setSearchTest(event.target.value)}
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
             fullWidth
           />
         </Grid>

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -24,12 +24,12 @@ const Events = (props) => {
   const [allEvents, setAllEvents] = useState([]);
   const [events, setEvents] = useState([]);
   const [filteredEvents, setFilteredEvents] = useState([]);
-  const [includePast, setIncludePast] = useQueryState('past', false);
+  const [includePast, setIncludePast] = useQueryState('past', 'Boolean');
   const [loading, setLoading] = useState(true);
-  const [filters, setFilters] = useQueryState('filters', []);
+  const [filters, setFilters] = useQueryState('filters', 'Array');
   const futureEvents = useMemo(() => gordonEvent.getFutureEvents(allEvents), [allEvents]);
 
-  const [searchTest, setSearchTest] = useQueryState('search', '');
+  const [searchTest, setSearchTest] = useQueryState('search', 'SingleValue');
 
   useEffect(() => {
     // Single use - Loads events data on page load / authentication

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -16,17 +16,18 @@ import {
   Switch,
   TextField,
 } from '@material-ui/core';
-import useQueryState from 'hooks/useQueryState';
+import useQueryState, { types } from 'hooks/useQueryState';
 
 const Events = (props) => {
   const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
   const [allEvents, setAllEvents] = useState([]);
   const [events, setEvents] = useState([]);
   const [filteredEvents, setFilteredEvents] = useState([]);
-  const [includePast, setIncludePast] = useQueryState('past', 'Boolean');
+  //TODO: useQueryState('search', types.SingleValue);- needs debouncing
+  const [search, setSearch] = useState('');
+  const [includePast, setIncludePast] = useQueryState('past', types.Boolean);
+  const [filters, setFilters] = useQueryState('filters', types.Array);
   const [loading, setLoading] = useState(true);
-  const [filters, setFilters] = useQueryState('filters', 'Array');
   const futureEvents = useMemo(() => gordonEvent.getFutureEvents(allEvents), [allEvents]);
 
   useEffect(() => {

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -30,7 +30,7 @@ const Events = (props) => {
 
   useEffect(() => {
     const loadEvents = async () => {
-      setLoading(true);
+      // setLoading(true);
       let allEvents;
       if (props.authentication) {
         allEvents = await gordonEvent.getAllEvents();

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -25,7 +25,7 @@ const Events = (props) => {
   const [filteredEvents, setFilteredEvents] = useState([]);
   //TODO: useQueryState('search', types.SingleValue); - needs debouncing
   const [search, setSearch] = useState('');
-  const [includePast, setIncludePast] = useQueryState('past', types.Boolean);
+  const [includePast, setIncludePast] = useQueryState('past', types.Boolean, true);
   const [filters, setFilters] = useQueryState('filters', types.Array);
   const [loading, setLoading] = useState(true);
   const futureEvents = useMemo(() => gordonEvent.getFutureEvents(allEvents), [allEvents]);

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -52,10 +52,7 @@ const Events = (props) => {
 
   // Apply filters to the events data
   useEffect(() => {
-    const loadFilteredEvents = async() => {
-      setFilteredEvents(gordonEvent.getFilteredEvents(events, filters, search));
-    }
-    loadFilteredEvents();
+    setFilteredEvents(gordonEvent.getFilteredEvents(events, filters, search));
   }, [events, filters, search]);
 
   useEffect(() => {

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -23,7 +23,7 @@ const Events = (props) => {
   const [allEvents, setAllEvents] = useState([]);
   const [events, setEvents] = useState([]);
   const [filteredEvents, setFilteredEvents] = useState([]);
-  //TODO: useQueryState('search', types.SingleValue);- needs debouncing
+  //TODO: useQueryState('search', types.SingleValue); - needs debouncing
   const [search, setSearch] = useState('');
   const [includePast, setIncludePast] = useQueryState('past', types.Boolean);
   const [filters, setFilters] = useQueryState('filters', types.Array);
@@ -31,8 +31,7 @@ const Events = (props) => {
   const futureEvents = useMemo(() => gordonEvent.getFutureEvents(allEvents), [allEvents]);
 
   useEffect(() => {
-    // Single use - Loads events data on page load / authentication
-    const loadEventsPage = async () => {
+    const loadAllEventsData = async () => {
       setLoading(true);
       let allEvents;
       if (props.authentication) {
@@ -43,15 +42,13 @@ const Events = (props) => {
       setAllEvents(allEvents);
       setLoading(false);
     };
-    loadEventsPage();
+    loadAllEventsData();
   }, [props.authentication]);
 
-  // When the actual events data changes update the events
   useEffect(() => {
     setEvents(includePast ? allEvents : futureEvents);
   }, [includePast, allEvents, futureEvents]);
 
-  // Apply filters to the events data
   useEffect(() => {
     setFilteredEvents(gordonEvent.getFilteredEvents(events, filters, search));
   }, [events, filters, search]);

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -73,7 +73,7 @@ const Events = (props) => {
 
   if (loading === true) {
     content = <GordonLoader />;
-  } else if (filteredEvents.length > 0) {
+  } else if (events.length > 0) {
     content = <EventList events={filteredEvents} />;
   }
 
@@ -87,7 +87,7 @@ const Events = (props) => {
             id="event-checkboxes"
             multiple
             value={filters}
-            onChange={(event) => {setFilters(event.target.value)}}
+            onChange={(event) => setFilters(event.target.value)}
             renderValue={(selected) => (
               <div className="filter-chips">
                 {selected.map((value) => (
@@ -111,7 +111,7 @@ const Events = (props) => {
       </div>
     </Collapse>
   );
-  
+
   return (
     <Grid container justify="center" alignContent="flex-start">
       {/* Search Bar and Filters */}


### PR DESCRIPTION
Extracts logic of events URL updating into a separate UseQueryState hook that can be used for other instances where we want to sync state with URL query parameters. All the information needed for this PR is documented within the code itself.

Also fixes some layout issues with events that you can see in `EventsList/index.js`

Minor issue that we can fix if need be: currently when you remove the last filter it collapses the whole menu area, rather than waiting for you to click 'clear filters'. I'm not too concerned about this mostly since 'Clear Filters' acting as a show/hide toggle isn't really intuitive anyways.

Other issue: setting "include past" takes forever to render. Pagination would be nice goal, though even without it this was faster before, so this should probably be fixed (or at least understood why this is slower) before merging.