### PR TITLE
Removed On/Off Indicator if Dorm Exists

### DIFF
--- a/src/components/Profile/components/OfficeInfoList/index.js
+++ b/src/components/Profile/components/OfficeInfoList/index.js
@@ -63,7 +63,7 @@ const OfficeInfoList = ({
     />
   ) : null;
 
-  const updateProfile =
+  const updateOfficeInfo =
     myProf && PersonType?.includes('fac') ? (
       <Typography align="left" className={styles.note}>
         NOTE: Update your office info
@@ -92,7 +92,7 @@ const OfficeInfoList = ({
             {mailstop}
             {officePhone}
             {officeHours}
-            {updateProfile}
+            {updateOfficeInfo}
           </List>
         </CardContent>
       </Card>

--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -282,7 +282,7 @@ const PersonalInfoList = ({
     ) : null;
 
   const onOffCampus =
-    isStudent && OnOffCampus ? (
+    isStudent && OnOffCampus && !(BuildingDescription || Hall) ? (
       <ProfileInfoListItem
         title="On/Off Campus:"
         contentText={OnOffCampus}


### PR DESCRIPTION
Pretty self explanatory. If there is a value for the dorm or hall of the student, it will not show that they are on campus as it is redundant to have both. 

Here is what it looked like before:
![image](https://user-images.githubusercontent.com/78440076/135677201-502fb948-ec65-44f4-ae51-dd83336e53e8.png)

Here is what it looks like now:
![image](https://user-images.githubusercontent.com/78440076/135677270-7a8abc3c-648a-4c80-b4c0-79d7f4100676.png)

Off Campus indicator still works:
![image](https://user-images.githubusercontent.com/78440076/135677320-df13e361-b145-4f90-8c44-8730f1a108a8.png)


Closes #1260 