### PR TITLE
Fix People Search class filter

### DIFF
--- a/src/services/goStalk.ts
+++ b/src/services/goStalk.ts
@@ -68,7 +68,7 @@ const search = (
   major: string,
   minor: string,
   hall: string,
-  classType: Class,
+  classType: Class | '',
   homeCity: string,
   state: string,
   country: string,
@@ -116,7 +116,7 @@ const search = (
   if (hall === '' || hall === null) {
     hall = CSharp;
   }
-  if (classType === null) {
+  if (classType === '') {
     // @ts-ignore
     classType = CSharp;
   }


### PR DESCRIPTION
People Search was broken since the switch to TypeScript because the class filter defaults to '', rather than null or a meaningful variable.