### PR TITLE
Fix UserContext issues with initialValue

### DIFF
--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -6,13 +6,20 @@ export const UserContext = createContext();
 export const UpdateUserContext = createContext();
 
 const UserContextProvider = ({ children }) => {
-  const [user, setUser] = useState(isAuthenticated() ? true : null);
-  const updateUser = async () =>
+  const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const updateUser = async () => {
     setUser(isAuthenticated() ? await userService.getProfileInfo() : null);
+    setIsLoading(false);
+  };
 
   useEffect(() => {
     updateUser();
   }, []);
+
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <UpdateUserContext.Provider value={updateUser}>


### PR DESCRIPTION
The initial value of UserContext was naively `true` if the user is authenticated. This was causing breaking errors, because the user object appeared to be present and so components were trying to access it's properties (while it was still initially `true`). The reason it was set to true was that a falsy value (like null, the most reasonable default) would cause the site to load as if the user were unauthenticated while it was still fetching profile info. This looked like a flash of the login screen before the site loaded.

Now UserContext will white out the screen while we load user info for the first time. If the user is not logged-in, the extra white screen is not noticeably longer than previous loading times. If the user IS authenticated, it takes a tiny bit longer, but it should end up making the site feel snappier overall, once the redundant fetches of profile info are removed. Also, since this only happens on initial site load (i.e. when the user first opens the site in a tab), it is an acceptable trade-off.