### PR TITLE
Fix News Search Uppercase Issue

### DIFF
--- a/src/services/news.js
+++ b/src/services/news.js
@@ -91,7 +91,10 @@ const getNotExpiredFormatted = async () => {
  */
 const getFilteredNews = (unexpiredNews, query) => {
   return unexpiredNews.filter((newsitem) => {
-    let queryparts = query.split(' ').filter((q) => q !== '');
+    let queryparts = query
+      .toLowerCase()
+      .split(' ')
+      .filter((q) => q !== '');
     for (let querypart of queryparts) {
       if (
         newsitem.Body.toLowerCase().includes(querypart) ||


### PR DESCRIPTION
News search returns nothing whenever you type in a capital letter. This is because I earlier neglected to lowercase the search string when also lowercasing the other values to compare it to.