### PR TITLE
CSS Modules Migration *PATCH* Quick search animation and width

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -46,9 +46,16 @@ $drawer-width: 240px;
     display: none;
   }
 
-  .people_search_container {
-    width: 9rem;
+  .people_search_container_container {
+    width: 15rem;
     text-align: right;
+  }
+
+  .people_search_container {
+    text-align: right;
+    width: 9rem;
+    transition: width 0.3s;
+    display: inline-block;
   }
 
   @media (min-width: $break-xs) {
@@ -63,7 +70,10 @@ $drawer-width: 240px;
       height: $header-height-sm;
     }
     .people_search_container {
-      width: auto;
+      width: 13rem;
+      &:focus-within {
+        width: 15rem;
+      }
     }
   }
 

--- a/src/components/Header/components/PeopleSearch/PeopleSearch.module.scss
+++ b/src/components/Header/components/PeopleSearch/PeopleSearch.module.scss
@@ -1,6 +1,8 @@
 @import '../../../../vars';
 
 .gordon_people_search {
+  width: inherit;
+
   .people_search_root {
     align-self: flex-end;
     color: inherit;
@@ -22,8 +24,8 @@
   .people_search_dropdown {
     position: absolute;
     max-height: 60vh;
-    width: 14rem;
-    max-width: inherit;
+    width: inherit;
+    max-width: 15rem;
     overflow-y: auto; // make this to scroll
     overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
@@ -38,17 +40,16 @@
     background-color: transparentize($color: $primary-cyan, $amount: 0.9);
   }
 
-  .people_search_suggestion {
-    display: block;
-    align-self: left;
-    padding-bottom: 25px;
-  }
-
   .people_search_suggestion_selected {
     background-color: $neutral-light-gray;
+  }
+
+  .people_search_suggestion,
+  .people_search_suggestion_selected {
     display: block;
     align-self: left;
     padding-bottom: 25px;
+    white-space: normal; // wrap long names
   }
 
   .people_search_suggestion_selected:hover {
@@ -100,9 +101,6 @@
   }
 
   @media (min-width: $break-sm) {
-    .text_field {
-      width: 14rem;
-    }
     .people_search_root {
       align-self: flex-end;
     }

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -229,8 +229,15 @@ const GordonHeader = ({ authentication, onDrawerToggle, onSignOut }) => {
             </Tabs>
           </div>
 
-          <div className={styles.people_search_container}>
-            {authentication ? <GordonPeopleSearch authentication={authentication} /> : loginButton}
+          <div className={styles.people_search_container_container}>
+            {/* Width is dynamic */}
+            <div className={styles.people_search_container}>
+              {authentication ? (
+                <GordonPeopleSearch authentication={authentication} />
+              ) : (
+                loginButton
+              )}
+            </div>
           </div>
 
           <GordonNavAvatarRightCorner


### PR DESCRIPTION
Patch to #1306 CSS Modules Migration
- Adds quick search animation on focus like in prod site (refactored width transition into the Header parent)
- Fixed width of People Search Results dropdown (wraps long names)

Resolves #1312 