### PR TITLE
Fixed special char return all results

### DIFF
--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -406,7 +406,6 @@ class PeopleSearch extends Component {
     let result = Object.values(valuesNeededForSearch)
       .map((x) => x.toString().replace(/[^a-zA-Z0-9\s,.'-]/g, '').trim())
       .some((x) => x);
-    
     return result;
   };
 

--- a/src/views/PeopleSearch/index.js
+++ b/src/views/PeopleSearch/index.js
@@ -404,8 +404,9 @@ class PeopleSearch extends Component {
     const { includeStudent, includeFacStaff, includeAlumni, ...valuesNeededForSearch } =
       this.state.searchValues;
     let result = Object.values(valuesNeededForSearch)
-      .map((x) => x.toString().trim())
+      .map((x) => x.toString().replace(/[^a-zA-Z0-9\s,.'-]/g, '').trim())
       .some((x) => x);
+    
     return result;
   };
 


### PR DESCRIPTION
This PR prevents using special characters in the text fields of the advanced people search returning everyone.