### PR TITLE
Wellness: Add StatusDescription

### DIFF
--- a/src/services/wellness.js
+++ b/src/services/wellness.js
@@ -33,6 +33,7 @@ export const StatusColors = {
  * @property {StatusColor} Status The user's status
  * @property {Date} Created when the status was created
  * @property {boolean} IsValid whether the status has expired
+ * @property {string} [StatusDescription] A custom description of the user's status
  */
 
 /**

--- a/src/views/WellnessCheck/components/HealthStatus/HealthStatus.module.scss
+++ b/src/views/WellnessCheck/components/HealthStatus/HealthStatus.module.scss
@@ -29,120 +29,61 @@
   }
 }
 
-.wellness_status {
-  .GREEN {
-    .status_box {
-      height: 250px;
-      background-color: $wellness-green;
-    }
+.animation {
+  text-align: center;
+  height: calc(70px + 3vw);
+  width: calc(70px + 3vw);
+  border-radius: 50%;
+  display: inline-block;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+  background-color: var(--status-background-color);
+  color: var(--status-color);
+  animation-name: statusAnimation;
+}
 
-    .status_time {
-      font-size: calc(14px + 1vw);
-      color: $neutral-white;
-      padding-bottom: 30px;
-    }
+.time {
+  font-size: calc(14px + 1vw);
+  color: var(--status-color);
+  padding-bottom: 30px;
+}
 
-    .status_animation {
-      text-align: center;
-      height: calc(70px + 3vw);
-      width: calc(70px + 3vw);
-      background-color: $wellness-green;
-      color: $neutral-white;
-      border-radius: 50%;
-      display: inline-block;
-      animation-name: animationCheck;
-      animation-duration: 1s;
-      animation-iteration-count: infinite;
-      animation-direction: alternate;
-    }
+.box {
+  height: 250px;
+  background-color: var(--status-background-color);
+}
+
+.status_description {
+  font-size: calc(14px + 1vw);
+  color: var(--status-color);
+}
+
+@keyframes statusAnimation {
+  from {
+    background-color: var(--status-background-color);
+    color: var(--status-color);
   }
 
-  @keyframes animationCheck {
-    from {
-      background-color: $wellness-green;
-      color: $neutral-white;
-    }
-    to {
-      background-color: $neutral-white;
-      color: $wellness-green;
-    }
+  to {
+    background-color: var(--status-color);
+    color: var(--status-background-color);
   }
+}
 
-  .YELLOW {
-    .status_box {
-      height: 250px;
-      background-color: $wellness-yellow;
-    }
+.GREEN {
+  --status-background-color: #{$wellness-green};
+  --status-color: #{$neutral-white};
+}
 
-    .status_time {
-      font-size: calc(14px + 1vw);
-      color: $neutral-dark-gray;
-      padding-bottom: 30px;
-    }
+.YELLOW {
+  --status-background-color: #{$wellness-yellow};
+  --status-color: #{$neutral-dark-gray};
+}
 
-    .status_animation {
-      text-align: center;
-      height: calc(70px + 3vw);
-      width: calc(70px + 3vw);
-      background-color: $wellness-yellow;
-      color: $neutral-dark-gray;
-      border-radius: 50%;
-      display: inline-block;
-      animation-name: animationBar;
-      animation-duration: 1s;
-      animation-iteration-count: infinite;
-      animation-direction: alternate;
-    }
-  }
-
-  @keyframes animationBar {
-    from {
-      background-color: $wellness-yellow;
-      color: $neutral-dark-gray;
-    }
-    to {
-      background-color: $neutral-dark-gray;
-      color: $wellness-yellow;
-    }
-  }
-
-  .RED {
-    .status_box {
-      height: 250px;
-      background-color: $wellness-red;
-    }
-
-    .status_time {
-      font-size: calc(14px + 1vw);
-      color: $neutral-gray2;
-      padding-bottom: 30px;
-    }
-
-    .status_animation {
-      text-align: center;
-      height: calc(70px + 3vw);
-      width: calc(70px + 3vw);
-      background-color: $wellness-red;
-      color: $neutral-gray2;
-      border-radius: 50%;
-      display: inline-block;
-      animation-name: animationCross;
-      animation-duration: 1s;
-      animation-iteration-count: infinite;
-      animation-direction: alternate;
-    }
-  }
-
-  @keyframes animationCross {
-    from {
-      background-color: $wellness-red;
-      color: $neutral-gray2;
-    }
-    to {
-      background-color: $neutral-gray2;
-      color: $wellness-red;
-    }
-  }
+.RED {
+  --status-background-color: #{$wellness-red};
+  --status-color: #{$neutral-gray2};
 }
 
 a.rtc_link {
@@ -158,6 +99,7 @@ a.rtc_link:hover {
 a.contact_link {
   color: $primary-cyan;
   text-decoration: underline;
+
   &:hover {
     text-decoration: underline;
   }

--- a/src/views/WellnessCheck/components/HealthStatus/index.js
+++ b/src/views/WellnessCheck/components/HealthStatus/index.js
@@ -6,7 +6,10 @@ import { useEffect, useState } from 'react';
 import { StatusColors } from 'services/wellness';
 import styles from './HealthStatus.module.css';
 
-const HealthStatus = ({ currentStatus, setCurrentStatus }) => {
+const HealthStatus = ({
+  currentStatus: { Status: currentStatus, StatusDescription },
+  setCurrentStatus,
+}) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [time, setTime] = useState(null);
   const [iconSize, setIconSize] = useState(0);
@@ -70,12 +73,15 @@ const HealthStatus = ({ currentStatus, setCurrentStatus }) => {
               src={`data:image/jpg;base64,${user.images?.pref || user.images.def}`}
               alt={user.profile.fullName}
             />
-            <Grid className={styles.wellness_status}>
+            <Grid>
               <Card className={styles[currentStatus]}>
-                <CardContent className={styles.status_box}>
-                  <div className={styles.status_time}>{time}</div>
+                <CardContent className={styles.box}>
+                  <div className={styles.time}>{time}</div>
 
-                  <div className={styles.status_animation}>{animatedIcon}</div>
+                  <div className={styles.animation}>{animatedIcon}</div>
+                  {StatusDescription && (
+                    <p className={styles.status_description}>Status: {StatusDescription}</p>
+                  )}
                 </CardContent>
               </Card>
               <br />

--- a/src/views/WellnessCheck/index.js
+++ b/src/views/WellnessCheck/index.js
@@ -18,7 +18,7 @@ const WellnessCheck = () => {
 
         const status = await wellness.getStatus();
         if (status && status.IsValid) {
-          setCurrentStatus(status.Status);
+          setCurrentStatus(status);
         }
 
         setLoading(false);
@@ -26,7 +26,7 @@ const WellnessCheck = () => {
     };
 
     loadPage();
-  }, [authenticated, currentStatus]);
+  }, [authenticated]);
 
   if (loading) {
     return <GordonLoader />;


### PR DESCRIPTION
This PR is the counterpart to gordon-cs/gordon-360-api#674. It shows the StatusDescription on the user's HealthStatus, if there is a StatusDescription to show.

It also refactors the HealthStatus scss module to reduce code duplication and simplify it greatly. By using CSS custom properties, we can declare the styles for the component only once, and override the dynamic properties (in this case, just the background and text color) depending on which color of status is showing. This is a much cleaner alternative to the previous approach of redeclaring the same properties for each color, only changing the background and text color (and changing it in several places). This also helps ensure consistency across the styles.