### PR TITLE
Add UTC label to API build time in About page

### DIFF
--- a/src/views/About/index.js
+++ b/src/views/About/index.js
@@ -106,7 +106,7 @@ const About = () => {
         </Typography>
         <hr />
         <Typography variant="body2" paragraph>
-          Api Version - {version}
+          Api Version - {version} UTC
         </Typography>
       </Grid>
     </Grid>


### PR DESCRIPTION
The API build time is included in the API executable and displayed in the About page.  The recorded time is UTC rather than one of the USA time zones so it's helpful to explicitly state this.  The simplest way to do this is to just add "UTC" to the string displayed in the About page.