### PR TITLE
Fix event page width

### DIFF
--- a/src/hooks/useWindowSize.js
+++ b/src/hooks/useWindowSize.js
@@ -1,0 +1,20 @@
+import { useLayoutEffect, useState } from 'react';
+
+const useWindowSize = () => {
+  const [size, setSize] = useState([0, 0]);
+  useLayoutEffect(() => {
+    const updateSize = () => {
+      setSize([window.innerWidth, window.innerHeight]);
+    };
+
+    window.addEventListener('resize', updateSize);
+
+    updateSize();
+
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
+
+  return size;
+};
+
+export default useWindowSize;

--- a/src/views/Events/index.js
+++ b/src/views/Events/index.js
@@ -20,6 +20,7 @@ import Media from 'react-media';
 import gordonEvent, { EVENT_FILTERS } from 'services/event';
 import GordonLoader from 'components/Loader';
 import { gordonColors } from 'theme';
+import useWindowSize from 'hooks/useWindowSize';
 
 const Events = (props) => {
   const [open, setOpen] = useState(false);
@@ -31,6 +32,7 @@ const Events = (props) => {
   const [loading, setLoading] = useState(true);
   const [filters, setFilters] = useState([]);
   const futureEvents = useMemo(() => gordonEvent.getFutureEvents(allEvents), [allEvents]);
+  const [width] = useWindowSize();
 
   useEffect(() => {
     const loadEvents = async () => {
@@ -125,8 +127,6 @@ const Events = (props) => {
       Events
     </div>
   );
-
-  let width = window.innerWidth;
 
   if (width >= 920) {
     return (


### PR DESCRIPTION
Created a custom hook to track width and height whenever the page is resized and adjusted events page to respond to width changes. 

This relates to issue #1323 