### PR TITLE
Add admin ability to submit banners to the home page carousel from 360

### DIFF
--- a/src/services/cms.ts
+++ b/src/services/cms.ts
@@ -1,22 +1,25 @@
 import http from './http';
 
 type Slide = {
-  ImagePath: string;
-  AltTag: string;
-  HasCaption: boolean;
+  ID: number;
+  Path: string;
   Title: string;
-  SubTitle: string;
-  Action: string;
-  ActionLink: string;
+  LinkURL: string;
   Width: number;
   Height: number;
   SortOrder: number;
 };
 
-const getSlides = (): Promise<Slide[]> => http.get('cms/slider');
+const getSlides = (): Promise<Slide[]> => http.get('cms/banner');
+
+const submitSlide = (slide: Slide): Promise<Slide> => http.post('cms/banner', slide);
+
+const deleteSlide = (ID: number): Promise<Slide> => http.del(`cms/banner/${ID}`);
 
 const cmsService = {
   getSlides,
+  submitSlide,
+  deleteSlide,
 };
 
 export default cmsService;

--- a/src/services/cms.ts
+++ b/src/services/cms.ts
@@ -10,9 +10,16 @@ type Slide = {
   SortOrder: number;
 };
 
+type SlidePosting = {
+  Title: string;
+  LinkURL: string;
+  SortOrder: number;
+  ImageData: string;
+};
+
 const getSlides = (): Promise<Slide[]> => http.get('cms/banner');
 
-const submitSlide = (slide: Slide): Promise<Slide> => http.post('cms/banner', slide);
+const submitSlide = (slide: SlidePosting): Promise<Slide> => http.post('cms/banner', slide);
 
 const deleteSlide = (ID: number): Promise<Slide> => http.del(`cms/banner/${ID}`);
 

--- a/src/views/BannerSubmission/components/Banner/Banner.module.scss
+++ b/src/views/BannerSubmission/components/Banner/Banner.module.scss
@@ -24,6 +24,17 @@ button.deleteButton {
   color: $secondary-red;
 }
 
-.banner_details {
+img.banner_image {
+  height: auto;
+  max-width: 1500px;
+  margin: auto;
+}
+
+.banner_details_large {
+  width: 100%;
+  padding-top: 1rem;
+}
+
+.banner_details_small {
   flex-direction: column;
 }

--- a/src/views/BannerSubmission/components/Banner/Banner.module.scss
+++ b/src/views/BannerSubmission/components/Banner/Banner.module.scss
@@ -1,24 +1,5 @@
 @import '../../../../vars';
 
-.news_item {
-  padding: 1rem;
-  align-items: center;
-  transition: background-color 150ms;
-  border-top: solid 1.5px $neutral-light-gray;
-
-  &:hover {
-    background-color: $primary-cyan;
-    cursor: pointer;
-
-    .news_column,
-    .descriptionText,
-    .news_content,
-    .news_heading {
-      color: $neutral-white;
-    }
-  }
-}
-
 button.deleteButton {
   border-color: $secondary-red;
   color: $secondary-red;
@@ -30,11 +11,6 @@ img.banner_image {
   margin: auto;
 }
 
-.banner_details_large {
-  width: 100%;
-  padding-top: 1rem;
-}
-
-.banner_details_small {
-  flex-direction: column;
+div.banner_actions {
+  justify-content: flex-end;
 }

--- a/src/views/BannerSubmission/components/Banner/Banner.module.scss
+++ b/src/views/BannerSubmission/components/Banner/Banner.module.scss
@@ -6,24 +6,6 @@
   transition: background-color 150ms;
   border-top: solid 1.5px $neutral-light-gray;
 
-  .news_authorProfileLink {
-    color: inherit;
-  }
-  .news_authorProfileLink:hover {
-    text-decoration: underline;
-    text-decoration-color: $neutral-white;
-  }
-
-  &.unapproved {
-    background-color: $neutral-light-gray;
-    border-color: $neutral-gray2;
-    font-style: italic;
-
-    p {
-      opacity: 0.6;
-    }
-  }
-
   &:hover {
     background-color: $primary-cyan;
     cursor: pointer;
@@ -35,28 +17,13 @@
       color: $neutral-white;
     }
   }
+}
 
-  &:hover.unapproved {
-    background-color: $neutral-gray2;
+button.deleteButton {
+  border-color: $secondary-red;
+  color: $secondary-red;
+}
 
-    p {
-      opacity: 1;
-    }
-
-    .news_column,
-    .descriptionText,
-    .news_content,
-    .news_heading {
-      color: $neutral-dark-gray;
-    }
-  }
-
-  button.btn {
-    margin: 0.5rem;
-  }
-
-  button.deleteButton {
-    border-color: $secondary-red;
-    color: $secondary-red;
-  }
+.banner_details {
+  flex-direction: column;
 }

--- a/src/views/BannerSubmission/components/Banner/Banner.module.scss
+++ b/src/views/BannerSubmission/components/Banner/Banner.module.scss
@@ -1,0 +1,62 @@
+@import '../../../../vars';
+
+.news_item {
+  padding: 1rem;
+  align-items: center;
+  transition: background-color 150ms;
+  border-top: solid 1.5px $neutral-light-gray;
+
+  .news_authorProfileLink {
+    color: inherit;
+  }
+  .news_authorProfileLink:hover {
+    text-decoration: underline;
+    text-decoration-color: $neutral-white;
+  }
+
+  &.unapproved {
+    background-color: $neutral-light-gray;
+    border-color: $neutral-gray2;
+    font-style: italic;
+
+    p {
+      opacity: 0.6;
+    }
+  }
+
+  &:hover {
+    background-color: $primary-cyan;
+    cursor: pointer;
+
+    .news_column,
+    .descriptionText,
+    .news_content,
+    .news_heading {
+      color: $neutral-white;
+    }
+  }
+
+  &:hover.unapproved {
+    background-color: $neutral-gray2;
+
+    p {
+      opacity: 1;
+    }
+
+    .news_column,
+    .descriptionText,
+    .news_content,
+    .news_heading {
+      color: $neutral-dark-gray;
+    }
+  }
+
+  button.btn {
+    margin: 0.5rem;
+  }
+
+  button.deleteButton {
+    border-color: $secondary-red;
+    color: $secondary-red;
+  }
+}

--- a/src/views/BannerSubmission/components/Banner/index.js
+++ b/src/views/BannerSubmission/components/Banner/index.js
@@ -1,4 +1,15 @@
-import { Button, CardContent, Collapse, Grid, Typography } from '@material-ui/core';
+import {
+  Accordion,
+  AccordionActions,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  CardContent,
+  Collapse,
+  Grid,
+  Typography,
+} from '@material-ui/core';
+import { ExpandMore } from '@material-ui/icons';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { useState } from 'react';
 import styles from './Banner.module.css';
@@ -9,46 +20,31 @@ const Banner = ({ banner, size, handleNewsItemDelete }) => {
   const deleteButton = (
     <Button
       variant="outlined"
-      color="primary"
       startIcon={<DeleteIcon />}
       onClick={() => handleNewsItemDelete(banner.ID)}
-      className={`${styles.btn} ${styles.deleteButton}`}
+      className={styles.deleteButton}
     >
       Delete
     </Button>
   );
 
-  // SINGLE SIZE - single column per news item
   if (size === 'single') {
     return (
-      <Grid
-        container
-        onClick={() => {
-          setOpen(!open);
-        }}
-        className={`${styles.news_item} ${styles.approved}`}
-        justify="center"
-      >
-        <Grid item xs={12}>
-          <Typography variant="h6" className={styles.news_heading} style={{ fontWeight: 'bold' }}>
+      <Accordion className={styles.news_item}>
+        <AccordionSummary expandIcon={<ExpandMore />}>
+          <Typography variant="h6" className={styles.news_heading}>
             {banner.Title}
           </Typography>
-        </Grid>
-        <Collapse in={open} timeout="auto" unmountOnExit>
-          <CardContent>
-            <Typography className={styles.news_content}>"{banner.Order}"</Typography>
-            <Typography className={styles.news_content}>{banner.LinkURL}</Typography>
-            <img src={`data:image/jpg;base64,${banner.Image}`} alt=" " />
-          </CardContent>
-          <Grid container justify="space-evenly">
-            {deleteButton}
-          </Grid>
-        </Collapse>
-      </Grid>
+        </AccordionSummary>
+        <AccordionDetails className={styles.banner_details}>
+          <Typography className={styles.news_content}>Sort Order: {banner.SortOrder}</Typography>
+          <Typography className={styles.news_content}>Link URL: {banner.LinkURL}</Typography>
+          <img src={`data:image/jpg;base64,${banner.Image}`} alt=" " />
+        </AccordionDetails>
+        <AccordionActions>{deleteButton}</AccordionActions>
+      </Accordion>
     );
-  }
-  // FULL SIZE - many columns per news item
-  else if (size === 'full') {
+  } else if (size === 'full') {
     return (
       <Grid
         container

--- a/src/views/BannerSubmission/components/Banner/index.js
+++ b/src/views/BannerSubmission/components/Banner/index.js
@@ -1,0 +1,118 @@
+import { Button, CardContent, Collapse, Grid, Typography } from '@material-ui/core';
+import DeleteIcon from '@material-ui/icons/Delete';
+import useNetworkStatus from 'hooks/useNetworkStatus';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import styles from './Banner.module.css';
+
+const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
+  const [open, setOpen] = useState(false);
+  const isOnline = useNetworkStatus();
+
+  const deleteButton = (
+    <Button
+      variant="outlined"
+      color="primary"
+      startIcon={<DeleteIcon />}
+      onClick={() => {
+        handleNewsItemDelete(posting.ID);
+      }}
+      className={`${styles.btn} ${styles.deleteButton}`}
+    >
+      Delete
+    </Button>
+  );
+
+  // SINGLE SIZE - single column per news item
+  if (size === 'single') {
+    return (
+      <Grid
+        container
+        onClick={() => {
+          setOpen(!open);
+        }}
+        className={`${styles.news_item} ${styles.approved}`}
+        justify="center"
+      >
+        <Grid item xs={12}>
+          <Typography variant="h6" className={styles.news_heading} style={{ fontWeight: 'bold' }}>
+            {posting.Title}
+          </Typography>
+        </Grid>
+        <Collapse in={open} timeout="auto" unmountOnExit>
+          <CardContent>
+            <Typography className={styles.news_content}>"{posting.Order}"</Typography>
+            <Typography className={styles.news_content}>{posting.LinkURL}</Typography>
+            <img src={`data:image/jpg;base64,${posting.Image}`} alt=" " />
+          </CardContent>
+          <Grid container justify="space-evenly">
+            {deleteButton}
+          </Grid>
+        </Collapse>
+      </Grid>
+    );
+  }
+  // FULL SIZE - many columns per news item
+  else if (size === 'full') {
+    return (
+      <Grid
+        container
+        direction="row"
+        onClick={() => {
+          setOpen(!open);
+        }}
+        className={`${styles.news_item} ${styles.approved}`}
+      >
+        <Grid item xs={2}>
+          <Typography className={styles.news_column}>{posting.Title}</Typography>
+        </Grid>
+        <Grid item xs={5}>
+          <Typography className={styles.news_column} style={{ fontWeight: 'bold' }}>
+            {posting.LinkURL}
+          </Typography>
+        </Grid>
+        <Grid item xs={3}></Grid>
+        <Grid item xs={2}>
+          <Typography className={styles.news_column}>{posting.dayPosted}</Typography>
+        </Grid>
+
+        {/* Collapsable details */}
+        <Collapse in={open} timeout="auto" unmountOnExit style={{ width: '100%' }}>
+          <CardContent>
+            <Grid container direction="row" alignItems="center" justify="space-around">
+              <Grid item xs={8} style={{ textAlign: 'left' }}>
+                <Typography className={styles.descriptionText}>Description:</Typography>
+                <Typography type="caption" className={styles.descriptionText}>
+                  {posting.Order}
+                </Typography>
+                <img src={`data:image/jpg;base64,${posting.Picture}`} alt=" " />
+              </Grid>
+              {/* Possible action buttons */}
+              <Grid item xs={4}>
+                <Grid container justify="space-evenly">
+                  {deleteButton}
+                </Grid>
+              </Grid>
+            </Grid>
+          </CardContent>
+        </Collapse>
+      </Grid>
+    );
+  }
+};
+
+Banner.propTypes = {
+  posting: PropTypes.shape({
+    Picture: PropTypes.string.isRequired,
+    Title: PropTypes.string.isRequired,
+    LinkURL: PropTypes.string,
+    Order: PropTypes.number.isRequired,
+  }).isRequired,
+
+  size: PropTypes.string.isRequired,
+  currentUsername: PropTypes.string.isRequired,
+  handleNewsItemDelete: PropTypes.func.isRequired,
+};
+
+export default Banner;

--- a/src/views/BannerSubmission/components/Banner/index.js
+++ b/src/views/BannerSubmission/components/Banner/index.js
@@ -11,9 +11,7 @@ const Banner = ({ banner, size, handleNewsItemDelete }) => {
       variant="outlined"
       color="primary"
       startIcon={<DeleteIcon />}
-      onClick={() => {
-        handleNewsItemDelete(banner.ID);
-      }}
+      onClick={() => handleNewsItemDelete(banner.ID)}
       className={`${styles.btn} ${styles.deleteButton}`}
     >
       Delete
@@ -55,9 +53,7 @@ const Banner = ({ banner, size, handleNewsItemDelete }) => {
       <Grid
         container
         direction="row"
-        onClick={() => {
-          setOpen(!open);
-        }}
+        onClick={() => setOpen((o) => !o)}
         className={`${styles.news_item} ${styles.approved}`}
       >
         <Grid item xs={1}>
@@ -75,14 +71,12 @@ const Banner = ({ banner, size, handleNewsItemDelete }) => {
           <Typography className={styles.news_column}>{banner.SortOrder}</Typography>
         </Grid>
 
-        {/* Collapsable details */}
         <Collapse in={open} timeout="auto" unmountOnExit style={{ width: '100%' }}>
           <CardContent>
             <Grid container direction="row" alignItems="center" justify="space-around">
               <Grid item xs={8} style={{ textAlign: 'left' }}>
                 <img src={banner.Path} alt=" " />
               </Grid>
-              {/* Possible action buttons */}
               <Grid item xs={4}>
                 <Grid container justify="space-evenly">
                   {deleteButton}

--- a/src/views/BannerSubmission/components/Banner/index.js
+++ b/src/views/BannerSubmission/components/Banner/index.js
@@ -1,89 +1,50 @@
 import {
-  Accordion,
-  AccordionActions,
-  AccordionDetails,
-  AccordionSummary,
   Button,
+  Card,
+  CardActions,
   CardContent,
-  Collapse,
-  Grid,
+  CardMedia,
+  Link,
   Typography,
 } from '@material-ui/core';
-import { ExpandMore } from '@material-ui/icons';
 import DeleteIcon from '@material-ui/icons/Delete';
-import { useState } from 'react';
 import styles from './Banner.module.css';
 
-const Banner = ({ banner, size, handleNewsItemDelete }) => {
-  const [open, setOpen] = useState(false);
-
-  const deleteButton = (
-    <Button
-      variant="outlined"
-      startIcon={<DeleteIcon />}
-      onClick={() => handleNewsItemDelete(banner.ID)}
-      className={styles.deleteButton}
-    >
-      Delete
-    </Button>
-  );
-
-  if (size === 'single') {
-    return (
-      <Accordion className={styles.news_item}>
-        <AccordionSummary expandIcon={<ExpandMore />}>
-          <Typography variant="h6" className={styles.news_heading}>
-            {banner.Title}
-          </Typography>
-        </AccordionSummary>
-        <AccordionDetails className={styles.banner_details}>
-          <Typography className={styles.news_content}>Sort Order: {banner.SortOrder}</Typography>
-          <Typography className={styles.news_content}>Link URL: {banner.LinkURL}</Typography>
-          <img src={`data:image/jpg;base64,${banner.Image}`} alt=" " />
-        </AccordionDetails>
-        <AccordionActions>{deleteButton}</AccordionActions>
-      </Accordion>
-    );
-  } else if (size === 'full') {
-    return (
-      <Grid
-        container
-        direction="row"
-        onClick={() => setOpen((o) => !o)}
-        className={`${styles.news_item} ${styles.approved}`}
-      >
-        <Grid item xs={1}>
-          <Typography className={styles.news_column}>{banner.ID}</Typography>
-        </Grid>
-        <Grid item xs={3}>
-          <Typography className={styles.news_column}>{banner.Title}</Typography>
-        </Grid>
-        <Grid item xs={7}>
-          <Typography className={styles.news_column} style={{ fontWeight: 'bold' }}>
+const Banner = ({ banner, handleNewsItemDelete }) => (
+  <Card>
+    <CardMedia
+      component="img"
+      alt={banner.Title}
+      src={banner.Path}
+      title={banner.Title}
+      className={styles.banner_image}
+    />
+    <CardContent>
+      <Typography gutterBottom variant="h5" component="h2">
+        {banner.Title}
+      </Typography>
+      <Typography variant="body2" color="textSecondary">
+        Link:{' '}
+        {banner.LinkURL ? (
+          <Link href={banner.LinkURL} target="_blank" rel="noreferrer">
             {banner.LinkURL}
-          </Typography>
-        </Grid>
-        <Grid item xs={1}>
-          <Typography className={styles.news_column}>{banner.SortOrder}</Typography>
-        </Grid>
-
-        <Collapse in={open} timeout="auto" unmountOnExit style={{ width: '100%' }}>
-          <CardContent>
-            <Grid container direction="row" alignItems="center" justify="space-around">
-              <Grid item xs={8} style={{ textAlign: 'left' }}>
-                <img src={banner.Path} alt=" " />
-              </Grid>
-              <Grid item xs={4}>
-                <Grid container justify="space-evenly">
-                  {deleteButton}
-                </Grid>
-              </Grid>
-            </Grid>
-          </CardContent>
-        </Collapse>
-      </Grid>
-    );
-  }
-};
+          </Link>
+        ) : (
+          'None'
+        )}
+      </Typography>
+    </CardContent>
+    <CardActions style={{ justifyContent: 'flex-end' }}>
+      <Button
+        variant="outlined"
+        startIcon={<DeleteIcon />}
+        onClick={() => handleNewsItemDelete(banner.ID)}
+        className={styles.deleteButton}
+      >
+        Delete
+      </Button>
+    </CardActions>
+  </Card>
+);
 
 export default Banner;

--- a/src/views/BannerSubmission/components/Banner/index.js
+++ b/src/views/BannerSubmission/components/Banner/index.js
@@ -34,7 +34,7 @@ const Banner = ({ banner, handleNewsItemDelete }) => (
         )}
       </Typography>
     </CardContent>
-    <CardActions style={{ justifyContent: 'flex-end' }}>
+    <CardActions className={styles.banner_actions}>
       <Button
         variant="outlined"
         startIcon={<DeleteIcon />}

--- a/src/views/BannerSubmission/components/Banner/index.js
+++ b/src/views/BannerSubmission/components/Banner/index.js
@@ -1,12 +1,10 @@
 import { Button, CardContent, Collapse, Grid, Typography } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
-import useNetworkStatus from 'hooks/useNetworkStatus';
 import { useState } from 'react';
 import styles from './Banner.module.css';
 
-const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
+const Banner = ({ banner, size, handleNewsItemDelete }) => {
   const [open, setOpen] = useState(false);
-  const isOnline = useNetworkStatus();
 
   const deleteButton = (
     <Button
@@ -14,7 +12,7 @@ const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
       color="primary"
       startIcon={<DeleteIcon />}
       onClick={() => {
-        handleNewsItemDelete(posting.ID);
+        handleNewsItemDelete(banner.ID);
       }}
       className={`${styles.btn} ${styles.deleteButton}`}
     >
@@ -35,14 +33,14 @@ const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
       >
         <Grid item xs={12}>
           <Typography variant="h6" className={styles.news_heading} style={{ fontWeight: 'bold' }}>
-            {posting.Title}
+            {banner.Title}
           </Typography>
         </Grid>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <CardContent>
-            <Typography className={styles.news_content}>"{posting.Order}"</Typography>
-            <Typography className={styles.news_content}>{posting.LinkURL}</Typography>
-            <img src={`data:image/jpg;base64,${posting.Image}`} alt=" " />
+            <Typography className={styles.news_content}>"{banner.Order}"</Typography>
+            <Typography className={styles.news_content}>{banner.LinkURL}</Typography>
+            <img src={`data:image/jpg;base64,${banner.Image}`} alt=" " />
           </CardContent>
           <Grid container justify="space-evenly">
             {deleteButton}
@@ -63,18 +61,18 @@ const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
         className={`${styles.news_item} ${styles.approved}`}
       >
         <Grid item xs={1}>
-          <Typography className={styles.news_column}>{posting.ID}</Typography>
+          <Typography className={styles.news_column}>{banner.ID}</Typography>
         </Grid>
         <Grid item xs={3}>
-          <Typography className={styles.news_column}>{posting.Title}</Typography>
+          <Typography className={styles.news_column}>{banner.Title}</Typography>
         </Grid>
         <Grid item xs={7}>
           <Typography className={styles.news_column} style={{ fontWeight: 'bold' }}>
-            {posting.LinkURL}
+            {banner.LinkURL}
           </Typography>
         </Grid>
         <Grid item xs={1}>
-          <Typography className={styles.news_column}>{posting.SortOrder}</Typography>
+          <Typography className={styles.news_column}>{banner.SortOrder}</Typography>
         </Grid>
 
         {/* Collapsable details */}
@@ -82,7 +80,7 @@ const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
           <CardContent>
             <Grid container direction="row" alignItems="center" justify="space-around">
               <Grid item xs={8} style={{ textAlign: 'left' }}>
-                <img src={posting.Path} alt=" " />
+                <img src={banner.Path} alt=" " />
               </Grid>
               {/* Possible action buttons */}
               <Grid item xs={4}>

--- a/src/views/BannerSubmission/components/Banner/index.js
+++ b/src/views/BannerSubmission/components/Banner/index.js
@@ -1,9 +1,7 @@
 import { Button, CardContent, Collapse, Grid, Typography } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
 import useNetworkStatus from 'hooks/useNetworkStatus';
-import PropTypes from 'prop-types';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import styles from './Banner.module.css';
 
 const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
@@ -64,17 +62,19 @@ const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
         }}
         className={`${styles.news_item} ${styles.approved}`}
       >
-        <Grid item xs={2}>
+        <Grid item xs={1}>
+          <Typography className={styles.news_column}>{posting.ID}</Typography>
+        </Grid>
+        <Grid item xs={3}>
           <Typography className={styles.news_column}>{posting.Title}</Typography>
         </Grid>
-        <Grid item xs={5}>
+        <Grid item xs={7}>
           <Typography className={styles.news_column} style={{ fontWeight: 'bold' }}>
             {posting.LinkURL}
           </Typography>
         </Grid>
-        <Grid item xs={3}></Grid>
-        <Grid item xs={2}>
-          <Typography className={styles.news_column}>{posting.dayPosted}</Typography>
+        <Grid item xs={1}>
+          <Typography className={styles.news_column}>{posting.SortOrder}</Typography>
         </Grid>
 
         {/* Collapsable details */}
@@ -82,11 +82,7 @@ const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
           <CardContent>
             <Grid container direction="row" alignItems="center" justify="space-around">
               <Grid item xs={8} style={{ textAlign: 'left' }}>
-                <Typography className={styles.descriptionText}>Description:</Typography>
-                <Typography type="caption" className={styles.descriptionText}>
-                  {posting.Order}
-                </Typography>
-                <img src={`data:image/jpg;base64,${posting.Picture}`} alt=" " />
+                <img src={posting.Path} alt=" " />
               </Grid>
               {/* Possible action buttons */}
               <Grid item xs={4}>
@@ -100,19 +96,6 @@ const Banner = ({ posting, size, currentUsername, handleNewsItemDelete }) => {
       </Grid>
     );
   }
-};
-
-Banner.propTypes = {
-  posting: PropTypes.shape({
-    Picture: PropTypes.string.isRequired,
-    Title: PropTypes.string.isRequired,
-    LinkURL: PropTypes.string,
-    Order: PropTypes.number.isRequired,
-  }).isRequired,
-
-  size: PropTypes.string.isRequired,
-  currentUsername: PropTypes.string.isRequired,
-  handleNewsItemDelete: PropTypes.func.isRequired,
 };
 
 export default Banner;

--- a/src/views/BannerSubmission/components/BannerAdmin/BannerAdmin.module.scss
+++ b/src/views/BannerSubmission/components/BannerAdmin/BannerAdmin.module.scss
@@ -1,0 +1,9 @@
+button.fab {
+  margin: 0px;
+  top: auto;
+  right: 20px;
+  bottom: 20px;
+  left: auto;
+  position: fixed;
+  z-index: 1;
+}

--- a/src/views/BannerSubmission/components/BannerAdmin/index.js
+++ b/src/views/BannerSubmission/components/BannerAdmin/index.js
@@ -1,56 +1,13 @@
-import {
-  Button,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  Fab,
-  TextField,
-  Tooltip,
-} from '@material-ui/core';
+import { Fab } from '@material-ui/core';
 import PostAddIcon from '@material-ui/icons/PostAdd';
-import GordonDialogBox from 'components/GordonDialogBox';
 import GordonLoader from 'components/Loader';
 import GordonSnackbar from 'components/Snackbar';
-import { useEffect, useRef, useState } from 'react';
-import Cropper from 'react-cropper';
-import { isMobile } from 'react-device-detect';
-import Dropzone from 'react-dropzone';
+import { useEffect, useState } from 'react';
 import cmsService from 'services/cms';
-import { gordonColors } from 'theme';
 import BannerList from '../BannerList';
-
-const CROP_DIM = 200; // Width of cropped image canvas
+import NewBannerDialog from '../NewBannerDialog';
 
 const styles = {
-  button: {
-    background: gordonColors.primary.blue,
-    color: 'white',
-
-    changeImageButton: {
-      background: gordonColors.primary.blue,
-      color: 'white',
-    },
-
-    resetButton: {
-      backgroundColor: '#f44336',
-      color: 'white',
-    },
-    cancelButton: {
-      backgroundColor: 'white',
-      color: gordonColors.primary.blue,
-      border: `1px solid ${gordonColors.primary.blue}`,
-      width: '38%',
-    },
-    hidden: {
-      display: 'none',
-    },
-  },
-  searchBar: {
-    margin: '0 auto',
-  },
-  newNewsForm: {
-    backgroundColor: '#fff',
-  },
   fab: {
     margin: 0,
     top: 'auto',
@@ -63,20 +20,9 @@ const styles = {
 };
 
 const BannerAdmin = () => {
-  //Solely for banner management
   const [banners, setBanners] = useState([]);
-  const [newBannerTitle, setNewBannerTitle] = useState('');
-  const [newBannerWebLink, setNewBannerWebLink] = useState('');
-  const [newBannerSortOrder, setNewBannerSortOrder] = useState(0);
-  const [openBannerActivity, setOpenBannerActivity] = useState(false);
-
-  //Solely for photo functions
-  const [cropperImageData, setCropperImageData] = useState(null);
-  const [photoDialogErrorTimeout, setPhotoDialogErrorTimeout] = useState(null);
-  const [photoDialogError, setPhotoDialogError] = useState(null);
+  const [isNewBannerDialogOpen, setIsNewBannerDialogOpen] = useState(false);
   const [snackbar, setSnackbar] = useState({ open: false, text: '', severity: '' });
-  const cropperRef = useRef();
-  const [aspectRatio, setAspectRatio] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -90,101 +36,9 @@ const BannerAdmin = () => {
     loadPage();
   }, []);
 
-  function handlePostClick() {
-    setOpenBannerActivity(true);
-  }
-
-  function handleWindowClose() {
-    setOpenBannerActivity(false);
-    setNewBannerTitle('');
-    setNewBannerWebLink('');
-    setCropperImageData(null);
-  }
-
   const createSnackbar = (text, severity) => {
     setSnackbar({ open: true, text, severity });
   };
-
-  async function clearPhotoDialogErrorTimeout() {
-    clearTimeout(photoDialogErrorTimeout);
-    setPhotoDialogErrorTimeout(null);
-    setPhotoDialogError(null);
-  }
-
-  function createPhotoDialogBoxMessage() {
-    let message = '';
-    // If an error occured and there's no currently running timeout, the error is displayed
-    // and a timeout for that error message is created
-    if (photoDialogError !== null) {
-      message = <span style={{ color: '#B63228' }}>{photoDialogError}</span>;
-      if (photoDialogErrorTimeout === null) {
-        // Shows the error message for 6 seconds and then returns back to normal text
-        setPhotoDialogErrorTimeout(
-          setTimeout(() => {
-            setPhotoDialogErrorTimeout(null);
-            setPhotoDialogError(null);
-          }, 6000),
-        );
-      }
-    }
-
-    // If no error occured and the cropper is shown, the cropper text is displayed
-    else if (cropperImageData) {
-      message = 'Crop Photo to liking & Click Submit';
-    }
-
-    // If no error occured and the cropper is not shown, the pick a file text is displayed
-    else {
-      message = isMobile
-        ? 'Tap Image to Browse Files'
-        : 'Drag & Drop Picture, or Click to Browse Files';
-    }
-    return message;
-  }
-
-  function onCropperZoom(event) {
-    if (event.detail.ratio > 1) {
-      event.preventDefault();
-      cropperRef.current.cropper.zoomTo(1);
-    }
-  }
-
-  function onDropAccepted(fileList) {
-    var previewImageFile = fileList[0];
-    var reader = new FileReader();
-    reader.onload = () => {
-      imageOnLoadHelper(reader);
-    };
-    reader.readAsDataURL(previewImageFile);
-  }
-
-  async function onDropRejected() {
-    await clearPhotoDialogErrorTimeout();
-    setPhotoDialogError('Sorry, invalid image file! Only PNG and JPEG images are accepted.');
-  }
-
-  async function handleSubmit() {
-    const newImage = cropperRef.current.cropper
-      .getCroppedCanvas({ width: CROP_DIM })
-      .toDataURL()
-      .replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
-
-    let bannerItem = {
-      Title: newBannerTitle,
-      LinkURL: newBannerWebLink,
-      SortOrder: newBannerSortOrder,
-      ImageData: newImage,
-    };
-
-    let result = await cmsService.submitSlide(bannerItem);
-    if (result === undefined) {
-      createSnackbar('Banner Submission Failed to Submit', 'error');
-    } else {
-      createSnackbar('Banner Submission Submitted Successfully', 'success');
-      handleWindowClose();
-      setBanners((b) => [...b, result]);
-    }
-  }
 
   async function handleBannerDelete(ID) {
     let result = await cmsService.deleteSlide(ID);
@@ -196,131 +50,24 @@ const BannerAdmin = () => {
     }
   }
 
-  function imageOnLoadHelper(reader) {
-    var dataURL = reader.result.toString();
-    var i = new Image();
-    i.onload = async () => {
-      var aRatio = i.width / i.height;
-      setAspectRatio(aRatio);
-      setPhotoDialogError(null);
-      setAspectRatio(aRatio);
-      setCropperImageData(dataURL);
-    };
-    i.src = dataURL;
-  }
-
   return (
     <>
-      <Fab variant="extended" color="primary" onClick={handlePostClick} style={styles.fab}>
+      <Fab
+        variant="extended"
+        color="primary"
+        onClick={() => setIsNewBannerDialogOpen(true)}
+        style={styles.fab}
+      >
         <PostAddIcon />
         Add a Banner
       </Fab>
 
-      <GordonDialogBox
-        open={openBannerActivity}
-        title="Make a new Banner"
-        buttonClicked={handleSubmit}
-        buttonName={'Submit'}
-        isButtonDisabled={!Boolean(newBannerTitle && cropperImageData && newBannerSortOrder)}
-        cancelButtonClicked={handleWindowClose}
-        cancelButtonName="Cancel"
-      >
-        <TextField
-          label="Subject"
-          variant="filled"
-          margin="dense"
-          fullWidth
-          name="newBannerTitle"
-          value={newBannerTitle}
-          onChange={(event) => setNewBannerTitle(event.target.value)}
-          helperText="Enter title to show if image fails to load"
-          required
-        />
-
-        <TextField
-          variant="filled"
-          label="URL"
-          margin="dense"
-          fullWidth
-          name="newBannerWebLink"
-          value={newBannerWebLink}
-          onChange={(event) => setNewBannerWebLink(event.target.value)}
-          helperText="Enter URL that banner should link to, if any"
-        />
-
-        <div className="gc360_photo_dialog_box">
-          <DialogContent className="gc360_photo_dialog_box_content">
-            <DialogContentText className="gc360_photo_dialog_box_content_text">
-              {createPhotoDialogBoxMessage()}
-            </DialogContentText>
-            {!cropperImageData && (
-              <Dropzone
-                onDropAccepted={onDropAccepted}
-                onDropRejected={onDropRejected}
-                accept="image/jpeg, image/jpg, image/png"
-              >
-                {({ getRootProps, getInputProps }) => (
-                  <section>
-                    <div className="gc360_photo_dialog_box_content_dropzone" {...getRootProps()}>
-                      <input {...getInputProps()} />
-                    </div>
-                  </section>
-                )}
-              </Dropzone>
-            )}
-            {cropperImageData && (
-              <div className="gc360_photo_dialog_box_content_cropper">
-                <Cropper
-                  ref={cropperRef}
-                  src={cropperImageData}
-                  autoCropArea={1}
-                  viewMode={3}
-                  aspectRatio={aspectRatio}
-                  highlight={false}
-                  background={false}
-                  zoom={onCropperZoom}
-                  zoomable={false}
-                  dragMode={'none'}
-                />
-              </div>
-            )}
-          </DialogContent>
-          <DialogActions className="gc360_photo_dialog_box_actions_top">
-            {cropperImageData && (
-              <Tooltip
-                classes={{ tooltip: 'tooltip' }}
-                id="tooltip-hide"
-                title="Remove this image from the submission"
-              >
-                <Button
-                  variant="contained"
-                  onClick={() => setCropperImageData(null)}
-                  style={styles.button.cancelButton}
-                  className="gc360_photo_dialog_box_content_button"
-                >
-                  Remove picture
-                </Button>
-              </Tooltip>
-            )}
-          </DialogActions>
-        </div>
-
-        <TextField
-          id="outlined-number"
-          variant="filled"
-          label="Sort Order"
-          type="number"
-          margin="dense"
-          fullWidth
-          name="newBannerSortOrderNumber"
-          value={newBannerSortOrder}
-          InputLabelProps={{
-            shrink: true,
-          }}
-          onChange={(event) => setNewBannerSortOrder(event.target.value)}
-          required
-        />
-      </GordonDialogBox>
+      <NewBannerDialog
+        open={isNewBannerDialogOpen}
+        setOpen={setIsNewBannerDialogOpen}
+        createSnackbar={createSnackbar}
+        addBanner={(newBanner) => setBanners((b) => [...b, newBanner])}
+      />
 
       <GordonSnackbar
         {...snackbar}

--- a/src/views/BannerSubmission/components/BannerAdmin/index.js
+++ b/src/views/BannerSubmission/components/BannerAdmin/index.js
@@ -2,10 +2,13 @@ import { Fab } from '@material-ui/core';
 import PostAddIcon from '@material-ui/icons/PostAdd';
 import GordonLoader from 'components/Loader';
 import GordonSnackbar from 'components/Snackbar';
+import { useWindowSize } from 'hooks';
 import { useEffect, useState } from 'react';
 import cmsService from 'services/cms';
 import BannerList from '../BannerList';
 import NewBannerDialog from '../NewBannerDialog';
+
+const BREAKPOINT_WIDTH = 1500;
 
 const styles = {
   fab: {
@@ -24,6 +27,7 @@ const BannerAdmin = () => {
   const [isNewBannerDialogOpen, setIsNewBannerDialogOpen] = useState(false);
   const [snackbar, setSnackbar] = useState({ open: false, text: '', severity: '' });
   const [loading, setLoading] = useState(true);
+  const [width] = useWindowSize();
 
   useEffect(() => {
     const loadPage = async () => {
@@ -59,7 +63,7 @@ const BannerAdmin = () => {
         style={styles.fab}
       >
         <PostAddIcon />
-        Add a Banner
+        {width > BREAKPOINT_WIDTH ? 'Add Banner' : ''}
       </Fab>
 
       <NewBannerDialog

--- a/src/views/BannerSubmission/components/BannerAdmin/index.js
+++ b/src/views/BannerSubmission/components/BannerAdmin/index.js
@@ -18,7 +18,7 @@ import { isMobile } from 'react-device-detect';
 import Dropzone from 'react-dropzone';
 import cmsService from 'services/cms';
 import { gordonColors } from 'theme';
-import BannerList from './components/BannerList';
+import BannerList from '../BannerList';
 
 const CROP_DIM = 200; // Width of cropped image canvas
 

--- a/src/views/BannerSubmission/components/BannerAdmin/index.js
+++ b/src/views/BannerSubmission/components/BannerAdmin/index.js
@@ -7,20 +7,9 @@ import { useEffect, useState } from 'react';
 import cmsService from 'services/cms';
 import BannerList from '../BannerList';
 import NewBannerDialog from '../NewBannerDialog';
+import styles from './BannerAdmin.module.scss';
 
-const BREAKPOINT_WIDTH = 1500;
-
-const styles = {
-  fab: {
-    margin: 0,
-    top: 'auto',
-    right: 40,
-    bottom: 40,
-    left: 'auto',
-    position: 'fixed',
-    zIndex: 1,
-  },
-};
+const BREAKPOINT_WIDTH = 1580; //The width at which the FAB no longer overlaps the banners
 
 const BannerAdmin = () => {
   const [banners, setBanners] = useState([]);
@@ -57,10 +46,11 @@ const BannerAdmin = () => {
   return (
     <>
       <Fab
-        variant="extended"
+        aria-label="add"
         color="primary"
         onClick={() => setIsNewBannerDialogOpen(true)}
-        style={styles.fab}
+        className={styles.fab}
+        variant={width > BREAKPOINT_WIDTH ? 'extended' : 'circular'}
       >
         <PostAddIcon />
         {width > BREAKPOINT_WIDTH ? 'Add Banner' : ''}

--- a/src/views/BannerSubmission/components/BannerAdmin/index.js
+++ b/src/views/BannerSubmission/components/BannerAdmin/index.js
@@ -1,0 +1,361 @@
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  Fab,
+  Grid,
+  TextField,
+  Tooltip,
+} from '@material-ui/core';
+import PostAddIcon from '@material-ui/icons/PostAdd';
+import GordonDialogBox from 'components/GordonDialogBox';
+import GordonLoader from 'components/Loader';
+import GordonSnackbar from 'components/Snackbar';
+import { useEffect, useRef, useState } from 'react';
+import Cropper from 'react-cropper';
+import { isMobile } from 'react-device-detect';
+import Dropzone from 'react-dropzone';
+import cmsService from 'services/cms';
+import { gordonColors } from 'theme';
+import BannerList from './components/BannerList';
+
+const CROP_DIM = 200; // Width of cropped image canvas
+
+const styles = {
+  button: {
+    background: gordonColors.primary.blue,
+    color: 'white',
+
+    changeImageButton: {
+      background: gordonColors.primary.blue,
+      color: 'white',
+    },
+
+    resetButton: {
+      backgroundColor: '#f44336',
+      color: 'white',
+    },
+    cancelButton: {
+      backgroundColor: 'white',
+      color: gordonColors.primary.blue,
+      border: `1px solid ${gordonColors.primary.blue}`,
+      width: '38%',
+    },
+    hidden: {
+      display: 'none',
+    },
+  },
+  searchBar: {
+    margin: '0 auto',
+  },
+  newNewsForm: {
+    backgroundColor: '#fff',
+  },
+  fab: {
+    margin: 0,
+    top: 'auto',
+    right: 40,
+    bottom: 40,
+    left: 'auto',
+    position: 'fixed',
+    zIndex: 1,
+  },
+};
+
+const BannerAdmin = () => {
+  //Solely for banner management
+  const [banners, setBanners] = useState([]);
+  const [newBannerTitle, setNewBannerTitle] = useState('');
+  const [newBannerWebLink, setNewBannerWebLink] = useState('');
+  const [newBannerSortOrder, setNewBannerSortOrder] = useState(0);
+  const [openBannerActivity, setOpenBannerActivity] = useState(false);
+
+  //Solely for photo functions
+  const [cropperImageData, setCropperImageData] = useState(null);
+  const [photoDialogErrorTimeout, setPhotoDialogErrorTimeout] = useState(null);
+  const [photoDialogError, setPhotoDialogError] = useState(null);
+  const [snackbar, setSnackbar] = useState({ open: false, text: '', severity: '' });
+  const cropperRef = useRef();
+  const [aspectRatio, setAspectRatio] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadPage = async () => {
+      setLoading(true);
+      const existingBanners = await cmsService.getSlides();
+      setBanners(existingBanners);
+      setLoading(false);
+    };
+
+    loadPage();
+  }, []);
+
+  function handlePostClick() {
+    setOpenBannerActivity(true);
+  }
+
+  function handleWindowClose() {
+    setOpenBannerActivity(false);
+    setNewBannerTitle('');
+    setNewBannerWebLink('');
+    setCropperImageData(null);
+  }
+
+  const createSnackbar = (text, severity) => {
+    setSnackbar({ open: true, text, severity });
+  };
+
+  async function clearPhotoDialogErrorTimeout() {
+    clearTimeout(photoDialogErrorTimeout);
+    setPhotoDialogErrorTimeout(null);
+    setPhotoDialogError(null);
+  }
+
+  function createPhotoDialogBoxMessage() {
+    let message = '';
+    // If an error occured and there's no currently running timeout, the error is displayed
+    // and a timeout for that error message is created
+    if (photoDialogError !== null) {
+      message = <span style={{ color: '#B63228' }}>{photoDialogError}</span>;
+      if (photoDialogErrorTimeout === null) {
+        // Shows the error message for 6 seconds and then returns back to normal text
+        setPhotoDialogErrorTimeout(
+          setTimeout(() => {
+            setPhotoDialogErrorTimeout(null);
+            setPhotoDialogError(null);
+          }, 6000),
+        );
+      }
+    }
+
+    // If no error occured and the cropper is shown, the cropper text is displayed
+    else if (cropperImageData) {
+      message = 'Crop Photo to liking & Click Submit';
+    }
+
+    // If no error occured and the cropper is not shown, the pick a file text is displayed
+    else {
+      message = isMobile
+        ? 'Tap Image to Browse Files'
+        : 'Drag & Drop Picture, or Click to Browse Files';
+    }
+    return message;
+  }
+
+  function onCropperZoom(event) {
+    if (event.detail.ratio > 1) {
+      event.preventDefault();
+      cropperRef.current.cropper.zoomTo(1);
+    }
+  }
+
+  function onDropAccepted(fileList) {
+    var previewImageFile = fileList[0];
+    var reader = new FileReader();
+    reader.onload = () => {
+      imageOnLoadHelper(reader);
+    };
+    reader.readAsDataURL(previewImageFile);
+  }
+
+  async function onDropRejected() {
+    await clearPhotoDialogErrorTimeout();
+    setPhotoDialogError('Sorry, invalid image file! Only PNG and JPEG images are accepted.');
+  }
+
+  async function handleSubmit() {
+    const newImage = cropperRef.current.cropper
+      .getCroppedCanvas({ width: CROP_DIM })
+      .toDataURL()
+      .replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
+
+    let bannerItem = {
+      Title: newBannerTitle,
+      LinkURL: newBannerWebLink,
+      SortOrder: newBannerSortOrder,
+      ImageData: newImage,
+    };
+
+    let result = await cmsService.submitSlide(bannerItem);
+    if (result === undefined) {
+      createSnackbar('Banner Submission Failed to Submit', 'error');
+    } else {
+      createSnackbar('Banner Submission Submitted Successfully', 'success');
+      handleWindowClose();
+      setBanners((b) => [...b, result]);
+    }
+  }
+
+  async function handleBannerDelete(ID) {
+    let result = await cmsService.deleteSlide(ID);
+    if (result === undefined) {
+      createSnackbar('Banner Failed to Delete', 'error');
+    } else {
+      setBanners((b) => b.filter((banner) => banner.ID !== ID));
+      createSnackbar('Banner Deleted Successfully', 'success');
+    }
+  }
+
+  function imageOnLoadHelper(reader) {
+    var dataURL = reader.result.toString();
+    var i = new Image();
+    i.onload = async () => {
+      var aRatio = i.width / i.height;
+      setAspectRatio(aRatio);
+      setPhotoDialogError(null);
+      setAspectRatio(aRatio);
+      setCropperImageData(dataURL);
+    };
+    i.src = dataURL;
+  }
+
+  return (
+    <>
+      <Fab variant="extended" color="primary" onClick={handlePostClick} style={styles.fab}>
+        <PostAddIcon />
+        Add a Banner
+      </Fab>
+
+      <GordonDialogBox
+        open={openBannerActivity}
+        title="Make a new Banner"
+        buttonClicked={handleSubmit}
+        buttonName={'Submit'}
+        isButtonDisabled={!Boolean(newBannerTitle && cropperImageData && newBannerSortOrder)}
+        cancelButtonClicked={handleWindowClose}
+        cancelButtonName="Cancel"
+      >
+        <Grid container>
+          <Grid item xs={12}>
+            <TextField
+              label="Subject"
+              variant="filled"
+              margin="dense"
+              fullWidth
+              name="newBannerTitle"
+              value={newBannerTitle}
+              onChange={(event) => {
+                setNewBannerTitle(event.target.value);
+              }}
+              // helperText="Please enter a title."
+            />
+          </Grid>
+
+          <Grid item xs={12}>
+            <TextField
+              variant="filled"
+              label="URL"
+              // margin="normal"
+              margin="dense"
+              //multiline
+              fullWidth
+              //rows={4}
+              name="newBannerWebLink"
+              value={newBannerWebLink}
+              onChange={(event) => {
+                setNewBannerWebLink(event.target.value);
+              }}
+              // helperText="Please enter a link."
+            />
+          </Grid>
+
+          <Grid item xs={12}>
+            <div className="gc360_photo_dialog_box">
+              <DialogContent className="gc360_photo_dialog_box_content">
+                <DialogContentText className="gc360_photo_dialog_box_content_text">
+                  {createPhotoDialogBoxMessage()}
+                </DialogContentText>
+                {!cropperImageData && (
+                  <Dropzone
+                    onDropAccepted={onDropAccepted}
+                    onDropRejected={onDropRejected}
+                    accept="image/jpeg, image/jpg, image/png"
+                  >
+                    {({ getRootProps, getInputProps }) => (
+                      <section>
+                        <div
+                          className="gc360_photo_dialog_box_content_dropzone"
+                          {...getRootProps()}
+                        >
+                          <input {...getInputProps()} />
+                        </div>
+                      </section>
+                    )}
+                  </Dropzone>
+                )}
+                {cropperImageData && (
+                  <div className="gc360_photo_dialog_box_content_cropper">
+                    <Cropper
+                      ref={cropperRef}
+                      src={cropperImageData}
+                      autoCropArea={1}
+                      viewMode={3}
+                      aspectRatio={aspectRatio}
+                      highlight={false}
+                      background={false}
+                      zoom={onCropperZoom}
+                      zoomable={false}
+                      dragMode={'none'}
+                    />
+                  </div>
+                )}
+              </DialogContent>
+              <DialogActions className="gc360_photo_dialog_box_actions_top">
+                {cropperImageData && (
+                  <Tooltip
+                    classes={{ tooltip: 'tooltip' }}
+                    id="tooltip-hide"
+                    title="Remove this image from the submission"
+                  >
+                    <Button
+                      variant="contained"
+                      onClick={() => setCropperImageData(null)}
+                      style={styles.button.cancelButton}
+                      className="gc360_photo_dialog_box_content_button"
+                    >
+                      Remove picture
+                    </Button>
+                  </Tooltip>
+                )}
+              </DialogActions>
+            </div>
+          </Grid>
+        </Grid>
+
+        <Grid item xs={12}>
+          <TextField
+            id="outlined-number"
+            variant="filled"
+            label="Number"
+            type="number"
+            margin="dense"
+            fullWidth
+            name="newBannerSortOrderNumber"
+            value={newBannerSortOrder}
+            InputLabelProps={{
+              shrink: true,
+            }}
+            onChange={(event) => setNewBannerSortOrder(event.target.value)}
+          />
+        </Grid>
+      </GordonDialogBox>
+
+      <GordonSnackbar
+        {...snackbar}
+        onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+        anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+      />
+
+      <Grid item xs={12} lg={8} style={{ marginBottom: '7rem' }}>
+        {loading ? (
+          <GordonLoader />
+        ) : (
+          <BannerList banners={banners} handleBannerDelete={handleBannerDelete} />
+        )}
+      </Grid>
+    </>
+  );
+};
+
+export default BannerAdmin;

--- a/src/views/BannerSubmission/components/BannerAdmin/index.js
+++ b/src/views/BannerSubmission/components/BannerAdmin/index.js
@@ -4,7 +4,6 @@ import {
   DialogContent,
   DialogContentText,
   Fab,
-  Grid,
   TextField,
   Tooltip,
 } from '@material-ui/core';
@@ -226,119 +225,101 @@ const BannerAdmin = () => {
         cancelButtonClicked={handleWindowClose}
         cancelButtonName="Cancel"
       >
-        <Grid container>
-          <Grid item xs={12}>
-            <TextField
-              label="Subject"
-              variant="filled"
-              margin="dense"
-              fullWidth
-              name="newBannerTitle"
-              value={newBannerTitle}
-              onChange={(event) => {
-                setNewBannerTitle(event.target.value);
-              }}
-              // helperText="Please enter a title."
-            />
-          </Grid>
+        <TextField
+          label="Subject"
+          variant="filled"
+          margin="dense"
+          fullWidth
+          name="newBannerTitle"
+          value={newBannerTitle}
+          onChange={(event) => setNewBannerTitle(event.target.value)}
+          helperText="Enter title to show if image fails to load"
+          required
+        />
 
-          <Grid item xs={12}>
-            <TextField
-              variant="filled"
-              label="URL"
-              // margin="normal"
-              margin="dense"
-              //multiline
-              fullWidth
-              //rows={4}
-              name="newBannerWebLink"
-              value={newBannerWebLink}
-              onChange={(event) => {
-                setNewBannerWebLink(event.target.value);
-              }}
-              // helperText="Please enter a link."
-            />
-          </Grid>
+        <TextField
+          variant="filled"
+          label="URL"
+          margin="dense"
+          fullWidth
+          name="newBannerWebLink"
+          value={newBannerWebLink}
+          onChange={(event) => setNewBannerWebLink(event.target.value)}
+          helperText="Enter URL that banner should link to, if any"
+        />
 
-          <Grid item xs={12}>
-            <div className="gc360_photo_dialog_box">
-              <DialogContent className="gc360_photo_dialog_box_content">
-                <DialogContentText className="gc360_photo_dialog_box_content_text">
-                  {createPhotoDialogBoxMessage()}
-                </DialogContentText>
-                {!cropperImageData && (
-                  <Dropzone
-                    onDropAccepted={onDropAccepted}
-                    onDropRejected={onDropRejected}
-                    accept="image/jpeg, image/jpg, image/png"
-                  >
-                    {({ getRootProps, getInputProps }) => (
-                      <section>
-                        <div
-                          className="gc360_photo_dialog_box_content_dropzone"
-                          {...getRootProps()}
-                        >
-                          <input {...getInputProps()} />
-                        </div>
-                      </section>
-                    )}
-                  </Dropzone>
+        <div className="gc360_photo_dialog_box">
+          <DialogContent className="gc360_photo_dialog_box_content">
+            <DialogContentText className="gc360_photo_dialog_box_content_text">
+              {createPhotoDialogBoxMessage()}
+            </DialogContentText>
+            {!cropperImageData && (
+              <Dropzone
+                onDropAccepted={onDropAccepted}
+                onDropRejected={onDropRejected}
+                accept="image/jpeg, image/jpg, image/png"
+              >
+                {({ getRootProps, getInputProps }) => (
+                  <section>
+                    <div className="gc360_photo_dialog_box_content_dropzone" {...getRootProps()}>
+                      <input {...getInputProps()} />
+                    </div>
+                  </section>
                 )}
-                {cropperImageData && (
-                  <div className="gc360_photo_dialog_box_content_cropper">
-                    <Cropper
-                      ref={cropperRef}
-                      src={cropperImageData}
-                      autoCropArea={1}
-                      viewMode={3}
-                      aspectRatio={aspectRatio}
-                      highlight={false}
-                      background={false}
-                      zoom={onCropperZoom}
-                      zoomable={false}
-                      dragMode={'none'}
-                    />
-                  </div>
-                )}
-              </DialogContent>
-              <DialogActions className="gc360_photo_dialog_box_actions_top">
-                {cropperImageData && (
-                  <Tooltip
-                    classes={{ tooltip: 'tooltip' }}
-                    id="tooltip-hide"
-                    title="Remove this image from the submission"
-                  >
-                    <Button
-                      variant="contained"
-                      onClick={() => setCropperImageData(null)}
-                      style={styles.button.cancelButton}
-                      className="gc360_photo_dialog_box_content_button"
-                    >
-                      Remove picture
-                    </Button>
-                  </Tooltip>
-                )}
-              </DialogActions>
-            </div>
-          </Grid>
-        </Grid>
+              </Dropzone>
+            )}
+            {cropperImageData && (
+              <div className="gc360_photo_dialog_box_content_cropper">
+                <Cropper
+                  ref={cropperRef}
+                  src={cropperImageData}
+                  autoCropArea={1}
+                  viewMode={3}
+                  aspectRatio={aspectRatio}
+                  highlight={false}
+                  background={false}
+                  zoom={onCropperZoom}
+                  zoomable={false}
+                  dragMode={'none'}
+                />
+              </div>
+            )}
+          </DialogContent>
+          <DialogActions className="gc360_photo_dialog_box_actions_top">
+            {cropperImageData && (
+              <Tooltip
+                classes={{ tooltip: 'tooltip' }}
+                id="tooltip-hide"
+                title="Remove this image from the submission"
+              >
+                <Button
+                  variant="contained"
+                  onClick={() => setCropperImageData(null)}
+                  style={styles.button.cancelButton}
+                  className="gc360_photo_dialog_box_content_button"
+                >
+                  Remove picture
+                </Button>
+              </Tooltip>
+            )}
+          </DialogActions>
+        </div>
 
-        <Grid item xs={12}>
-          <TextField
-            id="outlined-number"
-            variant="filled"
-            label="Number"
-            type="number"
-            margin="dense"
-            fullWidth
-            name="newBannerSortOrderNumber"
-            value={newBannerSortOrder}
-            InputLabelProps={{
-              shrink: true,
-            }}
-            onChange={(event) => setNewBannerSortOrder(event.target.value)}
-          />
-        </Grid>
+        <TextField
+          id="outlined-number"
+          variant="filled"
+          label="Sort Order"
+          type="number"
+          margin="dense"
+          fullWidth
+          name="newBannerSortOrderNumber"
+          value={newBannerSortOrder}
+          InputLabelProps={{
+            shrink: true,
+          }}
+          onChange={(event) => setNewBannerSortOrder(event.target.value)}
+          required
+        />
       </GordonDialogBox>
 
       <GordonSnackbar
@@ -347,13 +328,11 @@ const BannerAdmin = () => {
         anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
       />
 
-      <Grid item xs={12} lg={8} style={{ marginBottom: '7rem' }}>
-        {loading ? (
-          <GordonLoader />
-        ) : (
-          <BannerList banners={banners} handleBannerDelete={handleBannerDelete} />
-        )}
-      </Grid>
+      {loading ? (
+        <GordonLoader />
+      ) : (
+        <BannerList banners={banners} handleBannerDelete={handleBannerDelete} />
+      )}
     </>
   );
 };

--- a/src/views/BannerSubmission/components/BannerList/BannerList.module.scss
+++ b/src/views/BannerSubmission/components/BannerList/BannerList.module.scss
@@ -1,0 +1,5 @@
+div.banner_list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/src/views/BannerSubmission/components/BannerList/index.js
+++ b/src/views/BannerSubmission/components/BannerList/index.js
@@ -1,9 +1,10 @@
 import { Container, Typography } from '@material-ui/core';
 import Banner from '../Banner';
+import styles from './BannerList.module.css';
 
 const BannerList = ({ banners, handleBannerDelete }) => {
   return (
-    <Container style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+    <Container className={styles.banner_list}>
       {banners.length > 0 ? (
         banners.map((banner) => (
           <Banner banner={banner} handleNewsItemDelete={handleBannerDelete} key={banner.ID} />

--- a/src/views/BannerSubmission/components/BannerList/index.js
+++ b/src/views/BannerSubmission/components/BannerList/index.js
@@ -1,12 +1,8 @@
 import { Card, Grid, List, Typography } from '@material-ui/core';
-import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
+import { useWindowSize } from 'hooks';
 import { gordonColors } from 'theme';
 import Banner from '../Banner';
 //import styles from './NewsList.module.css';
-
-//https://www.pluralsight.com/guides/re-render-react-component-on-window-resize
-//Excellent resource for handling rerender on resize -Josh
 
 const BREAKPOINT_WIDTH = 540;
 
@@ -30,80 +26,51 @@ const singleHeader = (
 
 const fullHeader = (
   <Grid container direction="row" style={headerStyle}>
-    <Grid item xs={4}>
-      <Typography variant="body2" style={headerStyle}>
-        PICTURE
-      </Typography>
+    <Grid item xs={1}>
+      <Typography style={headerStyle}>ID</Typography>
     </Grid>
     <Grid item xs={3}>
       <Typography variant="body2" style={headerStyle}>
-        TITLE
+        Title
       </Typography>
     </Grid>
-    <Grid item xs={3}>
+    <Grid item xs={7}>
       <Typography variant="body2" style={headerStyle}>
-        URL
+        Link URL
       </Typography>
     </Grid>
-    <Grid item xs={2}>
+    <Grid item xs={1}>
       <Typography variant="body2" style={headerStyle}>
-        ORDER
+        Sort Order
       </Typography>
     </Grid>
   </Grid>
 );
 
-const BannerList = ({ banners, currentUsername, handleNewsItemDelete }) => {
-  const [width, setWidth] = useState(window.innerWidth);
-
-  useEffect(() => {
-    function handleResize() {
-      setWidth(window.innerWidth);
-    }
-    window.addEventListener('resize', handleResize);
-    return (_) => {
-      window.removeEventListener('resize', handleResize);
-    };
-  });
+const BannerList = ({ banners, currentUsername, handleBannerDelete }) => {
+  const [width] = useWindowSize();
 
   return banners.length > 0 ? (
     <Card>
       {width < BREAKPOINT_WIDTH ? singleHeader : fullHeader}
-      <Grid>
-        <List disablePadding>
-          {/* //className={styles.news_list} disablePadding> */}
-          {banners.length > 0 &&
-            banners.map((posting) => (
-              <Banner
-                posting={posting}
-                size={width < BREAKPOINT_WIDTH ? 'single' : 'full'}
-                currentUsername={currentUsername}
-                handleNewsItemDelete={handleNewsItemDelete}
-                key={posting.ID}
-              />
-            ))}
-        </List>
-      </Grid>
+      <List disablePadding>
+        {banners.length > 0 &&
+          banners.map((posting) => (
+            <Banner
+              posting={posting}
+              size={width < BREAKPOINT_WIDTH ? 'single' : 'full'}
+              currentUsername={currentUsername}
+              handleNewsItemDelete={handleBannerDelete}
+              key={posting.ID}
+            />
+          ))}
+      </List>
     </Card>
   ) : (
     <Typography variant="h4" align="center">
       No Banners
     </Typography>
   );
-};
-
-BannerList.propTypes = {
-  banner: PropTypes.arrayOf(
-    PropTypes.shape({
-      Picture: PropTypes.string.isRequired,
-      Title: PropTypes.string.isRequired,
-      LinkURL: PropTypes.string,
-      Order: PropTypes.number.isRequired,
-    }),
-  ).isRequired,
-
-  currentUsername: PropTypes.string.isRequired,
-  handleNewsItemDelete: PropTypes.func.isRequired,
 };
 
 export default BannerList;

--- a/src/views/BannerSubmission/components/BannerList/index.js
+++ b/src/views/BannerSubmission/components/BannerList/index.js
@@ -47,29 +47,29 @@ const fullHeader = (
   </Grid>
 );
 
-const BannerList = ({ banners, currentUsername, handleBannerDelete }) => {
+const BannerList = ({ banners, handleBannerDelete }) => {
   const [width] = useWindowSize();
 
-  return banners.length > 0 ? (
+  return (
     <Card>
       {width < BREAKPOINT_WIDTH ? singleHeader : fullHeader}
       <List disablePadding>
-        {banners.length > 0 &&
-          banners.map((posting) => (
+        {banners.length > 0 ? (
+          banners.map((banner) => (
             <Banner
-              posting={posting}
+              banner={banner}
               size={width < BREAKPOINT_WIDTH ? 'single' : 'full'}
-              currentUsername={currentUsername}
               handleNewsItemDelete={handleBannerDelete}
-              key={posting.ID}
+              key={banner.ID}
             />
-          ))}
+          ))
+        ) : (
+          <Typography variant="h6" align="center">
+            No Banners
+          </Typography>
+        )}
       </List>
     </Card>
-  ) : (
-    <Typography variant="h4" align="center">
-      No Banners
-    </Typography>
   );
 };
 

--- a/src/views/BannerSubmission/components/BannerList/index.js
+++ b/src/views/BannerSubmission/components/BannerList/index.js
@@ -1,0 +1,109 @@
+import { Card, Grid, List, Typography } from '@material-ui/core';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+import { gordonColors } from 'theme';
+import Banner from '../Banner';
+//import styles from './NewsList.module.css';
+
+//https://www.pluralsight.com/guides/re-render-react-component-on-window-resize
+//Excellent resource for handling rerender on resize -Josh
+
+const BREAKPOINT_WIDTH = 540;
+
+const headerStyle = {
+  backgroundColor: gordonColors.primary.blue,
+  color: '#FFF',
+  padding: '10px',
+};
+
+const singleHeader = (
+  <div style={headerStyle}>
+    <Grid container direction="row">
+      <Grid item xs={12}>
+        <Typography variant="body2" style={headerStyle}>
+          BANNERS
+        </Typography>
+      </Grid>
+    </Grid>
+  </div>
+);
+
+const fullHeader = (
+  <Grid container direction="row" style={headerStyle}>
+    <Grid item xs={4}>
+      <Typography variant="body2" style={headerStyle}>
+        PICTURE
+      </Typography>
+    </Grid>
+    <Grid item xs={3}>
+      <Typography variant="body2" style={headerStyle}>
+        TITLE
+      </Typography>
+    </Grid>
+    <Grid item xs={3}>
+      <Typography variant="body2" style={headerStyle}>
+        URL
+      </Typography>
+    </Grid>
+    <Grid item xs={2}>
+      <Typography variant="body2" style={headerStyle}>
+        ORDER
+      </Typography>
+    </Grid>
+  </Grid>
+);
+
+const BannerList = ({ banners, currentUsername, handleNewsItemDelete }) => {
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    function handleResize() {
+      setWidth(window.innerWidth);
+    }
+    window.addEventListener('resize', handleResize);
+    return (_) => {
+      window.removeEventListener('resize', handleResize);
+    };
+  });
+
+  return banners.length > 0 ? (
+    <Card>
+      {width < BREAKPOINT_WIDTH ? singleHeader : fullHeader}
+      <Grid>
+        <List disablePadding>
+          {/* //className={styles.news_list} disablePadding> */}
+          {banners.length > 0 &&
+            banners.map((posting) => (
+              <Banner
+                posting={posting}
+                size={width < BREAKPOINT_WIDTH ? 'single' : 'full'}
+                currentUsername={currentUsername}
+                handleNewsItemDelete={handleNewsItemDelete}
+                key={posting.ID}
+              />
+            ))}
+        </List>
+      </Grid>
+    </Card>
+  ) : (
+    <Typography variant="h4" align="center">
+      No Banners
+    </Typography>
+  );
+};
+
+BannerList.propTypes = {
+  banner: PropTypes.arrayOf(
+    PropTypes.shape({
+      Picture: PropTypes.string.isRequired,
+      Title: PropTypes.string.isRequired,
+      LinkURL: PropTypes.string,
+      Order: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+
+  currentUsername: PropTypes.string.isRequired,
+  handleNewsItemDelete: PropTypes.func.isRequired,
+};
+
+export default BannerList;

--- a/src/views/BannerSubmission/components/BannerList/index.js
+++ b/src/views/BannerSubmission/components/BannerList/index.js
@@ -1,75 +1,19 @@
-import { Card, Grid, List, Typography } from '@material-ui/core';
-import { useWindowSize } from 'hooks';
-import { gordonColors } from 'theme';
+import { Container, Typography } from '@material-ui/core';
 import Banner from '../Banner';
-//import styles from './NewsList.module.css';
-
-const BREAKPOINT_WIDTH = 540;
-
-const headerStyle = {
-  backgroundColor: gordonColors.primary.blue,
-  color: '#FFF',
-  padding: '10px',
-};
-
-const singleHeader = (
-  <div style={headerStyle}>
-    <Grid container direction="row">
-      <Grid item xs={12}>
-        <Typography variant="body2" style={headerStyle}>
-          BANNERS
-        </Typography>
-      </Grid>
-    </Grid>
-  </div>
-);
-
-const fullHeader = (
-  <Grid container direction="row" style={headerStyle}>
-    <Grid item xs={1}>
-      <Typography style={headerStyle}>ID</Typography>
-    </Grid>
-    <Grid item xs={3}>
-      <Typography variant="body2" style={headerStyle}>
-        Title
-      </Typography>
-    </Grid>
-    <Grid item xs={7}>
-      <Typography variant="body2" style={headerStyle}>
-        Link URL
-      </Typography>
-    </Grid>
-    <Grid item xs={1}>
-      <Typography variant="body2" style={headerStyle}>
-        Sort Order
-      </Typography>
-    </Grid>
-  </Grid>
-);
 
 const BannerList = ({ banners, handleBannerDelete }) => {
-  const [width] = useWindowSize();
-
   return (
-    <Card>
-      {width < BREAKPOINT_WIDTH ? singleHeader : fullHeader}
-      <List disablePadding>
-        {banners.length > 0 ? (
-          banners.map((banner) => (
-            <Banner
-              banner={banner}
-              size={width < BREAKPOINT_WIDTH ? 'single' : 'full'}
-              handleNewsItemDelete={handleBannerDelete}
-              key={banner.ID}
-            />
-          ))
-        ) : (
-          <Typography variant="h6" align="center">
-            No Banners
-          </Typography>
-        )}
-      </List>
-    </Card>
+    <Container style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      {banners.length > 0 ? (
+        banners.map((banner) => (
+          <Banner banner={banner} handleNewsItemDelete={handleBannerDelete} key={banner.ID} />
+        ))
+      ) : (
+        <Typography variant="h6" align="center">
+          No Banners
+        </Typography>
+      )}
+    </Container>
   );
 };
 

--- a/src/views/BannerSubmission/components/NewBannerDialog/NewBannerDialog.module.scss
+++ b/src/views/BannerSubmission/components/NewBannerDialog/NewBannerDialog.module.scss
@@ -1,0 +1,21 @@
+@import '../../../../vars';
+
+.image_preview {
+  width: 100%;
+}
+
+.dropzone {
+  transition: border-color 100ms, background-color 100ms, box-shadow 100ms;
+  height: 20vh;
+  display: flex;
+  border: 0.2rem dashed darkgray;
+  border-radius: 0.75rem;
+  align-items: center;
+  cursor: pointer;
+  padding-inline: 1rem;
+
+  &:hover {
+    background-color: $neutral-light-gray2;
+    box-shadow: 0 0 0 0.25rem $neutral-light-gray2;
+  }
+}

--- a/src/views/BannerSubmission/components/NewBannerDialog/index.js
+++ b/src/views/BannerSubmission/components/NewBannerDialog/index.js
@@ -30,9 +30,9 @@ const NewBannerDialog = ({ open, setOpen, createSnackbar, addBanner }) => {
 
     let result = await cmsService.submitSlide(bannerItem);
     if (result === undefined) {
-      createSnackbar('Banner Submission Failed to Submit', 'error');
+      createSnackbar('Sorry, banner submission failed', 'error');
     } else {
-      createSnackbar('Banner Submission Submitted Successfully', 'success');
+      createSnackbar('Successfully submitted banner', 'success');
       handleWindowClose();
       addBanner(result);
     }
@@ -85,17 +85,14 @@ const NewBannerDialog = ({ open, setOpen, createSnackbar, addBanner }) => {
             reader.onload = () => setImage(reader.result);
             reader.onerror = () =>
               createSnackbar(
-                'That image failed to load. Please try a different image or contact CTS for help.',
+                'Image failed to load. Please try a different image or contact CTS for help.',
                 'error',
               );
 
             reader.readAsDataURL(file);
           }}
           onDropRejected={() =>
-            createSnackbar(
-              'Sorry, invalid image file! Only PNG and JPEG images are accepted.',
-              'error',
-            )
+            createSnackbar('Invalid image file. Only PNG and JPEG images are accepted.', 'error')
           }
           accept="image/jpeg, image/jpg, image/png"
           maxFiles={1}

--- a/src/views/BannerSubmission/components/NewBannerDialog/index.js
+++ b/src/views/BannerSubmission/components/NewBannerDialog/index.js
@@ -12,18 +12,8 @@ import Cropper from 'react-cropper';
 import { isMobile } from 'react-device-detect';
 import Dropzone from 'react-dropzone';
 import cmsService from 'services/cms';
-import { gordonColors } from 'theme';
 
 const CROP_DIM = 200; // Width of cropped image canvas
-
-const styles = {
-  cancelButton: {
-    backgroundColor: 'white',
-    color: gordonColors.primary.blue,
-    border: `1px solid ${gordonColors.primary.blue}`,
-    width: '38%',
-  },
-};
 
 const NewBannerDialog = ({ open, setOpen, createSnackbar, addBanner }) => {
   const [title, setTitle] = useState('');
@@ -217,7 +207,6 @@ const NewBannerDialog = ({ open, setOpen, createSnackbar, addBanner }) => {
               <Button
                 variant="contained"
                 onClick={() => setCropperImageData(null)}
-                style={styles.cancelButton}
                 className="gc360_photo_dialog_box_content_button"
               >
                 Remove picture

--- a/src/views/BannerSubmission/components/NewBannerDialog/index.js
+++ b/src/views/BannerSubmission/components/NewBannerDialog/index.js
@@ -1,0 +1,249 @@
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  TextField,
+  Tooltip,
+} from '@material-ui/core';
+import GordonDialogBox from 'components/GordonDialogBox';
+import { useRef, useState } from 'react';
+import Cropper from 'react-cropper';
+import { isMobile } from 'react-device-detect';
+import Dropzone from 'react-dropzone';
+import cmsService from 'services/cms';
+import { gordonColors } from 'theme';
+
+const CROP_DIM = 200; // Width of cropped image canvas
+
+const styles = {
+  cancelButton: {
+    backgroundColor: 'white',
+    color: gordonColors.primary.blue,
+    border: `1px solid ${gordonColors.primary.blue}`,
+    width: '38%',
+  },
+};
+
+const NewBannerDialog = ({ open, setOpen, createSnackbar, addBanner }) => {
+  const [title, setTitle] = useState('');
+  const [link, setLink] = useState('');
+  const [sortOrder, setSortOrder] = useState(0);
+  const [cropperImageData, setCropperImageData] = useState(null);
+  const [photoDialogErrorTimeout, setPhotoDialogErrorTimeout] = useState(null);
+  const [photoDialogError, setPhotoDialogError] = useState(null);
+  const cropperRef = useRef();
+  const [aspectRatio, setAspectRatio] = useState(null);
+
+  function handleWindowClose() {
+    setOpen(false);
+    setTitle('');
+    setLink('');
+    setSortOrder(0);
+    setCropperImageData(null);
+  }
+
+  async function clearPhotoDialogErrorTimeout() {
+    clearTimeout(photoDialogErrorTimeout);
+    setPhotoDialogErrorTimeout(null);
+    setPhotoDialogError(null);
+  }
+
+  function createPhotoDialogBoxMessage() {
+    let message = '';
+    // If an error occured and there's no currently running timeout, the error is displayed
+    // and a timeout for that error message is created
+    if (photoDialogError !== null) {
+      message = <span style={{ color: '#B63228' }}>{photoDialogError}</span>;
+      if (photoDialogErrorTimeout === null) {
+        // Shows the error message for 6 seconds and then returns back to normal text
+        setPhotoDialogErrorTimeout(
+          setTimeout(() => {
+            setPhotoDialogErrorTimeout(null);
+            setPhotoDialogError(null);
+          }, 6000),
+        );
+      }
+    }
+
+    // If no error occured and the cropper is shown, the cropper text is displayed
+    else if (cropperImageData) {
+      message = 'Crop Photo to liking & Click Submit';
+    }
+
+    // If no error occured and the cropper is not shown, the pick a file text is displayed
+    else {
+      message = isMobile
+        ? 'Tap Image to Browse Files'
+        : 'Drag & Drop Picture, or Click to Browse Files';
+    }
+    return message;
+  }
+
+  function onCropperZoom(event) {
+    if (event.detail.ratio > 1) {
+      event.preventDefault();
+      cropperRef.current.cropper.zoomTo(1);
+    }
+  }
+
+  function onDropAccepted(fileList) {
+    var previewImageFile = fileList[0];
+    var reader = new FileReader();
+    reader.onload = () => {
+      imageOnLoadHelper(reader);
+    };
+    reader.readAsDataURL(previewImageFile);
+  }
+
+  async function onDropRejected() {
+    await clearPhotoDialogErrorTimeout();
+    setPhotoDialogError('Sorry, invalid image file! Only PNG and JPEG images are accepted.');
+  }
+
+  async function handleSubmit() {
+    const newImage = cropperRef.current.cropper
+      .getCroppedCanvas({ width: CROP_DIM })
+      .toDataURL()
+      .replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
+
+    let bannerItem = {
+      Title: title,
+      LinkURL: link,
+      SortOrder: sortOrder,
+      ImageData: newImage,
+    };
+
+    let result = await cmsService.submitSlide(bannerItem);
+    if (result === undefined) {
+      createSnackbar('Banner Submission Failed to Submit', 'error');
+    } else {
+      createSnackbar('Banner Submission Submitted Successfully', 'success');
+      handleWindowClose();
+      addBanner(result);
+    }
+  }
+
+  function imageOnLoadHelper(reader) {
+    var dataURL = reader.result.toString();
+    var i = new Image();
+    i.onload = async () => {
+      var aRatio = i.width / i.height;
+      setAspectRatio(aRatio);
+      setPhotoDialogError(null);
+      setAspectRatio(aRatio);
+      setCropperImageData(dataURL);
+    };
+    i.src = dataURL;
+  }
+
+  return (
+    <GordonDialogBox
+      open={open}
+      title="Make a new Banner"
+      buttonClicked={handleSubmit}
+      buttonName={'Submit'}
+      isButtonDisabled={!Boolean(title && cropperImageData && sortOrder)}
+      cancelButtonClicked={handleWindowClose}
+      cancelButtonName="Cancel"
+    >
+      <TextField
+        label="Subject"
+        variant="filled"
+        margin="dense"
+        fullWidth
+        name="newBannerTitle"
+        value={title}
+        onChange={(event) => setTitle(event.target.value)}
+        helperText="Enter title to show if image fails to load"
+        required
+      />
+
+      <TextField
+        variant="filled"
+        label="URL"
+        margin="dense"
+        fullWidth
+        name="newBannerWebLink"
+        value={link}
+        onChange={(event) => setLink(event.target.value)}
+        helperText="Enter URL that banner should link to, if any"
+      />
+
+      <div className="gc360_photo_dialog_box">
+        <DialogContent className="gc360_photo_dialog_box_content">
+          <DialogContentText className="gc360_photo_dialog_box_content_text">
+            {createPhotoDialogBoxMessage()}
+          </DialogContentText>
+          {!cropperImageData && (
+            <Dropzone
+              onDropAccepted={onDropAccepted}
+              onDropRejected={onDropRejected}
+              accept="image/jpeg, image/jpg, image/png"
+            >
+              {({ getRootProps, getInputProps }) => (
+                <section>
+                  <div className="gc360_photo_dialog_box_content_dropzone" {...getRootProps()}>
+                    <input {...getInputProps()} />
+                  </div>
+                </section>
+              )}
+            </Dropzone>
+          )}
+          {cropperImageData && (
+            <div className="gc360_photo_dialog_box_content_cropper">
+              <Cropper
+                ref={cropperRef}
+                src={cropperImageData}
+                autoCropArea={1}
+                viewMode={3}
+                aspectRatio={aspectRatio}
+                highlight={false}
+                background={false}
+                zoom={onCropperZoom}
+                zoomable={false}
+                dragMode={'none'}
+              />
+            </div>
+          )}
+        </DialogContent>
+        <DialogActions className="gc360_photo_dialog_box_actions_top">
+          {cropperImageData && (
+            <Tooltip
+              classes={{ tooltip: 'tooltip' }}
+              id="tooltip-hide"
+              title="Remove this image from the submission"
+            >
+              <Button
+                variant="contained"
+                onClick={() => setCropperImageData(null)}
+                style={styles.cancelButton}
+                className="gc360_photo_dialog_box_content_button"
+              >
+                Remove picture
+              </Button>
+            </Tooltip>
+          )}
+        </DialogActions>
+      </div>
+
+      <TextField
+        id="outlined-number"
+        variant="filled"
+        label="Sort Order"
+        type="number"
+        margin="dense"
+        fullWidth
+        name="newBannerSortOrderNumber"
+        value={sortOrder}
+        InputLabelProps={{
+          shrink: true,
+        }}
+        onChange={(event) => setSortOrder(event.target.value)}
+        required
+      />
+    </GordonDialogBox>
+  );
+};
+
+export default NewBannerDialog;

--- a/src/views/BannerSubmission/components/NewBannerDialog/index.js
+++ b/src/views/BannerSubmission/components/NewBannerDialog/index.js
@@ -140,7 +140,7 @@ const NewBannerDialog = ({ open, setOpen, createSnackbar, addBanner }) => {
   return (
     <GordonDialogBox
       open={open}
-      title="Make a new Banner"
+      title="Add a new Banner"
       buttonClicked={handleSubmit}
       buttonName={'Submit'}
       isButtonDisabled={!Boolean(title && cropperImageData && sortOrder)}
@@ -148,11 +148,11 @@ const NewBannerDialog = ({ open, setOpen, createSnackbar, addBanner }) => {
       cancelButtonName="Cancel"
     >
       <TextField
-        label="Subject"
+        label="Banner Title"
         variant="filled"
         margin="dense"
         fullWidth
-        name="newBannerTitle"
+        name="title"
         value={title}
         onChange={(event) => setTitle(event.target.value)}
         helperText="Enter title to show if image fails to load"
@@ -161,10 +161,10 @@ const NewBannerDialog = ({ open, setOpen, createSnackbar, addBanner }) => {
 
       <TextField
         variant="filled"
-        label="URL"
+        label="Banner Link URL"
         margin="dense"
         fullWidth
-        name="newBannerWebLink"
+        name="link"
         value={link}
         onChange={(event) => setLink(event.target.value)}
         helperText="Enter URL that banner should link to, if any"
@@ -234,7 +234,7 @@ const NewBannerDialog = ({ open, setOpen, createSnackbar, addBanner }) => {
         type="number"
         margin="dense"
         fullWidth
-        name="newBannerSortOrderNumber"
+        name="sortOrder"
         value={sortOrder}
         InputLabelProps={{
           shrink: true,

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -5,7 +5,7 @@ import { useAuth, useNetworkStatus } from 'hooks';
 import { useEffect, useState } from 'react';
 import storageService from 'services/storage';
 import { gordonColors } from 'theme';
-import { BannerAdmin } from './components/BannerAdmin';
+import BannerAdmin from './components/BannerAdmin';
 
 const style = {
   color: gordonColors.primary.blue,

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -1,39 +1,11 @@
-//Theme and styling
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  Fab,
-  Grid,
-  TextField,
-  Tooltip,
-  Typography,
-} from '@material-ui/core';
-import PostAddIcon from '@material-ui/icons/PostAdd';
-//Designed components
-import GordonDialogBox from 'components/GordonDialogBox';
+import { Button, Card, CardContent, CardHeader, Grid, Typography } from '@material-ui/core';
 import GordonOffline from 'components/GordonOffline';
 import GordonUnauthorized from 'components/GordonUnauthorized';
-import GordonLoader from 'components/Loader';
-import GordonSnackbar from 'components/Snackbar';
 import { useAuth, useNetworkStatus } from 'hooks';
-//React and local services/hooks
-import { useEffect, useRef, useState } from 'react';
-//External components
-import Cropper from 'react-cropper';
-import { isMobile } from 'react-device-detect';
-import Dropzone from 'react-dropzone';
-import cmsService from 'services/cms';
+import { useEffect, useState } from 'react';
 import storageService from 'services/storage';
 import { gordonColors } from 'theme';
-//Subcomponents
-import BannerList from './components/BannerList';
-
-const CROP_DIM = 200; // Width of cropped image canvas
+import { BannerAdmin } from './components/BannerAdmin';
 
 const style = {
   color: gordonColors.primary.blue,
@@ -45,222 +17,20 @@ const style = {
   },
 };
 
-const styles2 = {
-  button: {
-    background: gordonColors.primary.blue,
-    color: 'white',
-
-    changeImageButton: {
-      background: gordonColors.primary.blue,
-      color: 'white',
-    },
-
-    resetButton: {
-      backgroundColor: '#f44336',
-      color: 'white',
-    },
-    cancelButton: {
-      backgroundColor: 'white',
-      color: gordonColors.primary.blue,
-      border: `1px solid ${gordonColors.primary.blue}`,
-      width: '38%',
-    },
-    hidden: {
-      display: 'none',
-    },
-  },
-  searchBar: {
-    margin: '0 auto',
-  },
-  newNewsForm: {
-    backgroundColor: '#fff',
-  },
-  fab: {
-    margin: 0,
-    top: 'auto',
-    right: 40,
-    bottom: 40,
-    left: 'auto',
-    position: 'fixed',
-    zIndex: 1,
-  },
-};
-
 const BannerSubmission = () => {
   const authenticated = useAuth();
   const isOnline = useNetworkStatus();
   const [isAdmin, setIsAdmin] = useState(false);
-  const [loading, setLoading] = useState(true);
-
-  //Solely for banner management
-  const [banners, setBanners] = useState([]);
-  const [newBannerTitle, setNewBannerTitle] = useState('');
-  const [newBannerWebLink, setNewBannerWebLink] = useState('');
-  const [newBannerSortOrder, setNewBannerSortOrder] = useState(0);
-  const [openBannerActivity, setOpenBannerActivity] = useState(false);
-
-  //Solely for photo functions
-  const [cropperImageData, setCropperImageData] = useState(null); //null if no picture chosen, else contains picture
-  const [photoDialogErrorTimeout, setPhotoDialogErrorTimeout] = useState(null);
-  const [photoDialogError, setPhotoDialogError] = useState(null);
-  const [snackbar, setSnackbar] = useState({ open: false, text: '', severity: '' });
-  const cropperRef = useRef();
-  const [aspectRatio, setAspectRatio] = useState(null);
 
   useEffect(() => {
     const loadPage = async () => {
-      setLoading(true);
       if (authenticated) {
         setIsAdmin(storageService.getLocalInfo().college_role === 'god');
-        const existingBanners = await cmsService.getSlides();
-        setBanners(existingBanners);
       }
-      setLoading(false);
     };
 
     loadPage();
   }, [authenticated]);
-
-  function handlePostClick() {
-    setOpenBannerActivity(true);
-  }
-
-  function handleWindowClose() {
-    setOpenBannerActivity(false);
-    setNewBannerTitle('');
-    setNewBannerWebLink('');
-    setCropperImageData(null);
-  }
-
-  const createSnackbar = (text, severity) => {
-    setSnackbar({ open: true, text, severity });
-  };
-
-  /**********************************************************
-  /*Following functions are solely related to photo submission*
-  /**********************************************************/
-
-  async function clearPhotoDialogErrorTimeout() {
-    clearTimeout(photoDialogErrorTimeout);
-    setPhotoDialogErrorTimeout(null);
-    setPhotoDialogError(null);
-  }
-
-  /**
-   * Creates the Photo Dialog message that will be displayed to the user
-   *
-   * @returns {string} The message of the Photo Dialog
-   */
-  function createPhotoDialogBoxMessage() {
-    let message = '';
-    // If an error occured and there's no currently running timeout, the error is displayed
-    // and a timeout for that error message is created
-    if (photoDialogError !== null) {
-      message = <span style={{ color: '#B63228' }}>{photoDialogError}</span>;
-      if (photoDialogErrorTimeout === null) {
-        // Shows the error message for 6 seconds and then returns back to normal text
-        setPhotoDialogErrorTimeout(
-          setTimeout(() => {
-            setPhotoDialogErrorTimeout(null);
-            setPhotoDialogError(null);
-          }, 6000),
-        );
-      }
-    }
-
-    // If no error occured and the cropper is shown, the cropper text is displayed
-    else if (cropperImageData) {
-      message = 'Crop Photo to liking & Click Submit';
-    }
-
-    // If no error occured and the cropper is not shown, the pick a file text is displayed
-    else {
-      message = isMobile
-        ? 'Tap Image to Browse Files'
-        : 'Drag & Drop Picture, or Click to Browse Files';
-    }
-    return message;
-  }
-
-  function onCropperZoom(event) {
-    if (event.detail.ratio > 1) {
-      event.preventDefault();
-      cropperRef.current.cropper.zoomTo(1);
-    }
-  }
-
-  /**
-   * Handles the acceptance of the user dropping an image in the Photo Uploader in News submission
-   *
-   * @param {*} fileList The image dropped in the Dropzone of the Photo Uploader
-   */
-  function onDropAccepted(fileList) {
-    var previewImageFile = fileList[0];
-    var reader = new FileReader();
-    reader.onload = () => {
-      imageOnLoadHelper(reader);
-    };
-    reader.readAsDataURL(previewImageFile);
-  }
-
-  /**
-   * Handles the rejection of the user dropping an invalid file in the Photo Updater Dialog Box
-   * Copied from Identification
-   */
-  async function onDropRejected() {
-    await clearPhotoDialogErrorTimeout();
-    setPhotoDialogError('Sorry, invalid image file! Only PNG and JPEG images are accepted.');
-  }
-
-  async function handleSubmit() {
-    const newImage = cropperRef.current.cropper
-      .getCroppedCanvas({ width: CROP_DIM })
-      .toDataURL()
-      .replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
-
-    let bannerItem = {
-      Title: newBannerTitle,
-      LinkURL: newBannerWebLink,
-      SortOrder: newBannerSortOrder,
-      ImageData: newImage,
-    };
-
-    let result = await cmsService.submitSlide(bannerItem);
-    if (result === undefined) {
-      createSnackbar('Banner Submission Failed to Submit', 'error');
-    } else {
-      createSnackbar('Banner Submission Submitted Successfully', 'success');
-      handleWindowClose();
-      setBanners((b) => [...b, result]);
-    }
-  }
-
-  async function handleBannerDelete(ID) {
-    let result = await cmsService.deleteSlide(ID);
-    if (result === undefined) {
-      createSnackbar('Banner Failed to Delete', 'error');
-    } else {
-      setBanners((b) => b.filter((banner) => banner.ID !== ID));
-      createSnackbar('Banner Deleted Successfully', 'success');
-    }
-  }
-
-  function imageOnLoadHelper(reader) {
-    var dataURL = reader.result.toString();
-    var i = new Image();
-    i.onload = async () => {
-      var aRatio = i.width / i.height;
-      setAspectRatio(aRatio);
-      setPhotoDialogError(null);
-      setAspectRatio(aRatio);
-      setCropperImageData(dataURL);
-    };
-    i.src = dataURL;
-  }
-
-  /***************************************************
-  /*End of methods solely related to photo submission*
-  /***************************************************/
 
   if (!authenticated) {
     return <GordonUnauthorized feature={'the banner submission'} />;
@@ -270,161 +40,11 @@ const BannerSubmission = () => {
     return <GordonOffline feature="Banner Sumission" />;
   }
 
-  return isAdmin ? (
-    <>
-      <Fab variant="extended" color="primary" onClick={handlePostClick} style={styles2.fab}>
-        <PostAddIcon />
-        Add a Banner
-      </Fab>
-      <GordonDialogBox
-        open={openBannerActivity}
-        title="Make a new Banner"
-        buttonClicked={handleSubmit}
-        buttonName={'Submit'}
-        isButtonDisabled={!Boolean(newBannerTitle && cropperImageData && newBannerSortOrder)}
-        cancelButtonClicked={handleWindowClose}
-        cancelButtonName="Cancel"
-      >
-        <Grid container>
-          {/* TITLE ENTRY */}
-          <Grid item xs={12}>
-            <TextField
-              label="Subject"
-              variant="filled"
-              margin="dense"
-              fullWidth
-              name="newBannerTitle"
-              value={newBannerTitle}
-              onChange={(event) => {
-                setNewBannerTitle(event.target.value);
-              }}
-              // helperText="Please enter a title."
-            />
-          </Grid>
+  if (isAdmin) {
+    return <BannerAdmin />;
+  }
 
-          {/* LINK ENTRY */}
-          <Grid item xs={12}>
-            <TextField
-              variant="filled"
-              label="URL"
-              // margin="normal"
-              margin="dense"
-              //multiline
-              fullWidth
-              //rows={4}
-              name="newBannerWebLink"
-              value={newBannerWebLink}
-              onChange={(event) => {
-                setNewBannerWebLink(event.target.value);
-              }}
-              // helperText="Please enter a link."
-            />
-          </Grid>
-
-          {/* IMAGE ENTRY */}
-          <Grid item xs={12}>
-            <div className="gc360_photo_dialog_box">
-              <DialogContent className="gc360_photo_dialog_box_content">
-                <DialogContentText className="gc360_photo_dialog_box_content_text">
-                  {createPhotoDialogBoxMessage()}
-                </DialogContentText>
-                {!cropperImageData && (
-                  <Dropzone
-                    onDropAccepted={onDropAccepted}
-                    onDropRejected={onDropRejected}
-                    accept="image/jpeg, image/jpg, image/png"
-                  >
-                    {({ getRootProps, getInputProps }) => (
-                      <section>
-                        <div
-                          className="gc360_photo_dialog_box_content_dropzone"
-                          {...getRootProps()}
-                        >
-                          <input {...getInputProps()} />
-                        </div>
-                      </section>
-                    )}
-                  </Dropzone>
-                )}
-                {cropperImageData && (
-                  <div className="gc360_photo_dialog_box_content_cropper">
-                    <Cropper
-                      ref={cropperRef}
-                      src={cropperImageData}
-                      autoCropArea={1}
-                      viewMode={3}
-                      aspectRatio={aspectRatio}
-                      highlight={false}
-                      background={false}
-                      zoom={onCropperZoom}
-                      zoomable={false}
-                      dragMode={'none'}
-                    />
-                  </div>
-                )}
-              </DialogContent>
-              <DialogActions className="gc360_photo_dialog_box_actions_top">
-                {cropperImageData && (
-                  <Tooltip
-                    classes={{ tooltip: 'tooltip' }}
-                    id="tooltip-hide"
-                    title="Remove this image from the submission"
-                  >
-                    <Button
-                      variant="contained"
-                      onClick={() => {
-                        setCropperImageData(null);
-                      }}
-                      style={styles2.button.cancelButton}
-                      className="gc360_photo_dialog_box_content_button"
-                    >
-                      Remove picture
-                    </Button>
-                  </Tooltip>
-                )}
-              </DialogActions>
-            </div>
-          </Grid>
-        </Grid>
-
-        {/* SORT ORDER NUMBER ENTRY */}
-        <Grid item xs={12}>
-          <TextField
-            id="outlined-number"
-            variant="filled"
-            label="Number"
-            type="number"
-            margin="dense"
-            fullWidth
-            name="newBannerSortOrderNumber"
-            value={newBannerSortOrder}
-            InputLabelProps={{
-              shrink: true,
-            }}
-            onChange={(event) => {
-              setNewBannerSortOrder(event.target.value);
-            }}
-          />
-        </Grid>
-      </GordonDialogBox>
-
-      {/* USER FEEDBACK */}
-      <GordonSnackbar
-        {...snackbar}
-        onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
-        anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
-      />
-
-      <Grid item xs={12} lg={8} style={{ marginBottom: '7rem' }}>
-        {/* list of banners */}
-        {loading ? (
-          <GordonLoader />
-        ) : (
-          <BannerList banners={banners} handleBannerDelete={handleBannerDelete} />
-        )}
-      </Grid>
-    </>
-  ) : (
+  return (
     <Grid container justifyContent="center">
       <Grid item xs={12} lg={8}>
         <Card>

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -1,38 +1,36 @@
 //Theme and styling
-import { gordonColors } from 'theme';
 import {
   Button,
+  Card,
+  CardContent,
+  CardHeader,
   DialogActions,
   DialogContent,
   DialogContentText,
   Fab,
   Grid,
-  MenuItem,
   TextField,
   Tooltip,
   Typography,
 } from '@material-ui/core';
 import PostAddIcon from '@material-ui/icons/PostAdd';
-import { Card, CardContent, CardHeader } from '@material-ui/core';
-
-//External components
-import Cropper from 'react-cropper';
-import Dropzone from 'react-dropzone';
-import { isMobile } from 'react-device-detect';
-
-//React and local services/hooks
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useAuth, useNetworkStatus } from 'hooks';
-import userService from 'services/user';
-import cmsService from 'services/cms';
-
 //Designed components
 import GordonDialogBox from 'components/GordonDialogBox';
-import GordonLoader from 'components/Loader';
 import GordonOffline from 'components/GordonOffline';
-import GordonSnackbar from 'components/Snackbar';
 import GordonUnauthorized from 'components/GordonUnauthorized';
-
+import GordonLoader from 'components/Loader';
+import GordonSnackbar from 'components/Snackbar';
+import { useAuth, useNetworkStatus } from 'hooks';
+//React and local services/hooks
+import { useCallback, useEffect, useRef, useState } from 'react';
+//External components
+import Cropper from 'react-cropper';
+import { isMobile } from 'react-device-detect';
+import Dropzone from 'react-dropzone';
+import cmsService from 'services/cms';
+import storageService from 'services/storage';
+import userService from 'services/user';
+import { gordonColors } from 'theme';
 //Subcomponents
 import BannerList from './components/BannerList';
 
@@ -136,7 +134,7 @@ const BannerSubmission = () => {
 
   useEffect(() => {
     if (authenticated) {
-      setIsAdmin(userService.getLocalInfo().college_role === 'god');
+      setIsAdmin(storageService.getLocalInfo().college_role === 'god');
     }
   }, [authenticated]);
 
@@ -232,23 +230,19 @@ const BannerSubmission = () => {
   }
 
   async function handleSubmit() {
-    let newImage;
-    //No check required because the submit button is not enabled if the cropper doesn't have anything.
-    //Theoretically.
-    //if (cropperImageData !== null) {
-    let croppedImage = cropperRef.current.cropper.getCroppedCanvas({ width: CROP_DIM }).toDataURL();
-    newImage = croppedImage.replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
-    //}
+    const newImage = cropperRef.current.cropper
+      .getCroppedCanvas({ width: CROP_DIM })
+      .toDataURL()
+      .replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
 
     let bannerItem = {
-      Picture: newImage,
       Title: newBannerTitle,
       LinkURL: newBannerWebLink,
-      Order: newBannerSortOrder,
+      SortOrder: newBannerSortOrder,
+      ImageData: newImage,
     };
 
-    // submit the banner item and give feedback
-    let result = await cmsService.submitBanner(bannerItem);
+    let result = await cmsService.submitSlide(bannerItem);
     if (result === undefined) {
       createSnackbar('Banner Submission Failed to Submit', 'error');
     } else {
@@ -265,7 +259,7 @@ const BannerSubmission = () => {
    */
   async function handleBannerDelete(ID) {
     // delete the banner item and give feedback
-    let result = await cmsService.deleteBanner(ID);
+    let result = await cmsService.deleteSlide(ID);
     if (result === undefined) {
       createSnackbar('Banner Failed to Delete', 'error');
     } else {
@@ -318,14 +312,12 @@ const BannerSubmission = () => {
     if (isOnline) {
       bannerJSX = (
         <>
-          <>
-            {isAdmin && (
-              <Fab variant="extended" color="primary" onClick={handlePostClick} style={styles2.fab}>
-                <PostAddIcon />
-                Add a Banner
-              </Fab>
-            )}
-          </>
+          {isAdmin && (
+            <Fab variant="extended" color="primary" onClick={handlePostClick} style={styles2.fab}>
+              <PostAddIcon />
+              Add a Banner
+            </Fab>
+          )}
 
           <Grid container justifyContent="center">
             <Grid item xs={12} lg={8}>

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -1,6 +1,42 @@
+//Theme and styling
 import { gordonColors } from 'theme';
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  Fab,
+  Grid,
+  MenuItem,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+import PostAddIcon from '@material-ui/icons/PostAdd';
+import { Card, CardContent, CardHeader } from '@material-ui/core';
 
-import { Typography, Grid, Button, Card, CardContent, CardHeader } from '@material-ui/core';
+//External components
+import Cropper from 'react-cropper';
+import Dropzone from 'react-dropzone';
+import { isMobile } from 'react-device-detect';
+
+//React and local services/hooks
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth, useNetworkStatus } from 'hooks';
+import userService from 'services/user';
+import cmsService from 'services/cms';
+
+//Designed components
+import GordonDialogBox from 'components/GordonDialogBox';
+import GordonLoader from 'components/Loader';
+import GordonOffline from 'components/GordonOffline';
+import GordonSnackbar from 'components/Snackbar';
+import GordonUnauthorized from 'components/GordonUnauthorized';
+
+//Subcomponents
+import BannerList from './components/BannerList'; //This won't work yet.
+
+const CROP_DIM = 200; // Width of cropped image canvas
 
 const style = {
   color: gordonColors.primary.blue,
@@ -12,47 +48,485 @@ const style = {
   },
 };
 
+const styles2 = {
+  button: {
+    background: gordonColors.primary.blue,
+    color: 'white',
+
+    changeImageButton: {
+      background: gordonColors.primary.blue,
+      color: 'white',
+    },
+
+    resetButton: {
+      backgroundColor: '#f44336',
+      color: 'white',
+    },
+    cancelButton: {
+      backgroundColor: 'white',
+      color: gordonColors.primary.blue,
+      border: `1px solid ${gordonColors.primary.blue}`,
+      width: '38%',
+    },
+    hidden: {
+      display: 'none',
+    },
+  },
+  searchBar: {
+    margin: '0 auto',
+  },
+  newNewsForm: {
+    backgroundColor: '#fff',
+  },
+  fab: {
+    margin: 0,
+    top: 'auto',
+    right: 40,
+    bottom: 40,
+    left: 'auto',
+    position: 'fixed',
+    zIndex: 1,
+  },
+};
+
 const BannerSubmission = () => {
-  return (
-    <Grid container justifyContent="center">
-      <Grid item xs={12} lg={8}>
-        <Card>
-          <CardHeader
-            title="Advertise your club or event on the 360 Homepage!"
-            titleTypographyProps={{ variant: 'h4', align: 'center' }}
-            style={{
-              backgroundColor: gordonColors.primary.blue,
-              color: 'white',
-            }}
-          />
-          <CardContent>
-            <Grid container justifyContent="center" direction="column">
-              <Grid item align="left">
-                <Typography variant="h6">Banner Image Guidelines</Typography>
-                <Typography variant="body2">
-                  1. Attach JPG image with a resolution of 1500 by 600.
-                  <br />
-                  2. Text must be clearly legible.
-                  <br />
-                  3. Include a url that you would like the banner image to link to in your email.
-                  <br />
-                  4. All banner images must be approved. There is limited space, so not all images
-                  will be.
-                </Typography>
-              </Grid>
-              <Grid item align="center">
-                <a href="mailto:360@gordon.edu?Subject=Banner Image Submission">
-                  <Button variant="contained" style={style.uploadButton}>
-                    Email the 360 Team
-                  </Button>
-                </a>
-              </Grid>
+  const authenticated = useAuth();
+  const [currentUsername, setCurrentUsername] = useState('');
+  const isOnline = useNetworkStatus();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  //Solely for banner management
+  const [banners, setBanners] = useState([]);
+  const [newBannerTitle, setNewBannerTitle] = useState('');
+  const [newBannerWebLink, setNewBannerWebLink] = useState('');
+  const [newBannerSortOrder, setNewBannerSortOrder] = useState(100);
+  const [openBannerActivity, setOpenBannerActivity] = useState(false);
+
+  //Solely for photo functions
+  const [cropperImageData, setCropperImageData] = useState(null); //null if no picture chosen, else contains picture
+  const [photoDialogErrorTimeout, setPhotoDialogErrorTimeout] = useState(null);
+  const [photoDialogError, setPhotoDialogError] = useState(null);
+  const [snackbar, setSnackbar] = useState({ open: false, text: '', severity: '' });
+  const cropperRef = useRef();
+  const [aspectRatio, setAspectRatio] = useState(null);
+
+  const loadBanners = useCallback(async () => {
+    setLoading(true);
+    if (authenticated) {
+      const existingBanners = await cmsService.getSlides();
+      setLoading(false);
+      setBanners(existingBanners);
+    } else {
+    }
+  }, [authenticated]);
+
+  useEffect(() => {
+    loadBanners();
+  }, [authenticated, loadBanners]);
+
+  useEffect(() => {
+    const loadUsername = async () => {
+      const user = await userService.getProfileInfo();
+      setCurrentUsername(user.AD_Username);
+    };
+
+    loadUsername();
+  }, []);
+
+  useEffect(() => {
+    if (authenticated) {
+      setIsAdmin(userService.getLocalInfo().college_role === 'god');
+    }
+  }, [authenticated]);
+
+  function handlePostClick() {
+    setOpenBannerActivity(true);
+  }
+
+  function handleWindowClose() {
+    setOpenBannerActivity(false);
+    setNewBannerTitle('');
+    setNewBannerWebLink('');
+    setCropperImageData(null);
+  }
+
+  const createSnackbar = (text, severity) => {
+    setSnackbar({ open: true, text, severity });
+  };
+
+  /**********************************************************
+  /*Following functions are solely related to photo submission*
+  /**********************************************************/
+
+  async function clearPhotoDialogErrorTimeout() {
+    clearTimeout(photoDialogErrorTimeout);
+    setPhotoDialogErrorTimeout(null);
+    setPhotoDialogError(null);
+  }
+
+  /**
+   * Creates the Photo Dialog message that will be displayed to the user
+   *
+   * @returns {string} The message of the Photo Dialog
+   */
+  function createPhotoDialogBoxMessage() {
+    let message = '';
+    // If an error occured and there's no currently running timeout, the error is displayed
+    // and a timeout for that error message is created
+    if (photoDialogError !== null) {
+      message = <span style={{ color: '#B63228' }}>{photoDialogError}</span>;
+      if (photoDialogErrorTimeout === null) {
+        // Shows the error message for 6 seconds and then returns back to normal text
+        setPhotoDialogErrorTimeout(
+          setTimeout(() => {
+            setPhotoDialogErrorTimeout(null);
+            setPhotoDialogError(null);
+          }, 6000),
+        );
+      }
+    }
+
+    // If no error occured and the cropper is shown, the cropper text is displayed
+    else if (cropperImageData) {
+      message = 'Crop Photo to liking & Click Submit';
+    }
+
+    // If no error occured and the cropper is not shown, the pick a file text is displayed
+    else {
+      message = isMobile
+        ? 'Tap Image to Browse Files'
+        : 'Drag & Drop Picture, or Click to Browse Files';
+    }
+    return message;
+  }
+
+  function onCropperZoom(event) {
+    if (event.detail.ratio > 1) {
+      event.preventDefault();
+      cropperRef.current.cropper.zoomTo(1);
+    }
+  }
+
+  /**
+   * Handles the acceptance of the user dropping an image in the Photo Uploader in News submission
+   *
+   * @param {*} fileList The image dropped in the Dropzone of the Photo Uploader
+   */
+  function onDropAccepted(fileList) {
+    var previewImageFile = fileList[0];
+    var reader = new FileReader();
+    reader.onload = () => {
+      imageOnLoadHelper(reader);
+    };
+    reader.readAsDataURL(previewImageFile);
+  }
+
+  /**
+   * Handles the rejection of the user dropping an invalid file in the Photo Updater Dialog Box
+   * Copied from Identification
+   */
+  async function onDropRejected() {
+    await clearPhotoDialogErrorTimeout();
+    setPhotoDialogError('Sorry, invalid image file! Only PNG and JPEG images are accepted.');
+  }
+
+  async function handleSubmit() {
+    let newImage;
+
+    if (cropperImageData !== null) {
+      let croppedImage = cropperRef.current.cropper
+        .getCroppedCanvas({ width: CROP_DIM })
+        .toDataURL();
+      newImage = croppedImage.replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
+    }
+
+    let bannerItem = {
+      categoryID: 1, //bad
+      Subject: newBannerTitle,
+      Body: newBannerWebLink,
+      Image: newImage,
+    };
+
+    // submit the banner item and give feedback
+    let result = await cmsService.submitBanner(bannerItem);
+    if (result === undefined) {
+      createSnackbar('Banner Submission Failed to Submit', 'error');
+    } else {
+      createSnackbar('Banner Submission Submitted Successfully', 'success');
+      handleWindowClose();
+      loadBanners(); //reload banners
+    }
+  }
+
+  /**
+   * When the delete button is clicked for a submission
+   *
+   * @param {number} snid The SNID of the submission to be deleted
+   */
+  async function handleBannerDelete(snid) {
+    // delete the banner item and give feedback
+    let result = await cmsService.deleteBanner(snid);
+    if (result === undefined) {
+      createSnackbar('Banner Failed to Delete', 'error');
+    } else {
+      createSnackbar('Banner Deleted Successfully', 'success');
+    }
+
+    loadBanners();
+  }
+
+  function imageOnLoadHelper(reader) {
+    var dataURL = reader.result.toString();
+    var i = new Image();
+    i.onload = async () => {
+      var aRatio = i.width / i.height;
+      setAspectRatio(aRatio);
+      setPhotoDialogError(null);
+      setAspectRatio(aRatio);
+      setCropperImageData(dataURL);
+    };
+    i.src = dataURL;
+  }
+
+  /***************************************************
+  /*End of methods solely related to photo submission*
+  /***************************************************/
+
+  // if all of the inputs are filled, enable 'submit' button
+  //URL not here because a URL is not required
+  let submitButtonDisabled = newBannerTitle === '' || cropperImageData === '';
+
+  let content;
+
+  //If user is online
+  if (authenticated) {
+    if (loading === true) {
+      content = <GordonLoader />;
+    } else {
+      content = (
+        <BannerList
+          banners={banners}
+          currentUsername={currentUsername}
+          //handleNewsItemEdit={handleNewsItemEdit}
+          handleBannerDelete={handleBannerDelete}
+        />
+      );
+    }
+
+    let bannerJSX;
+
+    if (isOnline) {
+      bannerJSX = (
+        <>
+          <>
+            {isAdmin && (
+              <Fab variant="extended" color="primary" onClick={handlePostClick} style={styles2.fab}>
+                <PostAddIcon />
+                Add a Banner
+              </Fab>
+            )}
+          </>
+
+          <Grid container justifyContent="center">
+            <Grid item xs={12} lg={8}>
+              <Card>
+                <CardHeader
+                  title="Advertise your club or event on the 360 Homepage!"
+                  titleTypographyProps={{ variant: 'h4', align: 'center' }}
+                  style={{
+                    backgroundColor: gordonColors.primary.blue,
+                    color: 'white',
+                  }}
+                />
+                <CardContent>
+                  <Grid container justifyContent="center" direction="column">
+                    <Grid item align="left">
+                      <Typography variant="h6">Banner Image Guidelines</Typography>
+                      <Typography variant="body2">
+                        1. Attach JPG image with a resolution of 1500 by 600.
+                        <br />
+                        2. Text must be clearly legible.
+                        <br />
+                        3. Include a url that you would like the banner image to link to in your
+                        email.
+                        <br />
+                        4. All banner images must be approved. There is limited space, so not all
+                        images will be.
+                      </Typography>
+                    </Grid>
+                    <Grid item align="center">
+                      <a href="mailto:360@gordon.edu?Subject=Banner Image Submission">
+                        <Button variant="contained" style={style.uploadButton}>
+                          Email the 360 Team
+                        </Button>
+                      </a>
+                    </Grid>
+                  </Grid>
+                </CardContent>
+              </Card>
             </Grid>
-          </CardContent>
-        </Card>
-      </Grid>
-    </Grid>
-  );
+
+            {/* Create Posting */}
+            {isAdmin && (
+              <>
+                <GordonDialogBox
+                  open={openBannerActivity}
+                  title="Make a new Banner"
+                  buttonClicked={handleSubmit}
+                  buttonName={'Submit'}
+                  isButtonDisabled={submitButtonDisabled}
+                  cancelButtonClicked={handleWindowClose}
+                  cancelButtonName="Cancel"
+                >
+                  <Grid container>
+                    {/* TITLE ENTRY */}
+                    <Grid item xs={12}>
+                      <TextField
+                        label="Subject"
+                        variant="filled"
+                        margin="dense"
+                        fullWidth
+                        name="newBannerTitle"
+                        value={newBannerTitle}
+                        onChange={(event) => {
+                          setNewBannerTitle(event.target.value);
+                        }}
+                        // helperText="Please enter a title."
+                      />
+                    </Grid>
+
+                    {/* LINK ENTRY */}
+                    <Grid item xs={12}>
+                      <TextField
+                        variant="filled"
+                        label="URL"
+                        // margin="normal"
+                        margin="dense"
+                        //multiline
+                        fullWidth
+                        //rows={4}
+                        name="newBannerWebLink"
+                        value={newBannerWebLink}
+                        onChange={(event) => {
+                          setNewBannerWebLink(event.target.value);
+                        }}
+                        // helperText="Please enter a link."
+                      />
+                    </Grid>
+
+                    {/* IMAGE ENTRY */}
+                    <Grid item xs={12}>
+                      <div className="gc360_photo_dialog_box">
+                        <DialogContent className="gc360_photo_dialog_box_content">
+                          <DialogContentText className="gc360_photo_dialog_box_content_text">
+                            {createPhotoDialogBoxMessage()}
+                          </DialogContentText>
+                          {!cropperImageData && (
+                            <Dropzone
+                              onDropAccepted={onDropAccepted}
+                              onDropRejected={onDropRejected}
+                              accept="image/jpeg, image/jpg, image/png"
+                            >
+                              {({ getRootProps, getInputProps }) => (
+                                <section>
+                                  <div
+                                    className="gc360_photo_dialog_box_content_dropzone"
+                                    {...getRootProps()}
+                                  >
+                                    <input {...getInputProps()} />
+                                  </div>
+                                </section>
+                              )}
+                            </Dropzone>
+                          )}
+                          {cropperImageData && (
+                            <div className="gc360_photo_dialog_box_content_cropper">
+                              <Cropper
+                                ref={cropperRef}
+                                src={cropperImageData}
+                                autoCropArea={1}
+                                viewMode={3}
+                                aspectRatio={aspectRatio}
+                                highlight={false}
+                                background={false}
+                                zoom={onCropperZoom}
+                                zoomable={false}
+                                dragMode={'none'}
+                              />
+                            </div>
+                          )}
+                        </DialogContent>
+                        <DialogActions className="gc360_photo_dialog_box_actions_top">
+                          {cropperImageData && (
+                            <Tooltip
+                              classes={{ tooltip: 'tooltip' }}
+                              id="tooltip-hide"
+                              title="Remove this image from the submission"
+                            >
+                              <Button
+                                variant="contained"
+                                onClick={() => {
+                                  setCropperImageData(null);
+                                }}
+                                style={styles2.button.cancelButton}
+                                className="gc360_photo_dialog_box_content_button"
+                              >
+                                Remove picture
+                              </Button>
+                            </Tooltip>
+                          )}
+                        </DialogActions>
+                      </div>
+                    </Grid>
+                  </Grid>
+
+                  {/* SORT ORDER NUMBER ENTRY */}
+                  <Grid item xs={12}>
+                    <TextField
+                      id="outlined-number"
+                      variant="filled"
+                      label="Number"
+                      type="number"
+                      margin="dense"
+                      fullWidth
+                      name="newBannerSortOrderNumber"
+                      value={newBannerSortOrder}
+                      InputLabelProps={{
+                        shrink: true,
+                      }}
+                      onChange={(event) => {
+                        setNewBannerSortOrder(event.target.value);
+                      }}
+                    />
+                  </Grid>
+                </GordonDialogBox>
+
+                {/* USER FEEDBACK */}
+                <GordonSnackbar
+                  {...snackbar}
+                  onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+                  anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+                />
+
+                <Grid item xs={12} lg={8} style={{ marginBottom: '7rem' }}>
+                  {/* list of banners */}
+                  {content}
+                </Grid>
+              </>
+            )}
+          </Grid>
+        </>
+      );
+      return bannerJSX;
+    }
+    //else if user is not online
+    else {
+      return <GordonOffline feature="Banner Sumission" />;
+    }
+  } else {
+    return <GordonUnauthorized feature={'the banner submission'} />;
+  }
 };
 
 export default BannerSubmission;

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -34,7 +34,7 @@ import GordonSnackbar from 'components/Snackbar';
 import GordonUnauthorized from 'components/GordonUnauthorized';
 
 //Subcomponents
-import BannerList from './components/BannerList'; //This won't work yet.
+import BannerList from './components/BannerList';
 
 const CROP_DIM = 200; // Width of cropped image canvas
 
@@ -100,7 +100,7 @@ const BannerSubmission = () => {
   const [banners, setBanners] = useState([]);
   const [newBannerTitle, setNewBannerTitle] = useState('');
   const [newBannerWebLink, setNewBannerWebLink] = useState('');
-  const [newBannerSortOrder, setNewBannerSortOrder] = useState(100);
+  const [newBannerSortOrder, setNewBannerSortOrder] = useState(-1);
   const [openBannerActivity, setOpenBannerActivity] = useState(false);
 
   //Solely for photo functions
@@ -233,19 +233,18 @@ const BannerSubmission = () => {
 
   async function handleSubmit() {
     let newImage;
-
-    if (cropperImageData !== null) {
-      let croppedImage = cropperRef.current.cropper
-        .getCroppedCanvas({ width: CROP_DIM })
-        .toDataURL();
-      newImage = croppedImage.replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
-    }
+    //No check required because the submit button is not enabled if the cropper doesn't have anything.
+    //Theoretically.
+    //if (cropperImageData !== null) {
+    let croppedImage = cropperRef.current.cropper.getCroppedCanvas({ width: CROP_DIM }).toDataURL();
+    newImage = croppedImage.replace(/data:image\/[A-Za-z]{3,4};base64,/, '');
+    //}
 
     let bannerItem = {
-      categoryID: 1, //bad
-      Subject: newBannerTitle,
-      Body: newBannerWebLink,
-      Image: newImage,
+      Picture: newImage,
+      Title: newBannerTitle,
+      LinkURL: newBannerWebLink,
+      Order: newBannerSortOrder,
     };
 
     // submit the banner item and give feedback
@@ -260,13 +259,13 @@ const BannerSubmission = () => {
   }
 
   /**
-   * When the delete button is clicked for a submission
+   * When the delete button is clicked on a banner
    *
-   * @param {number} snid The SNID of the submission to be deleted
+   * @param {number} ID The ID of the banner to be deleted
    */
-  async function handleBannerDelete(snid) {
+  async function handleBannerDelete(ID) {
     // delete the banner item and give feedback
-    let result = await cmsService.deleteBanner(snid);
+    let result = await cmsService.deleteBanner(ID);
     if (result === undefined) {
       createSnackbar('Banner Failed to Delete', 'error');
     } else {
@@ -295,7 +294,8 @@ const BannerSubmission = () => {
 
   // if all of the inputs are filled, enable 'submit' button
   //URL not here because a URL is not required
-  let submitButtonDisabled = newBannerTitle === '' || cropperImageData === '';
+  let submitButtonDisabled =
+    newBannerTitle === '' || cropperImageData === '' || newBannerSortOrder === -1;
 
   let content;
 
@@ -308,7 +308,6 @@ const BannerSubmission = () => {
         <BannerList
           banners={banners}
           currentUsername={currentUsername}
-          //handleNewsItemEdit={handleNewsItemEdit}
           handleBannerDelete={handleBannerDelete}
         />
       );

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -1,4 +1,12 @@
-import { Button, Card, CardContent, CardHeader, Grid, Typography } from '@material-ui/core';
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Grid,
+  Typography,
+} from '@material-ui/core';
 import GordonOffline from 'components/GordonOffline';
 import GordonUnauthorized from 'components/GordonUnauthorized';
 import { useAuth, useNetworkStatus } from 'hooks';
@@ -8,12 +16,12 @@ import { gordonColors } from 'theme';
 import BannerAdmin from './components/BannerAdmin';
 
 const style = {
-  color: gordonColors.primary.blue,
-
   uploadButton: {
     background: gordonColors.primary.cyan,
     color: 'white',
-    marginTop: '20px',
+  },
+  cardAction: {
+    justifyContent: 'center',
   },
 };
 
@@ -23,13 +31,9 @@ const BannerSubmission = () => {
   const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
-    const loadPage = async () => {
-      if (authenticated) {
-        setIsAdmin(storageService.getLocalInfo().college_role === 'god');
-      }
-    };
-
-    loadPage();
+    if (authenticated) {
+      setIsAdmin(storageService.getLocalInfo().college_role === 'god');
+    }
   }, [authenticated]);
 
   if (!authenticated) {
@@ -57,29 +61,27 @@ const BannerSubmission = () => {
             }}
           />
           <CardContent>
-            <Grid container justifyContent="center" direction="column">
-              <Grid item align="left">
-                <Typography variant="h6">Banner Image Guidelines</Typography>
-                <Typography variant="body2">
-                  1. Attach JPG image with a resolution of 1500 by 600.
-                  <br />
-                  2. Text must be clearly legible.
-                  <br />
-                  3. Include a url that you would like the banner image to link to in your email.
-                  <br />
-                  4. All banner images must be approved. There is limited space, so not all images
-                  will be.
-                </Typography>
-              </Grid>
-              <Grid item align="center">
-                <a href="mailto:360@gordon.edu?Subject=Banner Image Submission">
-                  <Button variant="contained" style={style.uploadButton}>
-                    Email the 360 Team
-                  </Button>
-                </a>
-              </Grid>
-            </Grid>
+            <Typography variant="h6">Banner Image Guidelines</Typography>
+            <Typography variant="body2">
+              1. Attach JPG image with a resolution of 1500 by 600.
+              <br />
+              2. Text must be clearly legible.
+              <br />
+              3. Include a url that you would like the banner image to link to in your email.
+              <br />
+              4. All banner images must be approved. There is limited space, so not all images will
+              be.
+            </Typography>
           </CardContent>
+          <CardActions style={style.cardAction}>
+            <Button
+              variant="contained"
+              style={style.uploadButton}
+              href="mailto:360@gordon.edu?Subject=Banner Image Submission"
+            >
+              Email the 360 Team
+            </Button>
+          </CardActions>
         </Card>
       </Grid>
     </Grid>

--- a/src/views/BannerSubmission/index.js
+++ b/src/views/BannerSubmission/index.js
@@ -63,14 +63,14 @@ const BannerSubmission = () => {
           <CardContent>
             <Typography variant="h6">Banner Image Guidelines</Typography>
             <Typography variant="body2">
-              1. Attach JPG image with a resolution of 1500 by 600.
+              1. Attach JPG or PNG image with a resolution of 1500 by 600.
               <br />
               2. Text must be clearly legible.
               <br />
               3. Include a url that you would like the banner image to link to in your email.
               <br />
-              4. All banner images must be approved. There is limited space, so not all images will
-              be.
+              4. All banner images must be approved. There is limited space, some images may not be
+              accepted.
             </Typography>
           </CardContent>
           <CardActions style={style.cardAction}>

--- a/src/views/Home/components/Carousel/index.js
+++ b/src/views/Home/components/Carousel/index.js
@@ -1,54 +1,52 @@
 import GordonLoader from 'components/Loader';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ImageGallery from 'react-image-gallery';
-import cms from 'services/cms';
+import cmsService from 'services/cms';
+import { compareByProperty, sort } from 'services/utils';
 
 const GordonCarousel = () => {
   const [loading, setLoading] = useState(true);
   const [carouselContent, setCarouselContent] = useState(null);
-  const [imageGallery, setImageGallery] = useState(null);
+  const imageGalleryRef = useRef();
 
   useEffect(() => {
-    const loadCarousel = async () => {
-      setCarouselContent(await cms.getSlides());
-      setLoading(false);
-    };
-
-    loadCarousel();
+    cmsService
+      .getSlides()
+      .then(sort(compareByProperty('SortOrder')))
+      .then(setCarouselContent)
+      .then(() => setLoading(false));
   }, []);
 
   const handleClickSlide = () => {
-    const currentSlideLink = carouselContent[imageGallery.getCurrentIndex()].LinkURL;
+    const currentSlideLink = carouselContent[imageGalleryRef.current.getCurrentIndex()].LinkURL;
     if (currentSlideLink !== '') {
       window.location = currentSlideLink;
     }
   };
 
-  if (loading === true) {
+  if (loading) {
     return <GordonLoader />;
-  } else {
-    return (
-      <ImageGallery
-        ref={(i) => {
-          setImageGallery(i);
-        }}
-        showThumbnails={false}
-        showFullscreenButton={false}
-        showPlayButton={false}
-        showBullets={true}
-        autoPlay={true}
-        showNav={false}
-        slideInterval={5000}
-        items={carouselContent.map((slide) => ({
-          original: slide.Path,
-          originalAlt: slide.Title,
-          originalTitle: slide.Title,
-        }))}
-        onClick={handleClickSlide}
-        lazyLoad={true}
-      />
-    );
   }
+
+  return (
+    <ImageGallery
+      ref={imageGalleryRef}
+      showThumbnails={false}
+      showFullscreenButton={false}
+      showPlayButton={false}
+      showBullets={true}
+      autoPlay={true}
+      showNav={false}
+      slideInterval={5000}
+      items={carouselContent.map((slide) => ({
+        original: slide.Path,
+        originalAlt: slide.Title,
+        originalTitle: slide.Title,
+      }))}
+      onClick={handleClickSlide}
+      lazyLoad={true}
+    />
+  );
 };
 
 export default GordonCarousel;

--- a/src/views/Home/components/Carousel/index.js
+++ b/src/views/Home/components/Carousel/index.js
@@ -1,8 +1,7 @@
-import { useState, useEffect } from 'react';
-
-import cms from 'services/cms';
-import ImageGallery from 'react-image-gallery';
 import GordonLoader from 'components/Loader';
+import { useEffect, useState } from 'react';
+import ImageGallery from 'react-image-gallery';
+import cms from 'services/cms';
 
 const GordonCarousel = () => {
   const [loading, setLoading] = useState(true);
@@ -19,8 +18,9 @@ const GordonCarousel = () => {
   }, []);
 
   const handleClickSlide = () => {
-    if (carouselContent[imageGallery.getCurrentIndex()].ActionLink !== '') {
-      window.location = carouselContent[imageGallery.getCurrentIndex()].ActionLink;
+    const currentSlideLink = carouselContent[imageGallery.getCurrentIndex()].LinkURL;
+    if (currentSlideLink !== '') {
+      window.location = currentSlideLink;
     }
   };
 
@@ -40,8 +40,8 @@ const GordonCarousel = () => {
         showNav={false}
         slideInterval={5000}
         items={carouselContent.map((slide) => ({
-          original: slide.ImagePath,
-          originalAlt: slide.AltTag,
+          original: slide.Path,
+          originalAlt: slide.Title,
           originalTitle: slide.Title,
         }))}
         onClick={handleClickSlide}


### PR DESCRIPTION
Since October 2021, there has been no way for site admins to change the banners on the home page carousel themselves. Instead, they've had to ask CTS to do it. This adds extra work for both parties and is generally cumbersome and undesirable. 

This pull request introduces a banner admin page from which site admins can upload and delete banners. Once gordon-cs/gordon-360-api#683 is merged, site admins will be able to use this page to manage the home page carousel themselves, while regular users will see that same message about how to submit banners for approval. While it might be nice to build an approval process within 360, it would not have any material benefits over the existing email approval process, so it has not been deemed as high priority.

Desktop view:
![image](https://user-images.githubusercontent.com/35319956/161272471-f9f915ee-7c30-44a9-b64a-0234ad51e1b1.png)

Mobile View:
![image](https://user-images.githubusercontent.com/35319956/161611588-5086b0ab-0e42-4d1e-bbf8-1eb7a696d3c4.png)

Add New Banner Dialog:
![image](https://user-images.githubusercontent.com/35319956/161611936-8739eca1-7828-4e04-a67f-fb5397b67bda.png)
![image](https://user-images.githubusercontent.com/35319956/161612138-34d7f8ca-7349-4e8c-8270-dd6cd1fb3611.png)
