### PR TITLE
Disable schedule on public Profile

### DIFF
--- a/src/components/Profile/index.js
+++ b/src/components/Profile/index.js
@@ -1,6 +1,8 @@
-import { useState, useCallback } from 'react';
+import { Grid } from '@material-ui/core';
+import GordonSnackbar from 'components/Snackbar';
+import useNetworkStatus from 'hooks/useNetworkStatus';
+import { useCallback, useState } from 'react';
 import user from 'services/user';
-
 import {
   EmergencyInfoList,
   Identification,
@@ -10,9 +12,6 @@ import {
   SchedulePanel,
   VictoryPromiseDisplay,
 } from './components';
-import { Grid } from '@material-ui/core';
-import GordonSnackbar from 'components/Snackbar';
-import useNetworkStatus from 'hooks/useNetworkStatus';
 
 const Profile = ({ profile, myProf }) => {
   const [snackbar, setSnackbar] = useState({ message: '', severity: null, open: false });
@@ -46,9 +45,11 @@ const Profile = ({ profile, myProf }) => {
         </Grid>
       )}
 
-      <Grid item xs={12} lg={10} align="center">
-        <SchedulePanel profile={profile} myProf={myProf} network={network} />
-      </Grid>
+      {(myProf || !profile.PersonType?.includes('stu')) && (
+        <Grid item xs={12} lg={10} align="center">
+          <SchedulePanel profile={profile} myProf={myProf} network={network} />
+        </Grid>
+      )}
 
       <Grid item xs={12} lg={5}>
         <Grid container spacing={2}>


### PR DESCRIPTION
We have been informed that showing a student's schedule to FacStaff without the student's consent is a potential privacy violation. We will revisit the privacy surrounding schedules when it is rewritten/fixed, but in the meantime the simplest solution is to disable the schedule when showing a student's PublicProfile.