### PR TITLE
Add notes on public profile page

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -252,6 +252,39 @@ const PersonalInfoList = ({
       />
     ) : null;
 
+  const note = isFacStaff ? (
+    <Typography align="left" className="note">
+      NOTE:
+      <ul>
+        <li>
+          To prevent your picture from displaying click{' '}
+          <a href="https://360.gordon.edu/myprofile"> here</a>.
+        </li>
+        <li>
+          To update your data contact <a href="mailto: hr@gordon.edu">Human Resources</a> (x4828).
+        </li>
+      </ul>
+    </Typography>
+  ) : isStudent ? (
+    <Typography align="left" className="note">
+      NOTE:
+      <ul>
+        <li>
+          To prevent your picture or your cell phone number from displaying, click{' '}
+          <a href="https://360.gordon.edu/myprofile">here</a>.
+        </li>
+        <li>
+          To update your On Campus Address, contact <a href="mailto: housing@gordon.edu">housing</a>
+          (x4263).
+        </li>
+        <li>
+          For all other changes or to partially/fully prevent your data from displaying, contact the{' '}
+          <a href="mailto: registrar@gordon.edu">Registrar's Office</a> (x4242).
+        </li>
+      </ul>
+    </Typography>
+  ) : null;
+
   const disclaimer =
     !myProf &&
     (isHomePhonePrivate ||
@@ -285,6 +318,7 @@ const PersonalInfoList = ({
             {studentID}
             {home}
             {spouse}
+            {note}
             {disclaimer}
           </List>
         </CardContent>

--- a/src/components/Profile/components/PersonalInfoList/index.scss
+++ b/src/components/Profile/components/PersonalInfoList/index.scss
@@ -7,6 +7,14 @@
     padding-left: 1rem;
   }
 
+  .note {
+    color: $neutral-black-opacity55;
+    background-color: $neutral-light-gray;
+    padding: 0.3rem 1rem;
+    margin-top: 1rem;
+    border-radius: 5px;
+  }
+
   .disclaimer {
     color: $secondary-red;
     background-color: $neutral-light-gray;


### PR DESCRIPTION
This is part of issue #897 .

Until #1172 resolve, we can use this note to let people know how to change their information.

This is the note from go.gordon.edu:

![Screen Shot 2021-06-08 at 3 08 09 PM](https://user-images.githubusercontent.com/70544403/121245445-09b8dd00-c86e-11eb-8162-34f6306aa7eb.png)
![Screen Shot 2021-06-08 at 3 09 48 PM](https://user-images.githubusercontent.com/70544403/121245460-0e7d9100-c86e-11eb-8f71-4a9dbb292cb6.png)

And here's what I add to 360.gordon.edu:

![Screen Shot 2021-06-08 at 3 14 14 PM](https://user-images.githubusercontent.com/70544403/121245515-1e957080-c86e-11eb-9c52-d3bfc73b12f8.png)
![Screen Shot 2021-06-08 at 3 14 46 PM](https://user-images.githubusercontent.com/70544403/121245528-20f7ca80-c86e-11eb-98ff-d39ea490cc93.png)
