### PR TITLE
Disabled Legend on Days Remaining for Staff View

### DIFF
--- a/src/views/Home/components/DaysLeft/index.js
+++ b/src/views/Home/components/DaysLeft/index.js
@@ -55,6 +55,9 @@ export default class DaysLeft extends Component {
         datasets: [{ data: [pastDays, daysleft], backgroundColor: [gordonColors.primary.blue] }],
         labels: ['Days Finished', 'Days Remaining'],
       };
+      const options = {
+        legend: false,
+      };
       content = (
         <div>
           <Grid
@@ -69,7 +72,7 @@ export default class DaysLeft extends Component {
               </Typography>
             </Grid>
           </Grid>
-          <Doughnut data={data} height={175} />
+          <Doughnut data={data} height={175} options={options}/>
           <div
             style={{
               marginTop: '1rem',


### PR DESCRIPTION
I managed to disable the legend on the staff view of the days remaining doughnut.

Added an "options" var to the Daysleft index.js with legend set to false, which disables the legend but keeps the hover text.

Resolved #1149