### PR TITLE
Show Deciding when no majors, and hide for alum without majors

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -226,12 +226,13 @@ const PersonalInfoList = ({
       />
     ) : null;
 
-  const majors = !isFacStaff ? (
-    <ProfileInfoListItem
-      title={Majors?.length > 1 ? 'Majors:' : 'Major:'}
-      contentText={Majors?.length < 1 ? 'Undecided' : Majors?.join(', ')}
-    />
-  ) : null;
+  const majors =
+    isFacStaff || (isAlumni && !Majors?.length) ? null : (
+      <ProfileInfoListItem
+        title={Majors?.length > 1 ? 'Majors:' : 'Major:'}
+        contentText={!Majors?.length ? 'Deciding' : Majors?.join(', ')}
+      />
+    );
 
   const graduationYear = isAlumni ? (
     <ProfileInfoListItem title={'Graduation Year:'} contentText={PreferredClassYear} />


### PR DESCRIPTION
The official term for students who haven't picked a major yet is 'Deciding', not 'Undecided'. Also, alumni who have no majors are not 'Deciding', they just don't have majors listed in our system. Hence, we only show the majors list item if the profile belongs to a student, or to an alum who has majors.