### PR TITLE
Apart app db updates

### DIFF
--- a/src/views/ApartmentApp/components/StudentApplication/components/HallChoiceList/components/HallChoiceListItem/index.js
+++ b/src/views/ApartmentApp/components/StudentApplication/components/HallChoiceList/components/HallChoiceListItem/index.js
@@ -44,14 +44,14 @@ const HallChoiceListItem = ({
 }) => {
   const [isHallNameValid, setIsHallNameValid] = useState(false);
 
-  useEffect(
-    () => setIsHallNameValid(hallName === '' || halls.some((hall) => hall.Name === hallName)),
-    [hallName, halls],
-  );
+  useEffect(() => setIsHallNameValid(hallName === '' || halls.some((hall) => hall === hallName)), [
+    hallName,
+    halls,
+  ]);
 
   const hallOptions = halls.map((hall) => (
-    <MenuItem value={hall.Name} key={hall.Name}>
-      {hall.Name}
+    <MenuItem value={hall} key={hall}>
+      {hall}
     </MenuItem>
   ));
 

--- a/src/views/ApartmentApp/components/StudentApplication/index.js
+++ b/src/views/ApartmentApp/components/StudentApplication/index.js
@@ -32,6 +32,7 @@ const DIALOG_PROPS = {
     action: 'default',
     title: 'How did you get here?',
     text: 'This text should not be displayed.',
+    open: false,
   },
   changeEditor: {
     action: 'changeEditor',


### PR DESCRIPTION
The database tables for apartment applications were renamed for consistency and clarity, e.g. from `AA_Admins` to `Housing_Admins`. This has affected the backend just slightly, and touches the front end in only one case. It appears that when fetching the list of apartment halls from the database, the API was returning an array of objects with the singular property `Name`, a string representing the name of the that hall. The API now returns  and an array of strings, each string being the name of the hall it represents. This only matters in so far as previously the frontend had to 'unwrap' the `Name` property from the hall objects - even though that was the only data a hall object contained. Now, accessing and iterating over the halls is easier because they are simply the names themselves.

I also fixed an unrelated MUI bug where the `open` prop of the `StudentApplication` dialog had no default value and was therefore `undefined`. MUI requires a not `undefined` value for this prop, so I have set the default to `false` since the dialog only opens in response to user actions.