### PR TITLE
Fix uncaught error on login with bad credentials

### DIFF
--- a/src/components/LoginDialogue/index.js
+++ b/src/components/LoginDialogue/index.js
@@ -19,7 +19,7 @@ const LoginDialogue = () => {
     setError(null);
 
     try {
-      login(username, password);
+      await login(username, password);
     } catch (err) {
       setError(err.message);
       setLoading(false);


### PR DESCRIPTION
Logging in with incorrect credentials was throwing an uncaught error, causing the login dialogue to break and load infinitely.

The issue was that LoginDialogue was not awaiting the login action, so it wasn't catching resulting errors.