### PR TITLE
Update wellness contact info on question card

### DIFF
--- a/src/components/WellnessQuestion/WellnessQuestion.module.scss
+++ b/src/components/WellnessQuestion/WellnessQuestion.module.scss
@@ -47,4 +47,12 @@
       text-decoration: none;
     }
   }
+
+  a.contact_link {
+    color: $primary-cyan;
+    text-decoration: underline;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }

--- a/src/components/WellnessQuestion/index.js
+++ b/src/components/WellnessQuestion/index.js
@@ -117,7 +117,12 @@ const WellnessQuestion = ({ setStatus }) => {
               </Grid>
             </Collapse>
           </Grid>
-          <div className={styles.wellness_header}>Health Center (for students): (978) 867-4300</div>
+          <div className={styles.wellness_header}>
+            Questions? Email{' '}
+            <a className={styles.contact_link} href="mailto:covid-19@gordon.edu">
+              Covid-19@gordon.edu
+            </a>
+          </div>
           <SymptomsDialog isOpen={isDialogOpen} setIsOpen={setIsDialogOpen} setStatus={setStatus} />
         </Card>
       </Grid>

--- a/src/views/WellnessCheck/components/HealthStatus/HealthStatus.module.scss
+++ b/src/views/WellnessCheck/components/HealthStatus/HealthStatus.module.scss
@@ -158,4 +158,7 @@ a.rtc_link:hover {
 a.contact_link {
   color: $primary-cyan;
   text-decoration: underline;
+  &:hover {
+    text-decoration: underline;
+  }
 }


### PR DESCRIPTION
The contact info is duplicated in two places, but I forgot and only changed it on the Health Status card but not the Wellness Question card.

Also, I updated the link styling to retain underline on hover.