### PR TITLE
Run CI workflow on Pull Request event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Lint and Build
 
-on: push
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
When we first implemented GitHub Actions, they had not yet put in place protections for GitHub Actions running from pull requests from forked repositories. This meant that any bad actor could fork our repo, change the workflows, and open a PR back to our repo, thereby causing their malicious workflow (e.g. a crypto-mining action) to run on our repo. Therefore, to protect our repo, we were running workflows only in response to `push` actions - since external contributors don't have permission to push to our branches.

This is no longer an issue, because GitHub has updated the permissions options. It is now set so that all external contributors will have to have a maintainer from our organization approve the workflow run before it can run in our repo. Therefore, we can now run our actions in response to pull request events. Running the workflow in this way will also allow us to set the workflow as mandatory for merging - meaning that incomplete/failed workflows will block merging (which is the intended usage of a CI job).