### PR TITLE
RELEASE: Restore timesheets, add Update Phone dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20392,6 +20392,14 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-text-mask": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/react-text-mask/-/react-text-mask-5.4.3.tgz",
+      "integrity": "sha1-mR77QpnjDC5sLEbRP2FxaUY+DS0=",
+      "requires": {
+        "prop-types": "^15.5.6"
+      }
+    },
     "react-timeago": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/react-timeago/-/react-timeago-6.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-responsive-carousel": "^3.2.18",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
+    "react-text-mask": "^5.4.3",
     "react-timeago": "^6.2.0",
     "react-to-print": "^2.12.6",
     "typescript": "^4.3.2",

--- a/src/components/Profile/components/PersonalInfoList/components/UpdatePhoneDialog/index.js
+++ b/src/components/Profile/components/PersonalInfoList/components/UpdatePhoneDialog/index.js
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import MaskedInput from 'react-text-mask';
+import EditIcon from '@material-ui/icons/Edit';
+import {
+  IconButton,
+  FormControl,
+  Input,
+  InputLabel,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@material-ui/core';
+import userService from 'services/user';
+import GordonSnackbar from 'components/Snackbar';
+import './index.css';
+
+const UpdatePhone = () => {
+  const [open, setOpen] = useState(false);
+  const [mobilePhoneNumber, setMobilePhoneNumber] = useState('');
+  const [snackbar, setSnackbar] = useState({ message: '', severity: null, open: false });
+
+  const handleSubmit = async () => {
+    await userService.setMobilePhoneNumber(mobilePhoneNumber);
+    setOpen(false);
+    handleChangeMobilePhoneNumber();
+  };
+
+  const createSnackbar = (message, severity) => {
+    setSnackbar({ message, severity, open: true });
+  };
+
+  const handleChangeMobilePhoneNumber = async (mobilePhoneNumber) => {
+    try {
+      await userService.setMobilePhoneNumber(mobilePhoneNumber);
+      createSnackbar('Your phone number will update within a couple hours.', 'success');
+    } catch {
+      createSnackbar('Phone number failed to update. Please contact CTS.', 'error');
+    }
+  };
+
+  return (
+    <div className="gc360-updatephone-dialog">
+      <IconButton className="gc360-my-profile_edit-icon" onClick={() => setOpen(true)}>
+        <EditIcon style={{ fontSize: 20 }} />
+      </IconButton>
+      <Dialog open={open} onClose={() => setOpen(false)}>
+        <DialogTitle className="gc360-updatephone-dialog_title">Update Phone Number</DialogTitle>
+        <DialogContent className="gc360-updatephone-dialog_content">
+          {/* SUBMISSION GUIDELINES */}
+          <DialogContentText className="gc360-updatephone-dialog_content_text">
+            Update your phone number below. When done, click update.
+          </DialogContentText>
+
+          {/* PHONE NUMBER ENTRY */}
+          <FormControl>
+            <InputLabel htmlFor="formatted-text-mask-input">Phone Number</InputLabel>
+            <Input
+              type="tel"
+              id="mobile-phone-number-input"
+              name="mobile-phone-number"
+              value={mobilePhoneNumber}
+              onChange={(event) => setMobilePhoneNumber(event.target.value)}
+              inputComponent={phoneMaskUS}
+              required="required"
+              autoFocus
+            />
+          </FormControl>
+        </DialogContent>
+
+        {/* CANCEL/UPDATE */}
+        <DialogActions className="gc360-updatephone-dialog_actions">
+          <Button onClick={() => setOpen(false)} variant="outlined" color="primary">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant="contained"
+            color="primary"
+            disabled={mobilePhoneNumber.replace(/[-()\s\D]/g, '').length !== 10}
+          >
+            Update
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <GordonSnackbar
+        open={snackbar.open}
+        severity={snackbar.severity}
+        text={snackbar.message}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+      />
+    </div>
+  );
+};
+
+// From material ui website
+// https://material-ui.com/components/text-fields/#integration-with-3rd-party-input-libraries
+export function phoneMaskUS(props) {
+  const { inputRef, ...other } = props;
+
+  return (
+    <MaskedInput
+      {...other}
+      ref={(ref) => {
+        inputRef(ref ? ref.inputElement : null);
+      }}
+      mask={['(', /[0-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+      placeholderChar={'\u2000'}
+    />
+  );
+}
+
+export default UpdatePhone;

--- a/src/components/Profile/components/PersonalInfoList/components/UpdatePhoneDialog/index.scss
+++ b/src/components/Profile/components/PersonalInfoList/components/UpdatePhoneDialog/index.scss
@@ -1,0 +1,30 @@
+@import '../../../../../../vars';
+
+.gc360-updatephone-dialog {
+  display: grid;
+  grid-template-rows: auto auto auto;
+  &_title {
+    background-color: $primary-blue;
+    color: $neutral-white;
+    text-align: center;
+    grid-row: 1;
+  }
+  &_content {
+    display: grid;
+    grid-row: 2;
+    grid-template-rows: auto auto auto auto auto;
+    grid-row-gap: 20px;
+    padding: 8px 20px 8px 16px !important;
+    &_text {
+      grid-row: 1;
+      grid-column: 1;
+      color: $neutral-gray;
+      text-align: center;
+    }
+    &_actions {
+      grid-row: 3;
+      justify-content: space-evenly !important;
+      margin-bottom: 0.5rem;
+    }
+  }
+}

--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import UpdatePhone from './components/UpdatePhoneDialog/index.js';
 import user from 'services/user';
 import './index.css';
 import ProfileInfoListItem from '../ProfileInfoListItem';
@@ -123,7 +124,12 @@ const PersonalInfoList = ({
       title="Mobile Phone:"
       contentText={
         myProf ? (
-          formatPhone(MobilePhone)
+          <Grid container spacing={0} alignItems="center">
+            <Grid item>{formatPhone(MobilePhone)}</Grid>
+            <Grid item>
+              <UpdatePhone />
+            </Grid>
+          </Grid>
         ) : MobilePhone === PRIVATE_INFO ? (
           PRIVATE_INFO
         ) : (

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -445,6 +445,10 @@ async function setCliftonStrengths(profile) {
   profile.CliftonStrengths = cliftonStrengths?.Strengths;
 }
 
+async function setMobilePhoneNumber(value) {
+  await http.put(`profiles/mobile_phone_number/${value}/`);
+}
+
 async function setMobilePhonePrivacy(makePrivate) {
   // 'Y' = private, 'N' = public
   await http.put('profiles/mobile_privacy/' + (makePrivate ? 'Y' : 'N'));
@@ -641,6 +645,7 @@ const userService = {
   setFullname,
   setClass,
   setMobilePhonePrivacy,
+  setMobilePhoneNumber,
   setImagePrivacy,
   getMemberships,
   getChapelCredits,

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.js
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.js
@@ -206,7 +206,9 @@ export default class PeopleSearchResult extends Component {
                 <Typography>{personClassJobTitle}</Typography>
               </Grid>
               <Grid item xs={2}>
-                <Typography>{Person.AD_Username}</Typography>
+                <Typography>
+                  {Person.AD_Username.includes('.') ? Person.AD_Username : null}
+                </Typography>
                 <Typography>{personMailLocation}</Typography>
               </Grid>
             </Grid>

--- a/src/views/Timesheets/index.js
+++ b/src/views/Timesheets/index.js
@@ -1,31 +1,60 @@
 //Main timesheets page
-import { Card, CardContent, CardHeader, Grid } from '@material-ui/core/';
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
+import GordonUnauthorized from 'components/GordonUnauthorized';
+import {
+  Grid,
+  Card,
+  CardContent,
+  CardHeader,
+  Link,
+  Tooltip,
+  FormControl,
+  InputLabel,
+  Select,
+  Input,
+  MenuItem,
+  Button,
+  Typography,
+  TextField,
+} from '@material-ui/core/';
+import DateFnsUtils from '@date-io/date-fns';
+import { isValid, isWithinInterval, addDays, set } from 'date-fns';
+import jobsService from 'services/jobs';
+import { MuiPickersUtilsProvider, KeyboardDateTimePicker } from '@material-ui/pickers';
+import ShiftDisplay from './components/ShiftDisplay';
+import { withStyles } from '@material-ui/core/styles';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import { gordonColors } from 'theme';
 import './timesheets.css';
+import GordonLoader from 'components/Loader';
+import { makeStyles } from '@material-ui/core/styles';
+import SimpleSnackbar from 'components/Snackbar';
+import user from 'services/user';
+import useNetworkStatus from 'hooks/useNetworkStatus';
+import GordonOffline from 'components/GordonOffline';
 
-// const MINIMUM_SHIFT_LENGTH = 0.08; // Minimum length for a shift is 5 minutes, 1/12 hour
-// const MILLISECONDS_PER_HOUR = 3600000;
+const MINIMUM_SHIFT_LENGTH = 0.08; // Minimum length for a shift is 5 minutes, 1/12 hour
+const MILLISECONDS_PER_HOUR = 3600000;
 
-// const withNoSeconds = (date) => set(date, { seconds: 0, milliseconds: 0 });
-// const withNoTime = (date) => set(date, { hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });
+const withNoSeconds = (date) => set(date, { seconds: 0, milliseconds: 0 });
+const withNoTime = (date) => set(date, { hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });
 
-// const useStyles = makeStyles((theme) => ({
-//   customWidth: {
-//     maxWidth: 500,
-//   },
-// }));
+const useStyles = makeStyles((theme) => ({
+  customWidth: {
+    maxWidth: 500,
+  },
+}));
 
-// const CustomTooltip = withStyles((theme) => ({
-//   tooltip: {
-//     backgroundColor: theme.palette.common.black,
-//     color: 'rgba(255, 255, 255, 0.87)',
-//     boxShadow: theme.shadows[1],
-//     fontSize: 12,
-//   },
-// }))(Tooltip);
+const CustomTooltip = withStyles((theme) => ({
+  tooltip: {
+    backgroundColor: theme.palette.common.black,
+    color: 'rgba(255, 255, 255, 0.87)',
+    boxShadow: theme.shadows[1],
+    fontSize: 12,
+  },
+}))(Tooltip);
 
 const Timesheets = (props) => {
-  /* BEGIN TEMPORARY SHUTDOWN
   const [userJobs, setUserJobs] = useState([]);
   const [selectedDateIn, setSelectedDateIn] = useState(null);
   const [selectedDateOut, setSelectedDateOut] = useState(null);
@@ -612,19 +641,6 @@ const Timesheets = (props) => {
   } else {
     return <GordonUnauthorized feature={'timesheets'} />;
   }
-  END TEMPORARY SHUTDOWN */
-  return (
-    <Grid container justify="center">
-      <Grid item xs={12} lg={8}>
-        <Card>
-          <CardHeader title="Timesheets Unavailable July 1st"></CardHeader>
-          <CardContent>
-            This page is currently offline until Friday 07/02/2021 for Maintenance.
-          </CardContent>
-        </Card>
-      </Grid>
-    </Grid>
-  );
 };
 
 export default Timesheets;


### PR DESCRIPTION
The HR Switch over is complete, so we can restore the student timesheets page (in time for students to submit their hours for the pay period that ends today).

Included in this release is the dialog to update phone numbers. This might not work in Production because of mismatched SQL permission issues, but I will fix it when I work in Tuesday. Since Timesheets is a critical system and the update phone is a small, new feature that no one knows exists, I think it is worthwhile to merge it in a (potentially) broken state for the time being.