### PR TITLE
Pass Involvement Description to AdminCard

### DIFF
--- a/src/views/InvolvementProfile/components/Membership/index.js
+++ b/src/views/InvolvementProfile/components/Membership/index.js
@@ -107,6 +107,7 @@ const Membership = ({ isAdmin, isSuperAdmin, involvementDescription, toggleIsAdm
                 sessionCode={sessionCode}
                 isSuperAdmin={isSuperAdmin}
                 onAddMember={handleAddMember}
+                involvementDescription={involvementDescription}
               />
             </Grid>
           )}


### PR DESCRIPTION
The `AdminCard` on the `InvolvementProfile` needs to have the `involvementDescription` passed to it since the member add dialog uses the description in its title. If it does not have it passed, the add member dialog looks like this:

![image](https://user-images.githubusercontent.com/43764277/137953090-cdb01a53-9487-4466-aa41-79862763b3f6.png)

I am not sure how long it has not been working, but this fixes the issue.