### PR TITLE
Added: nickname (all), maiden name (all), graduation year (alumni), major (alumni), minor (alumni) in profile

### DIFF
--- a/src/components/Profile/components/Identification/index.js
+++ b/src/components/Profile/components/Identification/index.js
@@ -727,25 +727,13 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
                         `${userProfile.Title} ${userProfile.FirstName}${
                             hasNickname ? ` (${userProfile.NickName})` : ''
                         } ${userProfile.LastName}${
-                            hasMaidenName ? ` (${userProfile.MaidenName})` : '')`
+                            hasMaidenName ? ` (${userProfile.MaidenName})` : ''}`
                       : // If the user doesn't have a title
-                        userProfile.fullName.split(' ')[0] +
-                        (hasNickname
-                          ? 
-                            ' (' +
-                            userProfile.NickName +
-                            ') ' 
-                            : ' ') +
-                        userProfile.fullName.split(' ')[2] +
-                        (hasMaidenName
-                          ? 
-                            ' (' +
-                            userProfile.MaidenName +
-                            ') ' 
-                            : '')}
-                    {/* {hasNickname
-                        ? userProfile.fullName + ' (' + userProfile.NickName + ')'
-                        : userProfile.fullName} */}
+                      `${userProfile.FirstName}${
+                            hasNickname ? ` (${userProfile.NickName})` : ''
+                        } ${userProfile.LastName}${
+                            hasMaidenName ? ` (${userProfile.MaidenName})` : ''}`
+                    }
                   </Typography>
                 </Grid>
                 {userProfile.JobTitle && userProfile.JobTitle !== '' && (

--- a/src/components/Profile/components/Identification/index.js
+++ b/src/components/Profile/components/Identification/index.js
@@ -430,9 +430,7 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
   }
 
   function createMaidenName(profile) {
-    let Name = String(profile.fullName);
-    let LastName = Name.split(' ')[2];
-    setHasMaidenName(LastName !== profile.MaidenName && profile.MaidenName !== '');
+    setHasMaidenName(profile?.MaidenName && profile?.LastName !== profile.MaidenName);
   }
 
   /**

--- a/src/components/Profile/components/Identification/index.js
+++ b/src/components/Profile/components/Identification/index.js
@@ -132,8 +132,9 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
       setUserProfile(profile);
 
       setIsImagePublic(profile.show_pic);
-      createNickname(profile);
-      createMaidenName(profile);
+
+      setHasNickname(profile?.NickName && profile.NickName !== profile.FirstName);
+      setHasMaidenName(profile?.MaidenName && profile?.LastName !== profile.MaidenName);
     }
 
     loadUserProfile();
@@ -421,16 +422,6 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
       event.preventDefault();
       cropperRef.current.cropper.zoomTo(1);
     }
-  }
-
-  function createNickname(profile) {
-    let Name = String(profile.fullName);
-    let FirstName = Name.split(' ')[0];
-    setHasNickname(FirstName !== profile.NickName && profile.NickName !== '');
-  }
-
-  function createMaidenName(profile) {
-    setHasMaidenName(profile?.MaidenName && profile?.LastName !== profile.MaidenName);
   }
 
   /**

--- a/src/components/Profile/components/Identification/index.js
+++ b/src/components/Profile/components/Identification/index.js
@@ -724,22 +724,10 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
                     userProfile.Title !== '' &&
                     userProfile.PersonType === 'fac'
                       ? // If the user has a title
-                        userProfile.Title +
-                        ' ' +
-                        userProfile.fullName.split(' ')[0] +
-                        (hasNickname
-                          ? 
-                            ' (' +
-                            userProfile.NickName +
-                            ') ' 
-                            : ' ') +
-                        userProfile.fullName.split(' ')[2] +
-                        (hasMaidenName
-                          ? 
-                            ' (' +
-                            userProfile.MaidenName +
-                            ') ' 
-                            : '')
+                        `${userProfile.Title} ${userProfile.FirstName}${
+                            hasNickname ? ` (${userProfile.NickName})` : ''
+                        } ${userProfile.LastName}${
+                            hasMaidenName ? ` (${userProfile.MaidenName})` : '')`
                       : // If the user doesn't have a title
                         userProfile.fullName.split(' ')[0] +
                         (hasNickname

--- a/src/components/Profile/components/Identification/index.js
+++ b/src/components/Profile/components/Identification/index.js
@@ -711,19 +711,13 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
                   className={styles.identification_card_content_card_container_info_name}
                 >
                   <Typography variant="h6" paragraph>
-                    {userProfile.Title &&
-                    userProfile.Title !== '' &&
-                    userProfile.PersonType === 'fac'
-                      ? // If the user has a title
-                        `${userProfile.Title} ${userProfile.FirstName}${
-                            hasNickname ? ` (${userProfile.NickName})` : ''
-                        } ${userProfile.LastName}${
-                            hasMaidenName ? ` (${userProfile.MaidenName})` : ''}`
-                      : // If the user doesn't have a title
-                      `${userProfile.FirstName}${
-                            hasNickname ? ` (${userProfile.NickName})` : ''
-                        } ${userProfile.LastName}${
-                            hasMaidenName ? ` (${userProfile.MaidenName})` : ''}`
+                    {
+                      `${
+                        userProfile.Title && userProfile.PersonType === 'fac' ? `${userProfile.Title} ` : ''
+                   }${userProfile.FirstName}${
+                          hasNickname ? ` (${userProfile.NickName})` : ''
+                   } ${userProfile.LastName}${
+                          hasMaidenName ? ` (${userProfile.MaidenName})` : ''}`
                     }
                   </Typography>
                 </Grid>

--- a/src/components/Profile/components/Identification/index.js
+++ b/src/components/Profile/components/Identification/index.js
@@ -33,7 +33,8 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
   const [hasPreferredImage, setHasPreferredImage] = useState(false);
   const [isPhotosSwitched, setisPhotosSwitched] = useState(false);
   const [showCropper, setShowCropper] = useState();
-  const [hasNickName, setHasNickname] = useState(Boolean);
+  const [hasNickname, setHasNickname] = useState(Boolean);
+  const [hasMaidenName, setHasMaidenName] = useState(Boolean);
   const [openPhotoDialog, setOpenPhotoDialog] = useState(false);
   const [photoDialogError, setPhotoDialogError] = useState();
   const [cropperData, setCropperData] = useState({ cropBoxDim: null, aspectRatio: null });
@@ -132,6 +133,7 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
 
       setIsImagePublic(profile.show_pic);
       createNickname(profile);
+      createMaidenName(profile);
     }
 
     loadUserProfile();
@@ -427,6 +429,12 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
     setHasNickname(FirstName !== profile.NickName && profile.NickName !== '');
   }
 
+  function createMaidenName(profile) {
+    let Name = String(profile.fullName);
+    let LastName = Name.split(' ')[2];
+    setHasMaidenName(LastName !== profile.MaidenName && profile.MaidenName !== '');
+  }
+
   /**
    * Creates the Photo Updater Dialog Box
    *
@@ -718,23 +726,38 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
                     userProfile.Title !== '' &&
                     userProfile.PersonType === 'fac'
                       ? // If the user has a title
-                        hasNickName
-                        ? // If the user has a title and a nickname
-                          userProfile.Title +
-                          ' ' +
-                          userProfile.fullName +
-                          ' (' +
-                          userProfile.NickName +
-                          ')'
-                        : // If the user has a title and no nickname
-                          userProfile.Title + ' ' + userProfile.fullName
+                        userProfile.Title +
+                        ' ' +
+                        userProfile.fullName.split(' ')[0] +
+                        (hasNickname
+                          ? 
+                            ' (' +
+                            userProfile.NickName +
+                            ') ' 
+                            : ' ') +
+                        userProfile.fullName.split(' ')[2] +
+                        (hasMaidenName
+                          ? 
+                            ' (' +
+                            userProfile.MaidenName +
+                            ') ' 
+                            : '')
                       : // If the user doesn't have a title
-                      hasNickName
-                      ? // If the user doesn't have a title but has a nickname
-                        userProfile.fullName + ' (' + userProfile.NickName + ')'
-                      : // If the user doesn't have a title or a nickname
-                        userProfile.fullName}
-                    {/* {hasNickName
+                        userProfile.fullName.split(' ')[0] +
+                        (hasNickname
+                          ? 
+                            ' (' +
+                            userProfile.NickName +
+                            ') ' 
+                            : ' ') +
+                        userProfile.fullName.split(' ')[2] +
+                        (hasMaidenName
+                          ? 
+                            ' (' +
+                            userProfile.MaidenName +
+                            ') ' 
+                            : '')}
+                    {/* {hasNickname
                         ? userProfile.fullName + ' (' + userProfile.NickName + ')'
                         : userProfile.fullName} */}
                   </Typography>

--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -56,6 +56,7 @@ const PersonalInfoList = ({
     OnCampusRoom,
     OnOffCampus,
     PersonType,
+    PreferredClassYear,
     SpouseName,
   },
   createSnackbar,
@@ -214,17 +215,24 @@ const PersonalInfoList = ({
   );
 
   const minors =
-    Minors?.length > 0 && isStudent ? (
+    Minors?.length > 0 && !isFacStaff ? (
       <ProfileInfoListItem
         title={Minors?.length > 1 ? 'Minors:' : 'Minor:'}
         contentText={Minors?.join(', ')}
       />
     ) : null;
 
-  const majors = isStudent ? (
+  const majors = !isFacStaff ? (
     <ProfileInfoListItem
       title={Majors?.length > 1 ? 'Majors:' : 'Major:'}
       contentText={Majors?.length < 1 ? 'Undecided' : Majors?.join(', ')}
+    />
+  ) : null;
+
+  const graduationYear = (!isFacStaff && !isStudent) ? (
+    <ProfileInfoListItem
+      title={'Graduation Year:'}
+      contentText={PreferredClassYear}
     />
   ) : null;
 
@@ -457,6 +465,7 @@ const PersonalInfoList = ({
           <List>
             {majors}
             {minors}
+            {graduationYear}
             {cliftonStrengths}
             {advisors}
             {onOffCampus}

--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -69,6 +69,7 @@ const PersonalInfoList = ({
   const isOnline = useNetworkStatus();
   const isStudent = PersonType?.includes('stu');
   const isFacStaff = PersonType?.includes('fac');
+  const isAlumni = PersonType?.includes('alu');
 
   // KeepPrivate has different values for Students and FacStaff.
   // Students: null for public, 'S' for semi-private (visible to other students, some info redacted)
@@ -229,7 +230,7 @@ const PersonalInfoList = ({
     />
   ) : null;
 
-  const graduationYear = (!isFacStaff && !isStudent) ? (
+  const graduationYear = isAlumni ? (
     <ProfileInfoListItem
       title={'Graduation Year:'}
       contentText={PreferredClassYear}


### PR DESCRIPTION
For everyone:

- **Reorganized**: identification name format: 

- - facStaff with a title: `title + firstName + (nickname) + lastName + (maidenName)`

- - Others:  `firstName + (nickname) + lastName + (maidenName)`

My old profile:
![image](https://user-images.githubusercontent.com/78691207/135720989-310fc6de-17c7-4220-a37e-685626e6a8ff.png)
My new profile:
![image](https://user-images.githubusercontent.com/78691207/135721000-b71a50fd-eb36-4a99-a64c-b28edee602ad.png)
Sample alumni (have nickname and maidenName) old profile:
![image](https://user-images.githubusercontent.com/78691207/135721072-ad0cac88-4316-4cc5-b4fa-b703a81f20d9.png)
Sample alumni (have nickname and maidenName) new profile:
![image](https://user-images.githubusercontent.com/78691207/135721133-df5db1df-f4c1-4a4d-892d-bdd9b7b88992.png)

- **Added**: Majors, Minors (though alumni don't have minor in database), Graduation Year
Sample alumni personalInfo:
![image](https://user-images.githubusercontent.com/78691207/135721240-e6865187-ee50-463a-9be9-5aea06486c11.png)
