### PR TITLE
Fix Quick People Search Loading

### DIFF
--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -78,7 +78,7 @@ export default class GordonPeopleSearch extends Component {
 
     let results = await peopleSearch.search(query);
     let suggestions = results.result;
-    console.log(results.result);
+    console.log(suggestions);
     this.setState({ suggestions });
   }
 

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -76,7 +76,9 @@ export default class GordonPeopleSearch extends Component {
     //but really its just that its capitalized what the heck
     query = query.toLowerCase();
 
-    let suggestions = await peopleSearch.search(query);
+    let results = await peopleSearch.search(query);
+    let suggestions = results.result;
+    console.log(results.result);
     this.setState({ suggestions });
   }
 
@@ -213,22 +215,17 @@ export default class GordonPeopleSearch extends Component {
                 suggestion.Nickname &&
                   suggestion.Nickname !== suggestion.FirstName &&
                   suggestion.Nickname !== suggestion.UserName.split(/ |\./)[0]
-                  ? suggestion.FirstName +
-                    ' (' +
-                    suggestion.Nickname +
-                    ') ' +
-                    suggestion.LastName
-                  : (suggestion.MaidenName &&
+                  ? suggestion.FirstName + ' (' + suggestion.Nickname + ') ' + suggestion.LastName
+                  : suggestion.MaidenName &&
                     suggestion.MaidenName !== suggestion.LastName &&
-                    suggestion.MaidenName !== suggestion.UserName.split(/ |\./)[1] 
+                    suggestion.MaidenName !== suggestion.UserName.split(/ |\./)[1]
                   ? suggestion.FirstName +
                     ' ' +
                     suggestion.LastName +
                     ' (' +
                     suggestion.MaidenName +
                     ')'
-                  :
-                  suggestion.FirstName + ' ' + suggestion.LastName),
+                  : suggestion.FirstName + ' ' + suggestion.LastName,
                 this.state.highlightQuery,
               )}
         </Typography>

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -123,9 +123,6 @@ export default class GordonPeopleSearch extends Component {
       if (suggestionIndex === -1) suggestionIndex = suggestionList.length - 1;
       this.setState({ suggestionIndex });
     }
-    // if (key === 'Backspace') {
-    //   this.setState({ suggestions: [] });
-    // }
   };
 
   reset() {

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -48,6 +48,7 @@ export default class GordonPeopleSearch extends Component {
     this.reset = this.reset.bind(this);
     this.handleKeys = this.handleKeys.bind(this);
     this.state = {
+      time: 0,
       suggestions: [],
       suggestionIndex: -1,
       query: String,
@@ -76,10 +77,17 @@ export default class GordonPeopleSearch extends Component {
     //but really its just that its capitalized what the heck
     query = query.toLowerCase();
 
-    let results = await peopleSearch.search(query);
-    let suggestions = results.result;
-    console.log(suggestions);
-    this.setState({ suggestions });
+    console.log(query);
+
+    let time,
+      suggestions = [];
+    let results = await peopleSearch.renderResults(query);
+    time = results.now;
+    if (this.state.time < time) {
+      this.state.time = time;
+      suggestions = results.result;
+      this.setState({ suggestions });
+    }
   }
 
   handleClick = (theChosenOne) => {
@@ -117,9 +125,9 @@ export default class GordonPeopleSearch extends Component {
       if (suggestionIndex === -1) suggestionIndex = suggestionList.length - 1;
       this.setState({ suggestionIndex });
     }
-    if (key === 'Backspace') {
-      this.setState({ suggestions: [] });
-    }
+    // if (key === 'Backspace') {
+    //   this.setState({ suggestions: [] });
+    // }
   };
 
   reset() {

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -77,8 +77,6 @@ export default class GordonPeopleSearch extends Component {
     //but really its just that its capitalized what the heck
     query = query.toLowerCase();
 
-    console.log(query);
-
     let time,
       suggestions = [];
     let results = await peopleSearch.renderResults(query);

--- a/src/services/people-search.js
+++ b/src/services/people-search.js
@@ -16,20 +16,28 @@ import http from './http';
  * @property {String} ConcatonatedInfo All names combined in a single string
  */
 
+function Results(time, searchResult) {
+  this.now = time;
+  this.result = searchResult;
+}
+
 /**
  * Search for a person
  * @param {String} query Query to search
- * @return {Promise.<SearchResult[]>} List of search results
+ * @return {results} List of search results
  */
 const search = (query) => {
   let searchQuery = query;
+  let now = Date.now();
 
   // If query has a space in it or is a username, separate it into first and last names
   if (query.trim().includes(' ') || (query.includes('.') && query.indexOf('.') !== 0)) {
     // Replace period or space with a slash: 'first.last' or 'first last' become 'first/last'
     searchQuery = query.trim().replace(/\.|\s/g, '/');
   }
-  return http.get(`accounts/search/${searchQuery}`);
+
+  let results = new Results(now, http.get(`accounts/search/${searchQuery}`));
+  return results;
 };
 
 const peopleSearchService = {

--- a/src/services/people-search.js
+++ b/src/services/people-search.js
@@ -26,7 +26,7 @@ function Results(time, searchResult) {
  * @param {String} query Query to search
  * @return {results} List of search results
  */
-const search = (query) => {
+const search = async (query) => {
   let searchQuery = query;
   let now = Date.now();
 

--- a/src/services/people-search.js
+++ b/src/services/people-search.js
@@ -12,6 +12,7 @@ import http from './http';
  * @property {String} FirstName First name
  * @property {String} Nickname Nickname
  * @property {String} LastName Last name
+ * @property {String} MaidenName Maiden name
  * @property {String} UserName Firstname.Lastname format
  * @property {String} ConcatonatedInfo All names combined in a single string
  */
@@ -24,11 +25,10 @@ function Results(time, searchResult) {
 /**
  * Search for a person
  * @param {String} query Query to search
- * @return {results} List of search results
+ * @return {Promise.<SearchResult[]>} List of search results
  */
 const search = async (query) => {
   let searchQuery = query;
-  let now = Date.now();
 
   // If query has a space in it or is a username, separate it into first and last names
   if (query.trim().includes(' ') || (query.includes('.') && query.indexOf('.') !== 0)) {
@@ -36,12 +36,18 @@ const search = async (query) => {
     searchQuery = query.trim().replace(/\.|\s/g, '/');
   }
 
-  let results = new Results(now, http.get(`accounts/search/${searchQuery}`));
+  return http.get(`accounts/search/${searchQuery}`);
+};
+
+const renderResults = async (query) => {
+  let now = Date.now();
+  let searchResult = await search(query).then();
+  let results = new Results(now, searchResult);
   return results;
 };
 
 const peopleSearchService = {
-  search,
+  renderResults,
 };
 
 export default peopleSearchService;


### PR DESCRIPTION
This PR fixes the display error on the quick people search.

Before, the quick people search sends requests every time when the input param is changed, which is very problematic because some requests take longer to search which overwrites the search result of the latest request that took much less time.

Before
===
(This happens if you type fast)
---
![image](https://user-images.githubusercontent.com/78691207/125510969-670718e2-86ed-40a1-8ffc-9581355d4eb8.png)

After
===
![image](https://user-images.githubusercontent.com/78691207/125511507-a6993880-c99d-4da7-a6c4-4746635d38b1.png)
