### PR TITLE
Disabled CL&W view for students during Summer/Winter term

### DIFF
--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -105,7 +105,7 @@ const CLWCreditsDaysLeft = () => {
               {`${daysRemaining} Days Left`}
             </Typography>
           </Grid>
-          {required != 0 ? (
+          {required != 0 && current != 0 ? (
             <Grid item>
               <Typography variant="body2" style={{ color: 'gray', textAlign: 'center' }}>
                 {`${remaining} CL&W Credit` + (remaining === 1 ? '' : 's') + ' Left'}
@@ -141,7 +141,7 @@ const CLWCreditsDaysLeft = () => {
             </div>
           </div>
 
-          {required != 0 ? (
+          {required != 0 && current != 0 ? (
             <div
               style={{
                 display: 'flex',

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -111,9 +111,8 @@ const CLWCreditsDaysLeft = () => {
                 {`${remaining} CL&W Credit` + (remaining === 1 ? '' : 's') + ' Left'}
               </Typography>
             </Grid>
-          ) : (
-            ''
-          )}
+          ) : null
+          }
         </Grid>
 
         <Doughnut data={data} height={175} options={options} />

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -108,7 +108,7 @@ const CLWCreditsDaysLeft = () => {
           {required ? (
             <Grid item>
               <Typography variant="body2" style={{ color: 'gray', textAlign: 'center' }}>
-                {`${remaining} CL&W Credit` + (remaining === 1 ? '' : 's') + ' Left'}
+                {`${remaining} CL&W Credit${remaining === 1 ? '' : 's'} Left`}
               </Typography>
             </Grid>
           ) : null

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Doughnut, defaults } from 'react-chartjs-2';
 import { Link } from 'react-router-dom';
-
 import { gordonColors } from 'theme';
 import user from 'services/user';
 import session from 'services/session';
@@ -76,7 +75,6 @@ const CLWCreditsDaysLeft = () => {
 
     const { current, required } = chapelCredits;
     const remaining = current > required ? 0 : required - current;
-
     const data = {
       legendEntries: ['Days Finished', 'CL&W Credits'],
       legendColors: [gordonColors.primary.blue, gordonColors.primary.cyan],
@@ -107,11 +105,15 @@ const CLWCreditsDaysLeft = () => {
               {`${daysRemaining} Days Left`}
             </Typography>
           </Grid>
-          <Grid item>
-            <Typography variant="body2" style={{ color: 'gray', textAlign: 'center' }}>
-              {`${remaining} CL&W Credit` + (remaining === 1 ? '' : 's') + ' Left'}
-            </Typography>
-          </Grid>
+          {required != 0 ? (
+            <Grid item>
+              <Typography variant="body2" style={{ color: 'gray', textAlign: 'center' }}>
+                {`${remaining} CL&W Credit` + (remaining === 1 ? '' : 's') + ' Left'}
+              </Typography>
+            </Grid>
+          ) : (
+            ''
+          )}
         </Grid>
 
         <Doughnut data={data} height={175} options={options} />
@@ -138,19 +140,24 @@ const CLWCreditsDaysLeft = () => {
               {'Day' + (daysFinished === 1 ? '' : 's') + ' Finished'}
             </div>
           </div>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
-            <div className="label-text" style={{ color: chapelColor }}>
-              {current}
+
+          {required != 0 ? (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <div className="label-text" style={{ color: chapelColor }}>
+                {current}
+              </div>
+              <div className="entry-text">{'CL&W Credit' + (current === 1 ? '' : 's')}</div>
             </div>
-            <div className="entry-text">{'CL&W Credit' + (current === 1 ? '' : 's')}</div>
-          </div>
+          ) : (
+            ''
+          )}
         </div>
       </React.Fragment>
     );

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -153,7 +153,7 @@ const CLWCreditsDaysLeft = () => {
               <div className="label-text" style={{ color: chapelColor }}>
                 {current}
               </div>
-              <div className="entry-text">{'CL&W Credit' + (current === 1 ? '' : 's')}</div>
+              <div className="entry-text">{`CL&W Credit${current === 1 ? '' : 's')`}</div>
             </div>
           ) : (
             ''

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -105,7 +105,7 @@ const CLWCreditsDaysLeft = () => {
               {`${daysRemaining} Days Left`}
             </Typography>
           </Grid>
-          {required !== 0 && current !== 0 ? (
+          {required && current ? (
             <Grid item>
               <Typography variant="body2" style={{ color: 'gray', textAlign: 'center' }}>
                 {`${remaining} CL&W Credit` + (remaining === 1 ? '' : 's') + ' Left'}
@@ -141,7 +141,7 @@ const CLWCreditsDaysLeft = () => {
             </div>
           </div>
 
-          {required !== 0 && current !== 0 ? (
+          {required && current ? (
             <div
               style={{
                 display: 'flex',

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -105,7 +105,7 @@ const CLWCreditsDaysLeft = () => {
               {`${daysRemaining} Days Left`}
             </Typography>
           </Grid>
-          {required != 0 && current != 0 ? (
+          {required !== 0 && current !== 0 ? (
             <Grid item>
               <Typography variant="body2" style={{ color: 'gray', textAlign: 'center' }}>
                 {`${remaining} CL&W Credit` + (remaining === 1 ? '' : 's') + ' Left'}
@@ -141,7 +141,7 @@ const CLWCreditsDaysLeft = () => {
             </div>
           </div>
 
-          {required != 0 && current != 0 ? (
+          {required !== 0 && current !== 0 ? (
             <div
               style={{
                 display: 'flex',

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -155,9 +155,8 @@ const CLWCreditsDaysLeft = () => {
               </div>
               <div className="entry-text">{`CL&W Credit${current === 1 ? '' : 's')`}</div>
             </div>
-          ) : (
-            ''
-          )}
+          ) : null
+          }
         </div>
       </React.Fragment>
     );

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -111,8 +111,7 @@ const CLWCreditsDaysLeft = () => {
                 {`${remaining} CL&W Credit${remaining === 1 ? '' : 's'} Left`}
               </Typography>
             </Grid>
-          ) : null
-          }
+          ) : null}
         </Grid>
 
         <Doughnut data={data} height={175} options={options} />
@@ -152,10 +151,9 @@ const CLWCreditsDaysLeft = () => {
               <div className="label-text" style={{ color: chapelColor }}>
                 {current}
               </div>
-              <div className="entry-text">{`CL&W Credit${current === 1 ? '' : 's')`}</div>
+              <div className="entry-text">{`CL&W Credit ${current === 1 ? '' : 's'}`}</div>
             </div>
-          ) : null
-          }
+          ) : null}
         </div>
       </React.Fragment>
     );

--- a/src/views/Home/components/CLWCreditsDaysLeft/index.js
+++ b/src/views/Home/components/CLWCreditsDaysLeft/index.js
@@ -105,7 +105,7 @@ const CLWCreditsDaysLeft = () => {
               {`${daysRemaining} Days Left`}
             </Typography>
           </Grid>
-          {required && current ? (
+          {required ? (
             <Grid item>
               <Typography variant="body2" style={{ color: 'gray', textAlign: 'center' }}>
                 {`${remaining} CL&W Credit` + (remaining === 1 ? '' : 's') + ' Left'}
@@ -141,7 +141,7 @@ const CLWCreditsDaysLeft = () => {
             </div>
           </div>
 
-          {required && current ? (
+          {required ? (
             <div
               style={{
                 display: 'flex',


### PR DESCRIPTION
Added functionality to disable the CL&W credit display for the student view of Home when not applicable (aka, Summer/Winter term when credits are not required or recorded). Closes #1243 