### PR TITLE
Redirect for auth, fixing Safari login

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -51,9 +51,7 @@ export const configureMSAL = (msalInstance: PublicClientApplication) => {
 };
 
 const authenticate = async () => {
-  const tokenResponse = await msalInstance.loginPopup(apiRequest);
-  const accountResponse = tokenResponse.account;
-  msalInstance.setActiveAccount(accountResponse);
+  await msalInstance.loginRedirect(apiRequest);
 };
 
 const acquireAccessToken = async () => {
@@ -73,7 +71,7 @@ const acquireAccessToken = async () => {
 
   const authResult = await msalInstance.acquireTokenSilent(request).catch(async (error) => {
     if (error instanceof InteractionRequiredAuthError) {
-      return await msalInstance.acquireTokenPopup(apiRequest);
+      return await msalInstance.acquireTokenRedirect(apiRequest);
     }
   });
 


### PR DESCRIPTION
The `loginPopup` authentication flow of `@azure/msal-browser` is not working on Safari (on both Macos and iOS). The login redirect works well on all browsers (and actually simplifies the code a little bit), so I am switching to that.