### PR TITLE
Added: close button on link page

### DIFF
--- a/src/components/QuickLinksDialog/index.js
+++ b/src/components/QuickLinksDialog/index.js
@@ -1,6 +1,7 @@
 import GordonDialogBox from 'components/GordonDialogBox/index';
 import PropTypes from 'prop-types';
 import GordonLinksList from './components/LinksList';
+import { Button } from '@material-ui/core';
 
 const GordonQuickLinksDialog = (props) => {
   return (
@@ -11,6 +12,9 @@ const GordonQuickLinksDialog = (props) => {
       title="Useful Links"
     >
       <GordonLinksList onClose={props.handleLinkClose} />
+      <Button onClick={props.handleLinkClose} variant="outlined" color="primary">
+        Close
+      </Button>
     </GordonDialogBox>
   );
 };


### PR DESCRIPTION
Added:

- A CLOSE button at the bottom of the useful link dialog box.

Example:
(PC View)
![image](https://user-images.githubusercontent.com/78691207/134771023-99f7e1dc-75d2-44c6-b604-078dfa24a8af.png)

(Mobile View)
![image](https://user-images.githubusercontent.com/78691207/134771062-861e1e35-88cb-45b9-877f-47d278627faa.png)
