### PR TITLE
Hotfix: Enrollment Check in - Fix major holds

### DIFF
--- a/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/components/MajorHolds/index.js
+++ b/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/components/MajorHolds/index.js
@@ -1,0 +1,42 @@
+import { Grid, Typography } from '@material-ui/core';
+import { gordonColors } from 'theme';
+
+const MajorHolds = ({ holds }) => (
+  <Grid item>
+    <Typography style={{ color: gordonColors.primary.blue }} align="center" variant="h6">
+      <b>Review Your Holds</b>
+    </Typography>
+    <Typography align="center">
+      According to our systems, you should contact the following department(s) in order to clear up
+      certain administrative holds before beginning the check-in process.
+    </Typography>
+    <ul>
+      {holds?.RegistrarHold && (
+        <li>
+          You have a "Registration Hold". Please contact the Registrar's Office at{' '}
+          <b>(978)-867-4243</b> or <a href="mailto:registrar@gordon.edu">registrar@gordon.edu</a>
+        </li>
+      )}
+      {holds?.HighSchoolTranscriptHold && (
+        <li>
+          You have a "High School Transcript Hold". Please contact the Registrar's Office at{' '}
+          <b>(978)-867-4243</b> or <a href="mailto:registrar@gordon.edu">registrar@gordon.edu</a>
+        </li>
+      )}
+      {holds?.FinancialHold && (
+        <li>
+          You have a "Financial Hold". Please contact Student Financial Services at{' '}
+          <b>(978) 867-4246</b> or <a href="sfs@gordon.edu">sfs@gordon.edu</a>.
+        </li>
+      )}
+      {holds?.MedicalHold && (
+        <li>
+          You have a "Medical Hold". Please contact the Health Center at <b>(978)-867-4300</b> or{' '}
+          <a href="mailto:healthcenter@gordon.edu">healthcenter@gordon.edu</a>.
+        </li>
+      )}
+    </ul>
+  </Grid>
+);
+
+export default MajorHolds;

--- a/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/components/MinorHolds/index.js
+++ b/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/components/MinorHolds/index.js
@@ -1,0 +1,29 @@
+import { Grid, Typography } from '@material-ui/core';
+
+const MinorHolds = ({ holds }) => (
+  <Grid item>
+    <Typography>
+      Even though you can still check in while maintaining the following holds, you should contact
+      the following department(s) at your earliest availability:
+    </Typography>
+    <ul>
+      {holds?.LaVidaHold && (
+        <li>
+          You have a "La Vida Hold". Students are required to complete Discovery or La Vida in their
+          first year at Gordon College. Please contact the Registrar's Office at{' '}
+          <b>(978) 867-4243</b> or <a href="registrar@gordon.edu">registrar@gordon.edu</a> so that
+          we can register you for Discovery or La Vida.
+        </li>
+      )}
+      {holds?.MajorHold && (
+        <li>
+          You have a "Declaration of Major Hold". Please contact the <b>Registrar's Office</b> at{' '}
+          <b>(978)-867-4243</b> or <a href="mailto:registrar@gordon.edu">registrar@gordon.edu</a> to
+          discuss declaring a major.
+        </li>
+      )}
+    </ul>
+  </Grid>
+);
+
+export default MinorHolds;

--- a/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/index.js
+++ b/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/index.js
@@ -2,72 +2,8 @@ import { Grid, Typography } from '@material-ui/core';
 import { gordonColors } from 'theme';
 // @TODO CSSMODULES - outside directory
 import styles from '../../EnrollmentCheckIn.module.css';
-
-const displayMajorHolds = (holds) => {
-  const majorHolds = [];
-  if (holds.RegistrarHold) {
-    majorHolds.push(
-      <li>
-        You have a "Registration Hold". Please contact the Registrar's Office at{' '}
-        <b>(978)-867-4243</b> or <a href="mailto:registrar@gordon.edu">registrar@gordon.edu</a>
-      </li>,
-    );
-  }
-  if (holds.HighSchoolTranscriptHold) {
-    majorHolds.push(
-      <li>
-        You have a "High School Transcript Hold". Please contact the Registrar's Office at{' '}
-        <b>(978)-867-4243</b> or <a href="mailto:registrar@gordon.edu">registrar@gordon.edu</a>
-      </li>,
-    );
-  }
-  if (holds.FinancialHold) {
-    majorHolds.push(
-      <li>
-        You have a "Financial Hold". Please contact Student Financial Services at{' '}
-        <b>(978) 867-4246</b> or <a href="sfs@gordon.edu">sfs@gordon.edu</a>.
-      </li>,
-    );
-  }
-  if (holds.MedicalHold) {
-    majorHolds.push(
-      <li>
-        You have a "Medical Hold". Please contact the Health Center at <b>(978)-867-4300</b> or{' '}
-        <a href="mailto:healthcenter@gordon.edu">healthcenter@gordon.edu</a>.
-      </li>,
-    );
-  }
-  return <ul>{majorHolds.length === 1 ? majorHolds[0] : majorHolds.join('\n<br />\n')}</ul>;
-};
-
-const displayMinorHolds = (holds) => {
-  let laVidaContent;
-  let declarationOfMajorContent;
-  if (holds.LaVidaHold) {
-    laVidaContent = (
-      <li>
-        You have a "La Vida Hold". Students are required to complete Discovery or La Vida in their
-        first year at Gordon College. Please contact the Registrar's Office at <b>(978) 867-4243</b>{' '}
-        or <a href="registrar@gordon.edu">registrar@gordon.edu</a> so that we can register you for
-        Discovery or La Vida.
-      </li>
-    );
-  }
-  if (holds.MajorHold) {
-    declarationOfMajorContent = (
-      <li>
-        You have a "Declaration of Major Hold". Please contact the <b>Registrar's Office</b> at{' '}
-        <b>(978)-867-4243</b> or <a href="mailto:registrar@gordon.edu">registrar@gordon.edu</a> to
-        discuss declaring a major.
-      </li>
-    );
-  }
-  return (
-    <ul>
-      {laVidaContent} <br /> {declarationOfMajorContent}
-    </ul>
-  );
-};
+import MajorHolds from './components/MajorHolds';
+import MinorHolds from './components/MinorHolds';
 
 const EnrollmentCheckInWelcome = ({ basicInfo, hasMajorHold, holds }) => {
   const hasMinorHold = holds?.LaVidaHold || holds?.DeclarationOfMajorHold;
@@ -86,18 +22,7 @@ const EnrollmentCheckInWelcome = ({ basicInfo, hasMajorHold, holds }) => {
         <br />
       </Grid>
       <Grid item>
-        {hasMajorHold && ( // If the student has a major hold, they cannot check in
-          <Grid item>
-            <Typography style={{ color: gordonColors.primary.blue }} align="center" variant="h6">
-              <b>Review Your Holds</b>
-            </Typography>
-            <Typography align="center">
-              According to our systems, you should contact the following department(s) in order to
-              clear up certain administrative holds before beginning the check-in process.
-            </Typography>
-            {displayMajorHolds(holds)}
-          </Grid>
-        )}
+        {hasMajorHold && <MajorHolds holds={holds} />}
         {holds?.MustRegisterForClasses && ( // If a student is not registered for courses they cannot check in
           <Grid item>
             <Typography variant="h6" align="center" style={{ color: gordonColors.primary.blue }}>
@@ -122,15 +47,7 @@ const EnrollmentCheckInWelcome = ({ basicInfo, hasMajorHold, holds }) => {
             )}
           </Grid>
         )}
-        {hasMinorHold && ( // If a student has a minor hold, warn them about it
-          <Grid item>
-            <Typography>
-              Even though you can still check in while maintaining the following holds, you should
-              contact the following department(s) at your earliest availability:
-            </Typography>
-            {displayMinorHolds(holds)}
-          </Grid>
-        )}
+        {hasMinorHold && <MinorHolds holds={holds} />}
         <Typography>
           If you are planning to withdraw or take a leave of absence, please contact Student Life at{' '}
           <b>(978)-867-4263</b> or{' '}


### PR DESCRIPTION
It turns out that #1432 broke the holds text for major holds in the enrollment check-in process. I had intended to simplify the `displayMajorHolds` method using an array instead of multiple variables to store the needed hold text. However, displaying the resulting list of holds text using `Array.protoype.join()` did not work as expected because the elements of the array were not string but rather `react.element`s. This meant that when displaying holds, they would be displayed as `[object Object]` to the end user. #1439 fixed this for single holds (which I thought at the time was the only issue), but not for multiple holds.

This hotfix has re-structured the way hold text is displayed. Rather than calling a function that returns the hold text, we now have a React component which is displayed only when needed. The component determines which hold texts to show internally, and so doesn't have to concatenate several hold text elements together.

The hotfix has been tested thoroughly in Train.