### PR TITLE
(S21) PATCH - Update Clifton Strength Color Accessibility

### DIFF
--- a/src/services/user.js
+++ b/src/services/user.js
@@ -227,10 +227,10 @@ const cliftonStrengthCategories = {
 };
 
 const cliftonStrengthColors = {
-  Executing: '#60409f',
+  Executing: '#9070bf',
   Influencing: '#c88a2e',
-  Relationship: '#04668f',
-  Thinking: '#2c8b0f',
+  Relationship: '#2486af',
+  Thinking: '#3c9b1f',
 };
 
 const cliftonStrengthLinks = {


### PR DESCRIPTION
Increase color contrast for Clifton Strengths to improve accessibility. Thanks @iamphg97 for pointing this out to me!

Before:
![image](https://user-images.githubusercontent.com/17221652/125959069-4de68842-69b1-45c4-b340-45051b943eaf.png)

After:
![image](https://user-images.githubusercontent.com/17221652/125959118-bf9f6692-05ee-4b33-9316-96ec4a19b92b.png)


Simon would be so proud