### PR TITLE
Display login error messages from API

### DIFF
--- a/src/components/LoginDialogue/index.js
+++ b/src/components/LoginDialogue/index.js
@@ -21,7 +21,8 @@ const LoginDialogue = () => {
     try {
       await login(username, password);
     } catch (err) {
-      setError(err.message);
+      console.log(err);
+      setError(err.message ?? err.error_description);
       setLoading(false);
     }
   };


### PR DESCRIPTION
The TokenIssuer returns errors in a different format then our CustomException format from the API. In order to properly inform user's of an error signing them in, we need to display the `error_description` property from the API.