### PR TITLE
Hotfix: Update enrollment checkin

### DIFF
--- a/src/views/EnrollmentCheckIn/components/EmergencyContactUpdate/index.js
+++ b/src/views/EnrollmentCheckIn/components/EmergencyContactUpdate/index.js
@@ -96,19 +96,18 @@ function createEmergencyContactFields(
   handleCheckEmergContact,
 ) {
   const contactNum = emergencyContact.SEQ_NUMBER;
-  let required;
-  if (
+  const isRequiredContact =
     contactNum === 1 ||
     emergencyContact.FirstName !== '' ||
     emergencyContact.LastName !== '' ||
     emergencyContact.Relationship !== '' ||
     emergencyContact.HomePhone !== '' ||
-    emergencyContact.MobilePhone !== ''
-  ) {
-    required = true;
-  } else {
-    required = false;
-  }
+    emergencyContact.MobilePhone !== '';
+
+  // At least one phone number is required for each emergency contact, but we don't care whether it's a home phone or a mobile phone.
+  const isPhoneRequired =
+    isRequiredContact && emergencyContact.HomePhone === '' && emergencyContact.MobilePhone === '';
+
   return (
     <Box padding={2} align="center">
       <Typography variant="body1" gutterBottom>
@@ -119,7 +118,7 @@ function createEmergencyContactFields(
       <Grid container spacing={2} justifyContent="center">
         <Grid item>
           <FormControl className={styles.emergencyContactForm}>
-            <InputLabel required={required} htmlFor={'FirstNameInput' + contactNum}>
+            <InputLabel required={isRequiredContact} htmlFor={'FirstNameInput' + contactNum}>
               First Name
             </InputLabel>
             <FilledInput
@@ -132,7 +131,7 @@ function createEmergencyContactFields(
         </Grid>
         <Grid item>
           <FormControl className={styles.emergencyContactForm}>
-            <InputLabel required={required} htmlFor={'LastNameInput' + contactNum}>
+            <InputLabel required={isRequiredContact} htmlFor={'LastNameInput' + contactNum}>
               Last Name
             </InputLabel>
             <FilledInput
@@ -146,7 +145,7 @@ function createEmergencyContactFields(
         </Grid>
         <Grid item>
           <FormControl className={styles.emergencyContactForm}>
-            <InputLabel required={required} htmlFor="component-simple">
+            <InputLabel required={isRequiredContact} htmlFor="component-simple">
               Relationship
             </InputLabel>
             <FilledInput
@@ -160,7 +159,7 @@ function createEmergencyContactFields(
         </Grid>
         <Grid item>
           <FormControl className={styles.emergencyContactForm}>
-            <InputLabel required={required} htmlFor="component-simple">
+            <InputLabel required={isPhoneRequired} htmlFor="component-simple">
               Home Phone
             </InputLabel>
             <FilledInput
@@ -186,7 +185,7 @@ function createEmergencyContactFields(
         </Grid>
         <Grid item>
           <FormControl className={styles.emergencyContactForm}>
-            <InputLabel required={required} htmlFor="component-simple">
+            <InputLabel required={isPhoneRequired} htmlFor="component-simple">
               Mobile Phone
             </InputLabel>
             <FilledInput

--- a/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/index.js
+++ b/src/views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome/index.js
@@ -35,14 +35,20 @@ const EnrollmentCheckInWelcome = ({ basicInfo, hasMajorHold, holds }) => {
               <Typography>
                 You will meet with your advisor during Orientation and he/she can register you. The
                 name of your advisor can be found by logging onto{' '}
-                <a href="https://my.gordon.edu">my.gordon.edu</a> and clicking on the <b>Student</b>{' '}
-                tab. You will see your advisor(s) listed under "My Advisors and Majors".
+                <a href="https://my.gordon.edu" className="gc360_text_link">
+                  my.gordon.edu
+                </a>{' '}
+                and clicking on the <b>Student</b> tab. You will see your advisor(s) listed under
+                "My Advisors and Majors".
               </Typography>
             ) : (
               // Otherwise display a standard registration prompt
               <Typography gutterBottom>
-                Register online at <a href="https://my.gordon.edu">my.gordon.edu</a> anytime between
-                8AM on January 11, 2022 and 11:59PM on January 19, 2022.
+                Register online at{' '}
+                <a href="https://my.gordon.edu" className="gc360_text_link">
+                  my.gordon.edu
+                </a>{' '}
+                during the first five days of classes.
               </Typography>
             )}
           </Grid>

--- a/src/views/EnrollmentCheckIn/index.js
+++ b/src/views/EnrollmentCheckIn/index.js
@@ -389,8 +389,8 @@ const EnrollmentCheckIn = (props) => {
                             (emergencyContact1.FirstName === '' ||
                               emergencyContact1.LastName === '' ||
                               emergencyContact1.Relationship === '' ||
-                              emergencyContact1.HomePhone === '' ||
-                              emergencyContact1.MobilePhone === '')) ||
+                              (emergencyContact1.HomePhone === '' &&
+                                emergencyContact1.MobilePhone === ''))) ||
                           (activeStep === 2 &&
                             phoneInfo.PersonalPhone === '' &&
                             phoneInfo.NoPhone === false) ||

--- a/src/views/EnrollmentCheckIn/index.js
+++ b/src/views/EnrollmentCheckIn/index.js
@@ -3,7 +3,6 @@ import GordonUnauthorized from 'components/GordonUnauthorized';
 import GordonLoader from 'components/Loader';
 import { useAuth } from 'hooks';
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import checkInService from 'services/checkIn';
 import user from 'services/user';
 import EmergencyContactUpdate from 'views/EnrollmentCheckIn/components/EmergencyContactUpdate';
@@ -423,13 +422,6 @@ const EnrollmentCheckIn = (props) => {
                         Submit
                       </Button>
                     </Grid>
-                    {activeStep === 0 && (
-                      <Grid item>
-                        <Button variant="contained" component={Link} to="/wellness">
-                          Wellness Check-in
-                        </Button>
-                      </Grid>
-                    )}
                   </Grid>
                 </Grid>
               </Grid>


### PR DESCRIPTION
This PR is a hotfix to the enrollment check in system. It is being pushed as a hotfix because the system went live overnight for the coming semester and the following changes were determined to be immediately necessary:
- Updating the description of the Add/Drop period: rather than hard-coding dates for a specific semester, we just specify that classes can be added during the first five days of classes, which is the standard add/drop period.
- Removing the wellness check in button: since students aren't being required to display their wellness check in on campus, they do not need to access before completing enrollment check in.
- Require either home or mobile phone but not both: awe require that each emergency contact a student lists include some phone number at which we can reach that contact. However, we only need either a home or mobile phone number, not both. Previously, we required both home and mobile phone number for every contact, which doesn't make sense because not everyone has both.

I also updated the styling on the link to MyGordon in the registration hold description, to make it visually clear that it's a link.