### PR TITLE
People Search Larger Images Toggle

### DIFF
--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -124,14 +124,7 @@ export default class PeopleSearchResult extends Component {
                   placeholderColor="#eeeeee"
                 />
               </Grid>
-              <Grid
-                item
-                style={{
-                  // a set width is necessary to keep profile images in line
-                  // while maintaining center alignment
-                  width: '260px',
-                }}
-              >
+              <Grid item xs={6}>
                 <Typography variant="h5">{fullName}</Typography>
                 <Typography variant="body2">{nickname}</Typography>
                 <Typography variant="body2">{personClassJobTitle}</Typography>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -203,7 +203,7 @@ export default class PeopleSearchResult extends Component {
             >
               <Grid item xs={1}>
                 <IMG
-                  className={'people-search-avatar'}
+                  className="people-search-avatar"
                   src={`data:image/jpg;base64,${this.state.avatar}`}
                   alt=""
                   noLazyLoad="true"

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -158,7 +158,7 @@ export default class PeopleSearchResult extends Component {
                 padding: '1rem',
               }}
             >
-              <Grid item>
+              <Grid item xs={6} container justify="flex-end">
                 <IMG
                   className="people-search-avatar-large"
                   src={`data:image/jpg;base64,${this.state.avatar}`}
@@ -167,14 +167,7 @@ export default class PeopleSearchResult extends Component {
                   placeholderColor="#eeeeee"
                 />
               </Grid>
-              <Grid
-                item
-                style={{
-                  // a set width is necessary to keep profile images in line
-                  // while maintaining center alignment
-                  width: '260px',
-                }}
-              >
+              <Grid item xs={6}>
                 <Typography variant="h5">{fullName}</Typography>
                 <Typography variant="body2">{nickname}</Typography>
                 <Typography variant="body2">{personClassJobTitle}</Typography>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -160,7 +160,7 @@ export default class PeopleSearchResult extends Component {
             >
               <Grid item xs={1}>
                 <IMG
-                  className="people-search-avatar"
+                  className={'people-search-avatar'}
                   src={`data:image/jpg;base64,${this.state.avatar}`}
                   alt=""
                   noLazyLoad="true"

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -143,6 +143,49 @@ export default class PeopleSearchResult extends Component {
           <Divider />
         </>
       );
+    } else if (size === 'largeImages') {
+      /*** Enlarged Images ***/
+      return (
+        <>
+          <Divider />
+          <Link className="gc360-link" to={`profile/${Person.AD_Username}`}>
+            <Grid
+              container
+              alignItems="center"
+              justify="center"
+              spacing={2}
+              style={{
+                padding: '1rem',
+              }}
+            >
+              <Grid item>
+                <IMG
+                  className="people-search-avatar-large"
+                  src={`data:image/jpg;base64,${this.state.avatar}`}
+                  alt=""
+                  noLazyLoad="true"
+                  placeholderColor="#eeeeee"
+                />
+              </Grid>
+              <Grid
+                item
+                style={{
+                  // a set width is necessary to keep profile images in line
+                  // while maintaining center alignment
+                  width: '260px',
+                }}
+              >
+                <Typography variant="h5">{fullName}</Typography>
+                <Typography variant="body2">{nickname}</Typography>
+                <Typography variant="body2">{personClassJobTitle}</Typography>
+                <Typography variant="body2">{Person.Email}</Typography>
+                <Typography variant="body2">{personMailLocation}</Typography>
+              </Grid>
+            </Grid>
+          </Link>
+          <Divider />
+        </>
+      );
     } else {
       /*** Full Size - Multiple Columns (Desktop View) ***/
       return (

--- a/src/views/PeopleSearch/components/PeopleSearchResult/peopleSearchResult.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/peopleSearchResult.scss
@@ -2,14 +2,14 @@
 
 .people-search-avatar-mobile {
   border-radius: 0.5rem;
-  height: 70px;
-  width: 70px;
+  height: 90px;
+  width: 90px;
 }
 
 .people-search-avatar-large {
   border-radius: 0.5rem;
-  height: 250px;
-  width: 250px;
+  height: 200px;
+  width: 200px;
 }
 
 .people-search-avatar {

--- a/src/views/PeopleSearch/components/PeopleSearchResult/peopleSearchResult.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/peopleSearchResult.scss
@@ -2,8 +2,8 @@
 
 .people-search-avatar-mobile {
   border-radius: 0.5rem;
-  height: 70px;
-  width: 70px;
+  height: 250px;
+  width: 250px;
 }
 
 .people-search-avatar {

--- a/src/views/PeopleSearch/components/PeopleSearchResult/peopleSearchResult.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/peopleSearchResult.scss
@@ -2,6 +2,12 @@
 
 .people-search-avatar-mobile {
   border-radius: 0.5rem;
+  height: 70px;
+  width: 70px;
+}
+
+.people-search-avatar-large {
+  border-radius: 0.5rem;
   height: 250px;
   width: 250px;
 }

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -539,7 +539,7 @@ class PeopleSearch extends Component {
     if (this.props.authentication) {
       PeopleSearchCheckbox = !this.state.loading ? (
         <Grid item xs={12} align="center">
-          <FormLabel component="legend">Type of People:</FormLabel>
+          <FormLabel component="legend">Include:</FormLabel>
           {this.state.personType && !this.state.personType.includes('alum') ? (
             <FormControlLabel
               control={
@@ -598,8 +598,8 @@ class PeopleSearch extends Component {
         </Grid>
       ) : (
         <Grid item xs={12} align="center">
-          <FormLabel component="legend">Type of People:</FormLabel>
-          <GordonLoader size={38} />
+          <FormLabel component="legend">Include:</FormLabel>
+          <GordonLoader size={79} />
         </Grid>
       );
 
@@ -1103,6 +1103,7 @@ class PeopleSearch extends Component {
                               offDepExpanded: false,
                               header: '',
                               peopleSearchResults: null,
+                              displayLargeImage: false,
                             },
                             () => this.updateURL(),
                           );

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -118,7 +118,7 @@ const peopleSearchHeaderDesktop = (
         <Typography variant="body2" style={styles.headerStyle}>
           @GORDON.EDU
           <br />
-          MAIL LOCATION
+          MAILBOX #
         </Typography>
       </Grid>
     </Grid>
@@ -748,7 +748,7 @@ class PeopleSearch extends Component {
                         />
                         <Grid item xs>
                           <FormControl fullWidth>
-                            <InputLabel>Hall</InputLabel>
+                            <InputLabel>Residence Hall</InputLabel>
                             <Select
                               value={this.state.searchValues.hall}
                               onChange={this.handleHallInputChange}

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -577,22 +577,24 @@ class PeopleSearch extends Component {
               label="Alumni"
             />
           ) : null}
-          {<Media query="(min-width: 960px)" /> ? (
-            <Grid item xs={12} align="center">
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={this.state.displayLargeImage}
-                    onChange={() => {
-                      this.handleChangeDisplayLargeImages();
-                    }}
-                  />
-                }
-                label="Display Large Images"
-              />
-            </Grid>
-          ) : null}
-          );
+          <Media
+            query="(min-width: 960px)"
+            render={() => (
+              <Grid item xs={12} align="center">
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={this.state.displayLargeImage}
+                      onChange={() => {
+                        this.handleChangeDisplayLargeImages();
+                      }}
+                    />
+                  }
+                  label="Display Large Images"
+                />
+              </Grid>
+            )}
+          />
         </Grid>
       ) : (
         <Grid item xs={12} align="center">

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -92,7 +92,7 @@ const noResultsCard = (
 const peopleSearchHeader = (
   <Media query="(min-width: 960px)">
     {(matches) =>
-      matches ? (
+      matches /*&& !displayLargeImage*/ ? (
         <div style={styles.headerStyle}>
           <Grid container direction="row" alignItems="center">
             <Grid item xs={1} />
@@ -177,6 +177,8 @@ class PeopleSearch extends Component {
 
       // For April Fools:
       relationshipStatusValue: '',
+
+      displayLargeImage: false,
 
       peopleSearchResults: null,
       header: '',
@@ -289,6 +291,14 @@ class PeopleSearch extends Component {
       },
     });
   }
+
+  handleChangeDisplayLargeImages() {
+    this.setState({
+      ...this.state,
+      displayLargeImage: !this.state.displayLargeImage,
+    });
+  }
+
   handleFirstNameInputChange = (e) => {
     this.setState({
       searchValues: { ...this.state.searchValues, firstName: e.target.value.trim() },
@@ -379,7 +389,7 @@ class PeopleSearch extends Component {
                   <PeopleSearchResult
                     key={person.AD_Username}
                     Person={person}
-                    size={matches ? 'full' : 'single'}
+                    size={matches /*&& !displayLargeImage*/ ? 'full' : 'single'}
                   />
                 ))
               }
@@ -412,6 +422,7 @@ class PeopleSearch extends Component {
   render() {
     const { classes } = this.props;
     let includeAlumniCheckbox;
+    let displayLargeImageCheckbox;
 
     const majorOptions = this.state.majors.map((major) => (
       <MenuItem value={major} key={major}>
@@ -499,6 +510,21 @@ class PeopleSearch extends Component {
           </Grid>
         );
       }
+      displayLargeImageCheckbox = (
+        <Grid item xs={12} align="center">
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={this.state.displayLargeImage}
+                onChange={() => {
+                  this.handleChangeDisplayLargeImages();
+                }}
+              />
+            }
+            label="Display Large Images"
+          />
+        </Grid>
+      );
 
       // April Fools
       let aprilFools = '';
@@ -665,6 +691,7 @@ class PeopleSearch extends Component {
                       {aprilFools}
                     </Grid>
                     {includeAlumniCheckbox}
+                    {displayLargeImageCheckbox}
                   </Grid>
 
                   <br />

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -89,55 +89,51 @@ const noResultsCard = (
   </Grid>
 );
 
-const peopleSearchHeader = (
-  <Media query="(min-width: 960px)">
-    {(matches) =>
-      matches /*&& !displayLargeImage*/ ? (
-        <div style={styles.headerStyle}>
-          <Grid container direction="row" alignItems="center">
-            <Grid item xs={1} />
-            <Grid item xs={2}>
-              <Typography variant="body2" style={styles.headerStyle}>
-                FIRST NAME
-              </Typography>
-            </Grid>
-            <Grid item xs={2}>
-              <Typography variant="body2" style={styles.headerStyle}>
-                LAST NAME
-              </Typography>
-            </Grid>
-            <Grid item xs={2}>
-              <Typography variant="body2" style={styles.headerStyle} noWrap>
-                DESCRIPTION
-              </Typography>
-            </Grid>
-            <Grid item xs={2}>
-              <Typography variant="body2" style={styles.headerStyle}>
-                CLASS/JOB TITLE
-              </Typography>
-            </Grid>
-            <Grid item xs={2}>
-              <Typography variant="body2" style={styles.headerStyle}>
-                @GORDON.EDU
-                <br />
-                MAIL LOCATION
-              </Typography>
-            </Grid>
-          </Grid>
-        </div>
-      ) : (
-        <div style={styles.headerStyle}>
-          <Grid container direction="row" justify="center">
-            <Grid item>
-              <Typography variant="body2" style={styles.headerStyle}>
-                RESULTS
-              </Typography>
-            </Grid>
-          </Grid>
-        </div>
-      )
-    }
-  </Media>
+const peopleSearchHeaderDesktop = (
+  <div style={styles.headerStyle}>
+    <Grid container direction="row" alignItems="center">
+      <Grid item xs={1} />
+      <Grid item xs={2}>
+        <Typography variant="body2" style={styles.headerStyle}>
+          FIRST NAME
+        </Typography>
+      </Grid>
+      <Grid item xs={2}>
+        <Typography variant="body2" style={styles.headerStyle}>
+          LAST NAME
+        </Typography>
+      </Grid>
+      <Grid item xs={2}>
+        <Typography variant="body2" style={styles.headerStyle} noWrap>
+          DESCRIPTION
+        </Typography>
+      </Grid>
+      <Grid item xs={2}>
+        <Typography variant="body2" style={styles.headerStyle}>
+          CLASS/JOB TITLE
+        </Typography>
+      </Grid>
+      <Grid item xs={2}>
+        <Typography variant="body2" style={styles.headerStyle}>
+          @GORDON.EDU
+          <br />
+          MAIL LOCATION
+        </Typography>
+      </Grid>
+    </Grid>
+  </div>
+);
+
+const peopleSearchHeaderMobile = (
+  <div style={styles.headerStyle}>
+    <Grid container direction="row" justify="center">
+      <Grid item>
+        <Typography variant="body2" style={styles.headerStyle}>
+          RESULTS
+        </Typography>
+      </Grid>
+    </Grid>
+  </div>
 );
 
 class PeopleSearch extends Component {
@@ -283,6 +279,7 @@ class PeopleSearch extends Component {
       relationshipStatusValue: e.target.value,
     });
   };
+
   handleChangeIncludeAlumni() {
     this.setState({
       searchValues: {
@@ -297,6 +294,7 @@ class PeopleSearch extends Component {
       ...this.state,
       displayLargeImage: !this.state.displayLargeImage,
     });
+    this.search();
   }
 
   handleFirstNameInputChange = (e) => {
@@ -389,13 +387,23 @@ class PeopleSearch extends Component {
                   <PeopleSearchResult
                     key={person.AD_Username}
                     Person={person}
-                    size={matches /*&& !displayLargeImage*/ ? 'full' : 'single'}
+                    size={
+                      !matches ? 'single' : this.state.displayLargeImage ? 'largeImages' : 'full'
+                    }
                   />
                 ))
               }
             </Media>
           ),
-          header: peopleSearchHeader,
+          header: (
+            <Media query="(min-width: 960px)">
+              {(matches) =>
+                matches && !this.state.displayLargeImage
+                  ? peopleSearchHeaderDesktop
+                  : peopleSearchHeaderMobile
+              }
+            </Media>
+          ),
         });
       }
     }
@@ -690,8 +698,10 @@ class PeopleSearch extends Component {
                     <Grid item xs={12}>
                       {aprilFools}
                     </Grid>
-                    {includeAlumniCheckbox}
-                    {displayLargeImageCheckbox}
+                    <Grid item xs={12}>
+                      {includeAlumniCheckbox}
+                      <Media query="(min-width: 960px)" render={() => displayLargeImageCheckbox} />
+                    </Grid>
                   </Grid>
 
                   <br />


### PR DESCRIPTION
Added a checkbox for people search on desktop that enables larger avatar previews for the results list. This should close issue #1212.

before 
<img width="922" alt="Screen Shot 2021-06-25 at 4 36 58 PM" src="https://user-images.githubusercontent.com/60272749/123482724-a3ed8480-d5d3-11eb-8391-5afef2607684.png">



After 
![image](https://user-images.githubusercontent.com/60272749/123481392-a64edf00-d5d1-11eb-9082-20aa57c3b84d.png)
