### PR TITLE
Remove Static Height for Health Box

### DIFF
--- a/src/views/WellnessCheck/components/HealthStatus/HealthStatus.module.scss
+++ b/src/views/WellnessCheck/components/HealthStatus/HealthStatus.module.scss
@@ -50,7 +50,6 @@
 }
 
 .box {
-  height: 250px;
   background-color: var(--status-background-color);
 }
 


### PR DESCRIPTION
The wellness status module does not show the "Status: ..." message if your screen is too wide (too wide being most computer monitor sizes). This is due to a static height being set for the colored box which is not tall enough to show the message.

My proposal is that we simply remove the css for the height and let the block size itself. I have tested with yellow and green status with many different page sizes and that is the most responsive option.

Current:
![image](https://user-images.githubusercontent.com/43764277/159777101-fca549ca-d8a2-422e-94d0-c8c32fcb6d00.png)
![image](https://user-images.githubusercontent.com/43764277/159777318-e55705cd-49d5-44e2-af1b-da3be04e81e3.png)

Proposed:
![image](https://user-images.githubusercontent.com/43764277/159777189-47b98a58-4d6c-40fb-84df-53638f48c725.png)
![image](https://user-images.githubusercontent.com/43764277/159777270-28250bdb-090e-45ab-8d4a-8b1715b2ae94.png)

