### PR TITLE
Make the encrypted ID invisible

### DIFF
--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -52,7 +52,7 @@ export default class PeopleSearchResult extends Component {
     fullName = Person.FirstName + ' ' + Person.LastName;
 
     // set nicknames up
-    if (Person.FirstName !== Person.NickName) {
+    if (Person.NickName && Person.FirstName !== Person.NickName) {
       nickname = '(' + Person.NickName + ')';
     }
     // set classes up
@@ -198,12 +198,6 @@ export default class PeopleSearchResult extends Component {
               </Grid>
               <Grid item xs={2}>
                 <Typography>{Person.LastName}</Typography>
-              </Grid>
-              <Grid item xs={2}>
-                <Typography>{Person.Type}</Typography>
-              </Grid>
-              <Grid item xs={2}>
-                <Typography>{personClassJobTitle}</Typography>
               </Grid>
               <Grid item xs={2}>
                 <Typography>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -52,7 +52,7 @@ export default class PeopleSearchResult extends Component {
     fullName = Person.FirstName + ' ' + Person.LastName;
 
     // set nicknames up
-    if (Person.NickName && Person.FirstName !== Person.NickName) {
+    if (Person.FirstName !== Person.NickName) {
       nickname = '(' + Person.NickName + ')';
     }
     // set classes up
@@ -206,7 +206,9 @@ export default class PeopleSearchResult extends Component {
                 <Typography>{personClassJobTitle}</Typography>
               </Grid>
               <Grid item xs={2}>
-                <Typography>{Person.AD_Username}</Typography>
+                <Typography>
+                  {Person.AD_Username.includes('.') ? Person.AD_Username : null}
+                </Typography>
                 <Typography>{personMailLocation}</Typography>
               </Grid>
             </Grid>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -200,6 +200,12 @@ export default class PeopleSearchResult extends Component {
                 <Typography>{Person.LastName}</Typography>
               </Grid>
               <Grid item xs={2}>
+                <Typography>{Person.Type}</Typography>
+              </Grid>
+              <Grid item xs={2}>
+                <Typography>{personClassJobTitle}</Typography>
+              </Grid>
+              <Grid item xs={2}>
                 <Typography>
                   {Person.AD_Username.includes('.') ? Person.AD_Username : null}
                 </Typography>


### PR DESCRIPTION
This PR makes the encrypted ID invisible.

Example:
![image](https://user-images.githubusercontent.com/78691207/124282453-d68a0680-db18-11eb-8b42-db16d6c82b04.png)
