### PR TITLE
Added: if statement to check whether clifton strength is null

### DIFF
--- a/src/services/user.js
+++ b/src/services/user.js
@@ -557,7 +557,14 @@ async function setAdvisors(profile) {
 
 async function setCliftonStrengths(profile) {
   const cliftonStrengths = await getCliftonStrengths(profile.AD_Username);
-  profile.CliftonStrengths = cliftonStrengths;
+  try {
+    if (cliftonStrengths.Categories[0] !== null) {
+      profile.CliftonStrengths = cliftonStrengths;
+    }
+  }
+  catch (e) {
+    console.log("Clifton strength error:", e);
+  }
 }
 
 async function setMobilePhoneNumber(value) {


### PR DESCRIPTION
This PR added:

- If statement to check whether Clifton strength is null

if the first element in `cliftonStrengths.categories` is  not `null`, then set `profile.cliftonStrengths` to the `cliftonStrengths` from database.