### PR TITLE
Reorganized quick people search suggestion display

### DIFF
--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -173,16 +173,6 @@ export default class GordonPeopleSearch extends Component {
     );
   }
 
-  checkMaidenName(maidenName, lastName, userName1) {
-    if (maidenName &&
-      maidenName !== lastName &&
-      maidenName !== userName1) {
-        return ' (' + maidenName + ')';
-      }
-      else
-      return "";
-  }
-
   renderSuggestion(params) {
     const { suggestion, itemProps } = params;
     let suggestionIndex = this.state.suggestionIndex;
@@ -236,8 +226,11 @@ export default class GordonPeopleSearch extends Component {
                 // Displays last name
                 suggestion.LastName +
                 // If having maiden name that is unique, display that maiden name
-                this.checkMaidenName(suggestion.MaidenName, suggestion.LastName,
-                  suggestion.UserName.split(/ |\./)[1]),
+                (suggestion.MaidenName &&
+                  suggestion.MaidenName !== suggestion.LastName &&
+                  suggestion.MaidenName !== suggestion.UserName.split(/ |\./)[1]
+                  ? ' (' + suggestion.MaidenName + ')'
+                  : ''),
                 this.state.highlightQuery,
               )}
         </Typography>

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -215,20 +215,22 @@ export default class GordonPeopleSearch extends Component {
                 ),
               ].map((e, key) => <span key={key}>{e}</span>)
             : this.getHighlightedText(
-                suggestion.Nickname &&
-                  suggestion.Nickname !== suggestion.FirstName &&
-                  suggestion.Nickname !== suggestion.UserName.split(/ |\./)[0]
-                  ? suggestion.FirstName + ' (' + suggestion.Nickname + ') ' + suggestion.LastName
-                  : suggestion.MaidenName &&
-                    suggestion.MaidenName !== suggestion.LastName &&
-                    suggestion.MaidenName !== suggestion.UserName.split(/ |\./)[1]
-                  ? suggestion.FirstName +
-                    ' ' +
-                    suggestion.LastName +
-                    ' (' +
-                    suggestion.MaidenName +
-                    ')'
-                  : suggestion.FirstName + ' ' + suggestion.LastName,
+                suggestion.FirstName +
+                // If having nickname that is unique, display that nickname
+                (suggestion.Nickname &&
+                suggestion.Nickname !== suggestion.FirstName &&
+                suggestion.Nickname !== suggestion.UserName.split(/ |\./)[0]
+                ? ' (' + suggestion.Nickname + ') '
+                : ' ') +
+                suggestion.LastName +
+                // If having maiden name that is unique, display that maiden name
+                (suggestion.MaidenName &&
+                suggestion.MaidenName !== suggestion.LastName &&
+                suggestion.MaidenName !== suggestion.UserName.split(/ |\./)[1]
+                ? ' (' +
+                suggestion.MaidenName +
+                ')'
+                : ''),
                 this.state.highlightQuery,
               )}
         </Typography>

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -173,6 +173,14 @@ export default class GordonPeopleSearch extends Component {
     );
   }
 
+  checkMaidenName(maidenName, lastName, userName1) {
+    if (maidenName &&
+      maidenName !== lastName &&
+      maidenName !== userName1) {
+        return ' (' + maidenName + ')';
+      }
+  }
+
   renderSuggestion(params) {
     const { suggestion, itemProps } = params;
     let suggestionIndex = this.state.suggestionIndex;
@@ -215,6 +223,7 @@ export default class GordonPeopleSearch extends Component {
                 ),
               ].map((e, key) => <span key={key}>{e}</span>)
             : this.getHighlightedText(
+                // Displays first name
                 suggestion.FirstName +
                 // If having nickname that is unique, display that nickname
                 (suggestion.Nickname &&
@@ -222,15 +231,11 @@ export default class GordonPeopleSearch extends Component {
                 suggestion.Nickname !== suggestion.UserName.split(/ |\./)[0]
                 ? ' (' + suggestion.Nickname + ') '
                 : ' ') +
+                // Displays last name
                 suggestion.LastName +
                 // If having maiden name that is unique, display that maiden name
-                (suggestion.MaidenName &&
-                suggestion.MaidenName !== suggestion.LastName &&
-                suggestion.MaidenName !== suggestion.UserName.split(/ |\./)[1]
-                ? ' (' +
-                suggestion.MaidenName +
-                ')'
-                : ''),
+                this.checkMaidenName(suggestion.maidenName, suggestion.lastName,
+                  suggestion.UserName.split(/ |\./)[1]),
                 this.state.highlightQuery,
               )}
         </Typography>

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -179,6 +179,8 @@ export default class GordonPeopleSearch extends Component {
       maidenName !== userName1) {
         return ' (' + maidenName + ')';
       }
+      else
+      return "";
   }
 
   renderSuggestion(params) {
@@ -234,7 +236,7 @@ export default class GordonPeopleSearch extends Component {
                 // Displays last name
                 suggestion.LastName +
                 // If having maiden name that is unique, display that maiden name
-                this.checkMaidenName(suggestion.maidenName, suggestion.lastName,
+                this.checkMaidenName(suggestion.MaidenName, suggestion.LastName,
                   suggestion.UserName.split(/ |\./)[1]),
                 this.state.highlightQuery,
               )}

--- a/src/components/Header/components/PeopleSearch/index.js
+++ b/src/components/Header/components/PeopleSearch/index.js
@@ -227,10 +227,10 @@ export default class GordonPeopleSearch extends Component {
                 suggestion.LastName +
                 // If having maiden name that is unique, display that maiden name
                 (suggestion.MaidenName &&
-                  suggestion.MaidenName !== suggestion.LastName &&
-                  suggestion.MaidenName !== suggestion.UserName.split(/ |\./)[1]
-                  ? ' (' + suggestion.MaidenName + ')'
-                  : ''),
+                suggestion.MaidenName !== suggestion.LastName &&
+                suggestion.MaidenName !== suggestion.UserName.split(/ |\./)[1]
+                ? ' (' + suggestion.MaidenName + ')'
+                : ''),
                 this.state.highlightQuery,
               )}
         </Typography>


### PR DESCRIPTION
The old code displays nickname if there is a nickname, if not, then check if there is maiden name, if not, then only show firstname + lastname.

The new code displays nickname if there is a nickname and maiden name if there is a maiden name.