### PR TITLE
S21 page title

### DIFF
--- a/src/components/Header/components/NavAvatarRightCorner/index.js
+++ b/src/components/Header/components/NavAvatarRightCorner/index.js
@@ -2,7 +2,6 @@ import { Avatar, IconButton, Tooltip } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { gordonColors } from 'theme';
 import React, { useState, useEffect } from 'react';
-import './nav-avatar-right-corner.css';
 import user from 'services/user';
 
 /**

--- a/src/components/Header/components/NavAvatarRightCorner/nav-avatar-right-corner.scss
+++ b/src/components/Header/components/NavAvatarRightCorner/nav-avatar-right-corner.scss
@@ -1,7 +1,0 @@
-@import '../../../../vars';
-
-@media (max-width: $break-md) {
-  .right-side-container {
-    display: none !important;
-  }
-}

--- a/src/components/Header/components/PeopleSearch/people-search.scss
+++ b/src/components/Header/components/PeopleSearch/people-search.scss
@@ -129,26 +129,6 @@
 
   @media (min-width: $break-md) {
     .text-field {
-      width: 11.5rem;
-    }
-    .people-search-root {
-      align-self: flex-end;
-      width: 13rem;
-      &:focus-within {
-        width: 15rem;
-      }
-    }
-    .people-search-suggestion,
-    .people-search-suggestion-selected {
-      width: 8.5rem;
-    }
-    .people-search-dropdown {
-      right: auto;
-    }
-  }
-
-  @media (min-width: 1000px) {
-    .text-field {
       width: 14rem;
     }
     .people-search-root {
@@ -161,6 +141,9 @@
     .people-search-suggestion,
     .people-search-suggestion-selected {
       width: 11.15rem;
+    }
+    .people-search-dropdown {
+      right: auto;
     }
   }
 

--- a/src/components/Header/components/PeopleSearch/people-search.scss
+++ b/src/components/Header/components/PeopleSearch/people-search.scss
@@ -90,7 +90,6 @@
   }
 
   @media (min-width: $break-xs) {
-    //margin-left: -10rem;
     .people-search-root {
       width: 8rem;
       &:focus-within {
@@ -100,7 +99,6 @@
   }
 
   @media (min-width: 400px) {
-    //margin-left: -8rem;
     .people-search-root {
       width: 10rem;
       &:focus-within {
@@ -117,20 +115,6 @@
     .people-search-dropdown {
       right: 28px;
     }
-  }
-
-  @media (min-width: $break-sm) {
-    width: auto;
-    //margin-left: -18px;
-    .people-search-root {
-      width: 12rem;
-      &:focus-within {
-        width: 14.5rem;
-      }
-    }
-  }
-
-  @media (min-width: $break-sm) {
     .text-field {
       width: 14rem;
     }
@@ -154,12 +138,6 @@
         width: 15rem;
       }
     }
-    .people-search-suggestion,
-    .people-search-suggestion-selected {
-      width: 12.25rem;
-    }
-  }
-  @media (min-width: 960px) {
     .people-search-suggestion,
     .people-search-suggestion-selected {
       width: 8.5rem;
@@ -191,7 +169,6 @@
     color: inherit;
     background: $primary-blue;
     transition: box-shadow 0.3s, width 0.3s;
-    //margin-right: 0.75rem;
     border-radius: 4px;
     border: 1px solid $neutral-white;
     padding: 2px 10px;

--- a/src/components/Header/header.scss
+++ b/src/components/Header/header.scss
@@ -67,9 +67,8 @@ $drawer-width: 240px;
     }
 
     .center-container {
-      flex: 8;
+      flex: 4;
       justify-content: center;
-      // float: none;
       display: flex;
       visibility: visible;
     }

--- a/src/components/Header/header.scss
+++ b/src/components/Header/header.scss
@@ -43,17 +43,13 @@ $drawer-width: 240px;
     margin-left: 16px;
     padding: 0;
     align-items: center;
-    display: flex;
+    display: none;
   }
 
   @media (min-width: $break-sm) {
     .app-bar {
       background-image: url('./gc_seal_top_64.png');
       height: $header-height-sm;
-    }
-    .right-side-container {
-      width: auto;
-      margin-left: 24px;
     }
   }
 
@@ -67,7 +63,7 @@ $drawer-width: 240px;
     }
 
     .center-container {
-      flex: 4;
+      flex: 3;
       justify-content: center;
       display: flex;
       visibility: visible;
@@ -76,9 +72,16 @@ $drawer-width: 240px;
     .tab {
       min-width: 80px;
     }
+    .right-side-container {
+      display: flex;
+      margin-left: 24px;
+    }
   }
 
   @media (min-width: $break-lg) {
+    .center-container {
+      flex: 7;
+    }
     .tab {
       min-width: 160px;
     }

--- a/src/components/Header/header.scss
+++ b/src/components/Header/header.scss
@@ -11,6 +11,8 @@ $drawer-width: 240px;
   .app-bar {
     position: absolute;
     background-repeat: no-repeat;
+    background-image: url('./gc_seal_top_56.png');
+    height: $header-height-xs;
   }
 
   .tab {
@@ -32,21 +34,16 @@ $drawer-width: 240px;
     margin-left: -12px;
   }
 
-  @media (min-width: 0px) {
-    .app-bar {
-      background-image: url('./gc_seal_top_56.png');
-      height: $header-height-xs;
-    }
+  .center-container {
+    visibility: hidden;
+    width: 0;
+  }
 
-    .center-container {
-      visibility: hidden;
-      width: 0;
-    }
-
-    .right-side-container {
-      margin-left: 16px;
-      padding: 0;
-    }
+  .right-side-container {
+    margin-left: 16px;
+    padding: 0;
+    align-items: center;
+    display: flex;
   }
 
   @media (min-width: $break-sm) {
@@ -97,11 +94,6 @@ $drawer-width: 240px;
     flex: 1;
     margin-right: 10px;
     font-weight: bold;
-  }
-
-  .right-side-container {
-    align-items: center;
-    display: flex;
   }
 
   .menu-button-icon {

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -221,14 +221,12 @@ const GordonHeader = ({ authentication, onDrawerToggle, onSignOut }) => {
           </div>
 
           {authentication ? <GordonPeopleSearch authentication={authentication} /> : loginButton}
-
           <GordonNavAvatarRightCorner
             onSignOut={onSignOut}
             authentication={authentication}
             onClick={handleOpenMenu}
             menuOpened={isMenuOpen}
           />
-
           <GordonNavButtonsRightCorner
             open={isMenuOpen}
             openDialogBox={setDialog}
@@ -237,7 +235,6 @@ const GordonHeader = ({ authentication, onDrawerToggle, onSignOut }) => {
             anchorEl={anchorElement}
             onClose={handleCloseMenu}
           />
-
           {createDialogBox()}
         </Toolbar>
       </AppBar>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -221,12 +221,14 @@ const GordonHeader = ({ authentication, onDrawerToggle, onSignOut }) => {
           </div>
 
           {authentication ? <GordonPeopleSearch authentication={authentication} /> : loginButton}
+
           <GordonNavAvatarRightCorner
             onSignOut={onSignOut}
             authentication={authentication}
             onClick={handleOpenMenu}
             menuOpened={isMenuOpen}
           />
+
           <GordonNavButtonsRightCorner
             open={isMenuOpen}
             openDialogBox={setDialog}
@@ -235,12 +237,14 @@ const GordonHeader = ({ authentication, onDrawerToggle, onSignOut }) => {
             anchorEl={anchorElement}
             onClose={handleCloseMenu}
           />
+
           {createDialogBox()}
         </Toolbar>
       </AppBar>
     </section>
   );
 };
+
 export default GordonHeader;
 
 GordonHeader.propTypes = {

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -241,7 +241,6 @@ const GordonHeader = ({ authentication, onDrawerToggle, onSignOut }) => {
     </section>
   );
 };
-
 export default GordonHeader;
 
 GordonHeader.propTypes = {


### PR DESCRIPTION
Did some redundant clean up in the `people_search.scss file` as well as changing the flex property in the `header.scss file`. 


------
The Page Title Formatting for Long Titles #1131, the padding in the header file has some issue that when I was trying to divide the flex property that was used in 3 groups see image below

![Screen Shot 2021-06-09 at 11 23 17 AM](https://user-images.githubusercontent.com/60272749/121383771-b13d1a80-c915-11eb-8aab-7b340189f080.png)

right now we only the header is only divided into two part:

![Screen Shot 2021-06-09 at 11 33 35 AM](https://user-images.githubusercontent.com/60272749/121385017-c1a1c500-c916-11eb-8234-7b12d798abfd.png)
I could not exactly make it even because of some more issues, My guess is the overall padding of the header. 



This is another issue that was found while working on the page title it is not a major issue but something to consider.