### PR TITLE
Added: Gordon ID for everyone private profile

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -352,7 +352,7 @@ const PersonalInfoList = ({
       />
     ) : null;
 
-  const studentID = myProf ? (
+  const gordonID = myProf ? (
     <ProfileInfoListItem
       title="Gordon ID:"
       contentText={ID}
@@ -463,7 +463,7 @@ const PersonalInfoList = ({
             {mail}
             {mobilePhoneListItem}
             {homePhoneListItem}
-            {studentID}
+            {gordonID}
             {home}
             {spouse}
             {note}

--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -352,23 +352,22 @@ const PersonalInfoList = ({
       />
     ) : null;
 
-  const studentID =
-    isStudent && myProf ? (
-      <ProfileInfoListItem
-        title="Student ID:"
-        contentText={ID}
-        ContentIcon={
-          <Grid container justifyContent="center">
-            <Grid container direction="column" justifyContent="center" alignItems="center">
-              <LockIcon />
-              Private
-            </Grid>
+  const studentID = myProf ? (
+    <ProfileInfoListItem
+      title="Gordon ID:"
+      contentText={ID}
+      ContentIcon={
+        <Grid container justifyContent="center">
+          <Grid container direction="column" justifyContent="center" alignItems="center">
+            <LockIcon />
+            Private
           </Grid>
-        }
-        privateInfo
-        myProf={myProf}
-      />
-    ) : null;
+        </Grid>
+      }
+      privateInfo
+      myProf={myProf}
+    />
+  ) : null;
 
   const spouse =
     isFacStaff && SpouseName ? (


### PR DESCRIPTION
This PR shows:

- ID for everyone (only students before the change)
- changed 'Student ID' to 'Gordon ID'

Example:
![image](https://user-images.githubusercontent.com/78691207/134440039-7b62e7b7-66ef-4bf4-9fa5-d314d2532542.png)
![image](https://user-images.githubusercontent.com/78691207/134440077-4a0fd06b-6d72-4409-b1ea-9d97935e3876.png)

Related to #1328.