### PR TITLE
Put context providers within App error boundary

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -17,16 +17,12 @@ import routes from './routes';
 import analytics from './services/analytics';
 import theme from './theme';
 
-const withContext = (App) => {
-  return () => (
+const ContextProviders = ({ children }) => {
+  return (
     <ThemeProvider theme={theme}>
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <NetworkContextProvider>
-          <UserContextProvider>
-            <AuthContext.Consumer>
-              {(authenticated) => <App auth={authenticated} />}
-            </AuthContext.Consumer>
-          </UserContextProvider>
+          <UserContextProvider>{children}</UserContextProvider>
         </NetworkContextProvider>
       </MuiPickersUtilsProvider>
     </ThemeProvider>
@@ -67,31 +63,40 @@ class App extends Component {
 
   render() {
     return (
-      <Router history={this.history}>
-        <section className={styles.app_wrapper}>
-          <GordonHeader onDrawerToggle={this.onDrawerToggle} />
-          <GordonNav onDrawerToggle={this.onDrawerToggle} drawerOpen={this.state.drawerOpen} />
-          <main className={styles.app_main}>
-            <Switch>
-              {routes.map((route) => (
-                <Route
-                  key={route.path}
-                  path={route.path}
-                  exact={route.exact}
-                  render={(props) => (
-                    <div className={styles.app_main_container}>
-                      <OfflineBanner currentPath={route.path} authentication={this.props.auth} />
-                      <route.component authentication={this.props.auth} {...props} />
-                    </div>
-                  )}
-                />
-              ))}
-            </Switch>
-          </main>
-        </section>
-      </Router>
+      <ContextProviders>
+        <Router history={this.history}>
+          <section className={styles.app_wrapper}>
+            <GordonHeader onDrawerToggle={this.onDrawerToggle} />
+            <GordonNav onDrawerToggle={this.onDrawerToggle} drawerOpen={this.state.drawerOpen} />
+            <main className={styles.app_main}>
+              <AuthContext.Consumer>
+                {(authenticated) => (
+                  <Switch>
+                    {routes.map((route) => (
+                      <Route
+                        key={route.path}
+                        path={route.path}
+                        exact={route.exact}
+                        render={(props) => (
+                          <div className={styles.app_main_container}>
+                            <OfflineBanner
+                              currentPath={route.path}
+                              authentication={this.props.auth}
+                            />
+                            <route.component authentication={authenticated} {...props} />
+                          </div>
+                        )}
+                      />
+                    ))}
+                  </Switch>
+                )}
+              </AuthContext.Consumer>
+            </main>
+          </section>
+        </Router>
+      </ContextProviders>
     );
   }
 }
 
-export default withContext(App);
+export default App;


### PR DESCRIPTION
When I refactored the Context providers out of the main App component, I mistakenly put them outside the `App` component. This is an issue because `App.js` is our error boundary - meaning it is the thing that catches errors not caught anywhere else. When errors were thrown inside the context providers, they were therefore outside the error boundary, and so any uncaught errors crashed the site.

The reason I moved the context providers outside App originally was so that `AuthContext` was available within App.js, allowing me to pass the authentication prop down. I realize now, I could've just added a context consumer beneath the providers with the JSX returned by App, which is exactly what I have now done. This way, `AuthContext` is available to be consumed and pass `authenticated` as a prop for the components that still need it. Once we refactor all those components with `useAuth`, the consumer will no longer be necessary.