### PR TITLE
Fix auth error on loading site

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -15,18 +15,16 @@ import IconButton from '@material-ui/core/IconButton';
 import LockIcon from '@material-ui/icons/Lock';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import GordonTooltip from 'components/GordonTooltip';
 import useNetworkStatus from 'hooks/useNetworkStatus';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import userService from 'services/user';
+import { gordonColors } from 'theme';
 import ProfileInfoListItem from '../ProfileInfoListItem';
 import UpdatePhone from './components/UpdatePhoneDialog/index.js';
 import styles from './PersonalInfoList.module.css';
-import GordonTooltip from 'components/GordonTooltip';
-import { gordonColors } from 'theme';
 
 const PRIVATE_INFO = 'Private as requested.';
-
-const isPolice = userService.getLocalInfo().college_role === 'gordon police';
 
 const formatPhone = (phone) => {
   if (phone?.length === 10) {
@@ -72,6 +70,7 @@ const PersonalInfoList = ({
   const isStudent = PersonType?.includes('stu');
   const isFacStaff = PersonType?.includes('fac');
   const isAlumni = PersonType?.includes('alu');
+  const isPolice = useMemo(() => userService.getLocalInfo().college_role === 'gordon police', []);
 
   // KeepPrivate has different values for Students and FacStaff.
   // Students: null for public, 'S' for semi-private (visible to other students, some info redacted)
@@ -336,7 +335,7 @@ const PersonalInfoList = ({
       </>
     ) : null;
 
-    const campusDormInfo =
+  const campusDormInfo =
     isStudent && OnOffCampus && !(BuildingDescription || Hall) ? (
       <ProfileInfoListItem
         title="Dormitory:"
@@ -345,7 +344,7 @@ const PersonalInfoList = ({
         myProf={myProf}
       />
     ) : isStudent ? (
-    <ProfileInfoListItem
+      <ProfileInfoListItem
         title="Dormitory:"
         contentText={
           <>
@@ -357,7 +356,8 @@ const PersonalInfoList = ({
         }
         privateInfo
         myProf={myProf}
-      /> ) : null;
+      />
+    ) : null;
 
   const gordonID = myProf ? (
     <ProfileInfoListItem


### PR DESCRIPTION
Within the `src/components/Profile/components/PersonalInfoList/index.js` file, there was a call to `userService.getLocalInfo()` that was outside any component. That meant it was compiled as part of the static JS rather than part of any React component, and so it was getting run when the site loaded. This is a problem because it would mean the value never updated (even if the logged-in user changed), and also because it was run even if the user wasn't authenticated. The latter case would cause `user.js` to throw an auth error because there's no token to read the user's local info from. Because the code was run outside of React, the error was thrown before React came online, meaning it prevented the entire site from loading at all.

I have changed it so that the relevant code is now inside the `PersonalInfoList` component. The value it fetches from local info is memoized, to prevent unnecessary work. Since `PersonalInfoList` is only ever rendered to an authenticated user, it won't cause an auth error (and if it did, it would now be caught by the error boundary). The memoization with no dependencies is fine because in order for the value to change, the user would have to log out and back in, so the component would unmount and remount.