### PR TITLE
HOTFIX: Enrollment check-in display single hold properly

### DIFF
--- a/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/index.js
+++ b/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/index.js
@@ -37,7 +37,7 @@ const displayMajorHolds = (holds) => {
       </li>,
     );
   }
-  return <ul>{majorHolds.join('\n<br />\n')}</ul>;
+  return <ul>{majorHolds.length === 1 ? majorHolds[0] : majorHolds.join('\n<br />\n')}</ul>;
 };
 
 const displayMinorHolds = (holds) => {


### PR DESCRIPTION
The enrollment check in welcome page displays different text depending on what (if any) holds a student has. However, it was not working when the student had a single hold. This has been fixed.