### PR TITLE
Cover Case When User ID is null

### DIFF
--- a/src/services/user.js
+++ b/src/services/user.js
@@ -579,8 +579,8 @@ const getSessionMembershipsWithoutGuests = async (id, session) => {
  * @param {string} [id] Identifier for student
  * @returns {Request[]} List of requests for student
  */
-const getSentMembershipRequests = (id = null) => {
-  return http.get(`requests/student/${id ?? ''}`);
+const getSentMembershipRequests = (id = '') => {
+  return http.get(`requests/student/${id}`);
 };
 
 /**


### PR DESCRIPTION
Fixes issue when id is not passed to getSentMembershipRequests(id) because the current behavior is to send a request to /null when an ID is not passed.