### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+The only supported versions of this project are the current versions of the `develop` and `master` branches.
+
+## Reporting a Vulnerability
+
+Please report potential vulnerabilities via email to CTS@gordon.edu and include "Potential 360 security vulnerability" in the subject.
+
+We will endeavor to respond to any reported vulnerabilities in a timely fashion. 
+We may decline vulnerabilities if we deem them invalid, for example if the vulnerability would only apply to 
+using a dependency in a Node.js environment which we do not do. If accepted, the vulnerability will be addressed by our team and we will update you on our progress. 
+Thank you for your assistance in keeping our corner of the internet safe.
+


### PR DESCRIPTION
A security policy gives well-meaning auditors information on the best way to report potential security vulnerabilities.