### PR TITLE
Fixed notification when people change the mobile phone number privacy option

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -95,7 +95,7 @@ const PersonalInfoList = ({
       setIsMobilePhonePrivate(!isMobilePhonePrivate);
 
       createSnackbar(
-        isMobilePhonePrivate ? 'Mobile Phone Hidden' : 'Mobile Phone Visible',
+        isMobilePhonePrivate ? 'Mobile Phone Visible' : 'Mobile Phone Hidden',
         'success',
       );
     } catch {


### PR DESCRIPTION
Realized we have a small bug when people change the mobile phone number privacy option...

When people change their privacy option, the website shows us a wrong notification message.
![Screen Shot 2021-06-07 at 6 11 59 PM](https://user-images.githubusercontent.com/70544403/121094674-ff8ad600-c7bc-11eb-81e3-10abf4df8aeb.png)
The private option --> "Mobile Phone Visible" (Wrong!!)
![Screen Shot 2021-06-07 at 6 12 09 PM](https://user-images.githubusercontent.com/70544403/121094691-01ed3000-c7bd-11eb-9ba0-baa3803df1d4.png)
The public option --> "Mobile Phone Hidden" (Wrong!!)

I just fixed the bug... Now, it should be all set.
![Screen Shot 2021-06-07 at 6 16 37 PM](https://user-images.githubusercontent.com/70544403/121094924-5f817c80-c7bd-11eb-8ea8-11b443c8efe2.png)
![Screen Shot 2021-06-07 at 6 16 44 PM](https://user-images.githubusercontent.com/70544403/121094930-61e3d680-c7bd-11eb-82c1-26c327be415b.png)

