### PR TITLE
Remove hard-coded number left in from testing

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -63,7 +63,6 @@ const PersonalInfoList = ({
   },
   createSnackbar,
 }) => {
-  MobilePhone = '5129449977';
   const [isMobilePhonePrivate, setIsMobilePhonePrivate] = useState(
     Boolean(IsMobilePhonePrivate && MobilePhone !== PRIVATE_INFO),
   );


### PR DESCRIPTION
I accidentally left a hard-coded debugging value in the PersonalInfoList. This has been removed.