### PR TITLE
S21 Final Update: Advanced People Search Checkboxes

### DIFF
--- a/src/services/goStalk.js
+++ b/src/services/goStalk.js
@@ -8,8 +8,9 @@ import http from './http';
 
 /**
  * Search for (AKA GoStalk) a person/people based on the following queried parameters
+ * @param {Boolean} includeStudent To decide if they want student in their search results or not
+ * @param {Boolean} includeFacStaff To decide if they want faculty and staff in their search results or not
  * @param {Boolean} includeAlumni For non-Students to decide if they want alumni in their search results or not
- * @param {Boolean} onlyAlumni For non-Students to decide it they want only alumni in their search results or not
  * @param {String} firstName First name queried
  * @param {String} lastName Last name queried
  * @param {String} major Major (matches up against 3 majors listed for people)
@@ -25,8 +26,9 @@ import http from './http';
  * @return {Promise.<SearchResult[]>} List of search results that match these queried parameters
  */
 const search = (
+  includeStudent,
+  includeFacStaff,
   includeAlumni,
-  onlyAlumni,
   firstName,
   lastName,
   major,
@@ -123,8 +125,9 @@ const search = (
     // workaround to avoid breaking the backend
     building = building.replace('.', '_');
   }
+
   return http.get(
-    `accounts/advanced-people-search/${includeAlumni}/${onlyAlumni}/${firstName}/${lastName}/${major}/${minor}/${hall}/${classType}/${homeCity}/${state}/${country}/${department}/${building}`,
+    `accounts/advanced-people-search/${includeStudent}/${includeFacStaff}/${includeAlumni}/${firstName}/${lastName}/${major}/${minor}/${hall}/${classType}/${homeCity}/${state}/${country}/${department}/${building}`,
   );
 };
 

--- a/src/services/goStalk.js
+++ b/src/services/goStalk.js
@@ -9,6 +9,7 @@ import http from './http';
 /**
  * Search for (AKA GoStalk) a person/people based on the following queried parameters
  * @param {Boolean} includeAlumni For non-Students to decide if they want alumni in their search results or not
+ * @param {Boolean} onlyAlumni For non-Students to decide it they want only alumni in their search results or not
  * @param {String} firstName First name queried
  * @param {String} lastName Last name queried
  * @param {String} major Major (matches up against 3 majors listed for people)
@@ -25,6 +26,7 @@ import http from './http';
  */
 const search = (
   includeAlumni,
+  onlyAlumni,
   firstName,
   lastName,
   major,
@@ -122,7 +124,7 @@ const search = (
     building = building.replace('.', '_');
   }
   return http.get(
-    `accounts/advanced-people-search/${includeAlumni}/${firstName}/${lastName}/${major}/${minor}/${hall}/${classType}/${homeCity}/${state}/${country}/${department}/${building}`,
+    `accounts/advanced-people-search/${includeAlumni}/${onlyAlumni}/${firstName}/${lastName}/${major}/${minor}/${hall}/${classType}/${homeCity}/${state}/${country}/${department}/${building}`,
   );
 };
 

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -178,6 +178,8 @@ class PeopleSearch extends Component {
         building: '',
       },
 
+      loading: true,
+
       // For April Fools:
       relationshipStatusValue: '',
 
@@ -200,6 +202,7 @@ class PeopleSearch extends Component {
   }
 
   async componentDidMount() {
+    // this.setState({ loading: true });
     if (this.props.authentication) {
       try {
         const profile = await user.getProfileInfo();
@@ -243,6 +246,8 @@ class PeopleSearch extends Component {
         this.loadSearchParamsFromURL();
       }
     }
+
+    this.setState({ loading: false });
   }
 
   async loadSearchParamsFromURL() {
@@ -515,7 +520,7 @@ class PeopleSearch extends Component {
     const networkStatus = JSON.parse(localStorage.getItem('network-status')) || 'online';
 
     if (this.props.authentication) {
-      PeopleSearchCheckbox = (
+      PeopleSearchCheckbox = !this.state.loading ? (
         <Grid item xs={12} align="center">
           <FormLabel component="legend">Type of People:</FormLabel>
           {this.state.personType && !this.state.personType.includes('alum') ? (
@@ -555,6 +560,11 @@ class PeopleSearch extends Component {
               label="Alumni"
             />
           ) : null}
+        </Grid>
+      ) : (
+        <Grid item xs={12} align="center">
+          <FormLabel component="legend">Type of People:</FormLabel>
+          <GordonLoader size={38} />
         </Grid>
       );
 
@@ -1063,7 +1073,7 @@ class PeopleSearch extends Component {
                           );
                         }}
                       >
-                        Clear All
+                        RESET
                       </Button>
                     </Grid>
                     {/* Search Button */}

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -162,6 +162,7 @@ class PeopleSearch extends Component {
       // These values *must* be in the same order as services/goStalk.js search function
       searchValues: {
         includeAlumni: false,
+        onlyAlumni: false,
         firstName: '',
         lastName: '',
         major: '',
@@ -237,6 +238,7 @@ class PeopleSearch extends Component {
     this.setState({
       searchValues: {
         includeAlumni: urlParams.get('includeAlumni') || false,
+        onlyAlumni: urlParams.get('onlyAlumni') || false,
         firstName: urlParams.get('firstName')?.trim() || '',
         lastName: urlParams.get('lastName')?.trim() || '',
         major: urlParams.get('major')?.trim() || '',
@@ -286,6 +288,14 @@ class PeopleSearch extends Component {
       searchValues: {
         ...this.state.searchValues,
         includeAlumni: !this.state.searchValues.includeAlumni,
+      },
+    });
+  }
+  handleChangeOnlyAlumni() {
+    this.setState({
+      searchValues: {
+        ...this.state.searchValues,
+        onlyAlumni: !this.state.searchValues.onlyAlumni,
       },
     });
   }
@@ -404,7 +414,7 @@ class PeopleSearch extends Component {
 
   render() {
     const { classes } = this.props;
-    let includeAlumniCheckbox;
+    let AlumniCheckbox;
 
     const majorOptions = this.state.majors.map((major) => (
       <MenuItem value={major} key={major}>
@@ -476,18 +486,33 @@ class PeopleSearch extends Component {
 
     if (this.props.authentication) {
       if (this.state.personType && !this.state.personType.includes('stu')) {
-        includeAlumniCheckbox = (
+        AlumniCheckbox = (
           <Grid item xs={12} align="center">
             <FormControlLabel
               control={
                 <Checkbox
                   checked={this.state.searchValues.includeAlumni}
+                  {...this.state.searchValues.onlyAlumni}
                   onChange={() => {
                     this.handleChangeIncludeAlumni();
                   }}
                 />
               }
+              disabled={this.state.searchValues.onlyAlumni}
               label="Include Alumni"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={this.state.searchValues.onlyAlumni}
+                  {...this.state.searchValues.includeAlumni}
+                  onChange={() => {
+                    this.handleChangeOnlyAlumni();
+                  }}
+                />
+              }
+              disabled={this.state.searchValues.includeAlumni}
+              label="Only Alumni"
             />
           </Grid>
         );
@@ -657,7 +682,7 @@ class PeopleSearch extends Component {
                     <Grid item xs={12}>
                       {aprilFools}
                     </Grid>
-                    {includeAlumniCheckbox}
+                    {AlumniCheckbox}
                   </Grid>
 
                   <br />
@@ -970,6 +995,7 @@ class PeopleSearch extends Component {
                             {
                               searchValues: {
                                 includeAlumni: false,
+                                onlyAlumni: false,
                                 firstName: '',
                                 lastName: '',
                                 major: '',

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -1034,9 +1034,13 @@ class PeopleSearch extends Component {
                           this.setState(
                             {
                               searchValues: {
-                                includeStudent: this.state.personType.includes('alum') ? false : true,
-                                includeStaff: true,
-                                includeAlumni: this.state.personType.includes('alum') ? true : false,
+                                includeStudent: this.state.personType.includes('alum')
+                                  ? false
+                                  : true,
+                                includeFacStaff: true,
+                                includeAlumni: this.state.personType.includes('alum')
+                                  ? true
+                                  : false,
                                 firstName: '',
                                 lastName: '',
                                 major: '',

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -8,6 +8,7 @@ import {
   CardActions,
   Checkbox,
   Collapse,
+  FormLabel,
   FormControl,
   FormControlLabel,
   Grid,
@@ -161,8 +162,8 @@ class PeopleSearch extends Component {
 
       // These values *must* be in the same order as services/goStalk.js search function
       searchValues: {
-        includeStudent: false,
-        includeFacStaff: false,
+        includeStudent: true,
+        includeFacStaff: true,
         includeAlumni: false,
         firstName: '',
         lastName: '',
@@ -223,10 +224,21 @@ class PeopleSearch extends Component {
           buildings,
           personType,
         });
+
+        if (personType.includes('alum')) {
+          this.setState({
+            searchValues: {
+              ...this.state.searchValues,
+              includeStudent: false,
+              includeAlumni: true,
+            },
+          });
+        }
       } catch (error) {
         // error
       }
 
+      this.updateURL();
       if (window.location.href.includes('?')) {
         this.loadSearchParamsFromURL();
       }
@@ -366,6 +378,7 @@ class PeopleSearch extends Component {
   };
 
   async search() {
+    console.log(this.state.searchValues);
     if (!Object.values(this.state.searchValues).some((x) => x)) {
       // do not search, only search if there are some non-blank non-false values
     } else {
@@ -497,6 +510,7 @@ class PeopleSearch extends Component {
     if (this.props.authentication) {
       PeopleSearchCheckbox = (
         <Grid item xs={12} align="center">
+          <FormLabel component="legend">Type of People:</FormLabel>
           {this.state.personType && !this.state.personType.includes('alum') ? (
             <FormControlLabel
               control={
@@ -1013,8 +1027,8 @@ class PeopleSearch extends Component {
                           this.setState(
                             {
                               searchValues: {
-                                includeStudent: false,
-                                includeStaff: false,
+                                includeStudent: true,
+                                includeStaff: true,
                                 includeAlumni: false,
                                 firstName: '',
                                 lastName: '',

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -161,8 +161,9 @@ class PeopleSearch extends Component {
 
       // These values *must* be in the same order as services/goStalk.js search function
       searchValues: {
+        includeStudent: false,
+        includeFacStaff: false,
         includeAlumni: false,
-        onlyAlumni: false,
         firstName: '',
         lastName: '',
         major: '',
@@ -237,8 +238,9 @@ class PeopleSearch extends Component {
 
     this.setState({
       searchValues: {
+        includeStudent: urlParams.get('includeStudent') || false,
+        includeFacStaff: urlParams.get('includeFacStaff') || false,
         includeAlumni: urlParams.get('includeAlumni') || false,
-        onlyAlumni: urlParams.get('onlyAlumni') || false,
         firstName: urlParams.get('firstName')?.trim() || '',
         lastName: urlParams.get('lastName')?.trim() || '',
         major: urlParams.get('major')?.trim() || '',
@@ -283,19 +285,27 @@ class PeopleSearch extends Component {
       relationshipStatusValue: e.target.value,
     });
   };
+  handleChangeIncludeStudent() {
+    this.setState({
+      searchValues: {
+        ...this.state.searchValues,
+        includeStudent: !this.state.searchValues.includeStudent,
+      },
+    });
+  }
+  handleChangeIncludeFacStaff() {
+    this.setState({
+      searchValues: {
+        ...this.state.searchValues,
+        includeFacStaff: !this.state.searchValues.includeFacStaff,
+      },
+    });
+  }
   handleChangeIncludeAlumni() {
     this.setState({
       searchValues: {
         ...this.state.searchValues,
         includeAlumni: !this.state.searchValues.includeAlumni,
-      },
-    });
-  }
-  handleChangeOnlyAlumni() {
-    this.setState({
-      searchValues: {
-        ...this.state.searchValues,
-        onlyAlumni: !this.state.searchValues.onlyAlumni,
       },
     });
   }
@@ -414,7 +424,7 @@ class PeopleSearch extends Component {
 
   render() {
     const { classes } = this.props;
-    let AlumniCheckbox;
+    let PeopleSearchCheckbox;
 
     const majorOptions = this.state.majors.map((major) => (
       <MenuItem value={major} key={major}>
@@ -485,38 +495,47 @@ class PeopleSearch extends Component {
     const networkStatus = JSON.parse(localStorage.getItem('network-status')) || 'online';
 
     if (this.props.authentication) {
-      if (this.state.personType && !this.state.personType.includes('stu')) {
-        AlumniCheckbox = (
-          <Grid item xs={12} align="center">
+      PeopleSearchCheckbox = (
+        <Grid item xs={12} align="center">
+          {this.state.personType && !this.state.personType.includes('alum') ? (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={this.state.searchValues.includeStudent}
+                  onChange={() => {
+                    this.handleChangeIncludeStudent();
+                  }}
+                />
+              }
+              label="Student"
+            />
+          ) : null}
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={this.state.searchValues.includeFacStaff}
+                onChange={() => {
+                  this.handleChangeIncludeFacStaff();
+                }}
+              />
+            }
+            label="Faculty/Staff"
+          />
+          {this.state.personType && !this.state.personType.includes('stu') ? (
             <FormControlLabel
               control={
                 <Checkbox
                   checked={this.state.searchValues.includeAlumni}
-                  {...this.state.searchValues.onlyAlumni}
                   onChange={() => {
                     this.handleChangeIncludeAlumni();
                   }}
                 />
               }
-              disabled={this.state.searchValues.onlyAlumni}
-              label="Include Alumni"
+              label="Alumni"
             />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={this.state.searchValues.onlyAlumni}
-                  {...this.state.searchValues.includeAlumni}
-                  onChange={() => {
-                    this.handleChangeOnlyAlumni();
-                  }}
-                />
-              }
-              disabled={this.state.searchValues.includeAlumni}
-              label="Only Alumni"
-            />
-          </Grid>
-        );
-      }
+          ) : null}
+        </Grid>
+      );
 
       // April Fools
       let aprilFools = '';
@@ -682,7 +701,7 @@ class PeopleSearch extends Component {
                     <Grid item xs={12}>
                       {aprilFools}
                     </Grid>
-                    {AlumniCheckbox}
+                    {PeopleSearchCheckbox}
                   </Grid>
 
                   <br />
@@ -994,8 +1013,9 @@ class PeopleSearch extends Component {
                           this.setState(
                             {
                               searchValues: {
+                                includeStudent: false,
+                                includeStaff: false,
                                 includeAlumni: false,
-                                onlyAlumni: false,
                                 firstName: '',
                                 lastName: '',
                                 major: '',


### PR DESCRIPTION
I added "Only Alumni Option" on Advanced People Search.
This is the UI part for https://github.com/gordon-cs/gordon-360-api/pull/608.

BEFORE:
<img width="1280" alt="Screen Shot 2021-06-22 at 3 20 59 PM" src="https://user-images.githubusercontent.com/70544403/122986562-9a62e300-d36d-11eb-8b50-ea063fd8f12a.png">
There was only one option, "Include Alumni".

<img width="1280" alt="Screen Shot 2021-06-22 at 3 21 11 PM" src="https://user-images.githubusercontent.com/70544403/122986567-9afb7980-d36d-11eb-9107-d22def936e3e.png">
If the user does not select "Include Alumni" option, current students/faculties/staffs show up (exclude alumni).

<img width="1280" alt="Screen Shot 2021-06-22 at 3 21 25 PM" src="https://user-images.githubusercontent.com/70544403/122986568-9afb7980-d36d-11eb-9b21-44d326c8d027.png">
If the user select "Include Alumni" option, current students/faculties/staffs and alumni show up.

NOW:
<img width="1280" alt="Screen Shot 2021-06-22 at 3 25 20 PM" src="https://user-images.githubusercontent.com/70544403/122987120-3ee52500-d36e-11eb-8425-c1302d6b83d1.png">
There are two options, "Include Alumni" and "Only Alumni".

<img width="1280" alt="Screen Shot 2021-06-22 at 3 25 30 PM" src="https://user-images.githubusercontent.com/70544403/122987193-515f5e80-d36e-11eb-96c9-e946f4a52061.png">
It shows the same result as the second image on BEFORE.

<img width="1280" alt="Screen Shot 2021-06-22 at 3 25 44 PM" src="https://user-images.githubusercontent.com/70544403/122987248-620fd480-d36e-11eb-8565-f83460a394fb.png">

<img width="1280" alt="Screen Shot 2021-06-22 at 3 25 56 PM" src="https://user-images.githubusercontent.com/70544403/122987257-63d99800-d36e-11eb-9641-f292c0b654f9.png">

If the user selects one of two options, the other option turns into disabled.



