### PR TITLE
Fix CORS for development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,9 +5,9 @@
 # REACT_APP_FONT_URL=https://cloud.typography.com/7763712/6754392/css/fonts.css
 
 # @TRAIN
-# REACT_APP_API_URL=https://360ApiTrain.gordon.edu/
+REACT_APP_API_URL=https://360ApiTrain.gordon.edu/
 REACT_APP_FONT_URL=https://cloud.typography.com/7763712/7294392/css/fonts.css
 
 # @LOCALHOST
-  REACT_APP_API_URL=http://localhost:51626/
+# REACT_APP_API_URL=http://localhost:51626/
 # REACT_APP_FONT_URL=https://cloud.typography.com/7763712/7294392/css/fonts.css

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,8 +1,6 @@
 import { getToken, isAuthenticated } from './auth';
 import { createError } from './error';
 
-const base = process.env.REACT_APP_API_URL;
-
 type HttpRequestBody =
   | string
   | FormData
@@ -51,6 +49,25 @@ const post = <TResponse>(
 const del = <TResponse>(endpoint: string): Promise<TResponse> => makeRequest(endpoint, 'delete');
 
 /**
+ * The base URL to use for requests to our API, e.g. `https://360api.gordon.edu`.
+ *
+ * In the development (i.e. local) environment, the base URL is relative (`/`), because we send api
+ * requests through the development server proxy so that the `origin` HTTP header is set to URL of
+ * the API server, cirucumventing CORS.
+ *
+ * When not in development, there is no proxy to re-write headers and forward requests, so requests
+ * are sent directly to the API. This is fine because the API server allows CORS from the front-end
+ * server. For example, 360api allows cross-origin requests from `https://360.gordon.edu`.
+ *
+ * For more info, see:
+ *    - https://create-react-app.dev/docs/proxying-api-requests-in-development/
+ *    - `src/setupProxy.js`
+ *    - https://developer.mozilla.org/en-US/docs/Web/HTTP/
+ */
+const apiBaseURL =
+  process.env.NODE_ENV === 'development' ? '/' : (process.env.REACT_APP_API_URL as string);
+
+/**
  * Make a request to the API
  *
  * @param endpoint API endpoint to request, a URL relative to API base URL, ex: `activity/023487` (no leading slash)
@@ -65,12 +82,11 @@ const makeRequest = async <TResponse>(
   body?: HttpRequestBody,
   headers?: Headers,
 ): Promise<TResponse> => {
-  const request = new Request(`${base}api/${endpoint}`, {
+  const response = await fetch(`${apiBaseURL}api/${endpoint}`, {
     method,
     body,
     headers: await handleAuthHeader(headers ?? new Headers()),
   });
-  const response = await fetch(request);
   return parseResponse(response);
 };
 

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -3,10 +3,9 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 module.exports = (app) => {
   app.use(
     '/api',
-    createProxyMiddleware({ target: process.env.REACT_APP_API_URL, changeOrigin: true }),
-  );
-  app.use(
-    '/token',
-    createProxyMiddleware({ target: process.env.REACT_APP_API_URL, changeOrigin: true }),
+    createProxyMiddleware({
+      target: process.env.REACT_APP_API_URL,
+      changeOrigin: true,
+    }),
   );
 };


### PR DESCRIPTION
In development (i.e. when running the front-end locally via `npm run start`), we want API requests to be sent to the front-end node server, and re-directed by the http-proxy-middleware to the appropriate API. This is because the proxy sets the `origin` header of API requests to the API url, thereby circumventing CORS errors while developing 360 locally.

While we could prevent CORS errors by allowing cross-origin requests from localhost in the API, that would be a bad idea. Essentially, that would allow nefarious third-party websites or applications on a user's machine to impersonate us and send requests on their behalf, compromising our API using their credentials.

Instead, this solution allows us to connect to any of our API servers while running the API locally, but ensures that from end user's browsers, only 360[train] is allowed to send requests to the API.

When not developing locally (i.e. when running a static build deployed to one of our web servers), we neither need nor have a proxy server to overwrite request's `origin` header. So, we send requests directly to the API, knowing that each API is configured to accept cross-origin requests from it's own front-end (i.e. 360apitrain allows cross-origin requests from the 360train origin).