### PR TITLE
Search Entire News String

### DIFF
--- a/src/services/news.js
+++ b/src/services/news.js
@@ -93,7 +93,7 @@ const getNotExpiredFormatted = async () => {
  * @returns {Promise<any>} Student news
  */
 const getFilteredNews = (unexpiredNews, query) => {
-  let lowerquery = query.toLowerCase();
+  const lowerquery = query.toLowerCase();
   return unexpiredNews.filter((newsitem) => {
     return (
       newsitem.Body.toLowerCase().includes(lowerquery) ||


### PR DESCRIPTION
This PR makes news search stop splitting the search query on the ' ' character (then searching each split string individually) and instead searches the entire search query entered by the user.

Closes #1385 