### PR TITLE
Fix updating involvements

### DIFF
--- a/src/services/activity.ts
+++ b/src/services/activity.ts
@@ -24,17 +24,16 @@ type Person = {
 const closeActivity = (activityCode: string, sessionCode: string): Promise<void> =>
   http.put(`activities/${activityCode}/session/${sessionCode}/close`);
 
-type ActivityEdit = {
-  ACT_CDE: string;
-  ACT_URL: string;
-  ACT_BLURB: string;
-  ACT_JOIN_INFO: string;
+type InvolvementUpdate = {
+  Description: string;
+  JoinInfo: string;
+  Url: string;
 };
 
-const editActivity = (activityCode: string, data: ActivityEdit): Promise<ActivityEdit> =>
+const editActivity = (activityCode: string, data: InvolvementUpdate): Promise<InvolvementUpdate> =>
   http.put(`activities/${activityCode}`, data);
 
-const setActivityImage = (activityCode: string, imageDataURI: string): Promise<any> =>
+const setActivityImage = (activityCode: string, imageDataURI: string): Promise<Activity> =>
   http.postImage(`activities/${activityCode}/image/`, imageDataURI);
 
 const get = (activityCode: string): Promise<Activity> => http.get(`activities/${activityCode}`);

--- a/src/views/InvolvementProfile/index.js
+++ b/src/views/InvolvementProfile/index.js
@@ -154,11 +154,10 @@ const InvolvementProfile = () => {
   };
 
   const onEditInvolvement = async () => {
-    let data = {
-      ACT_CDE: involvementInfo.ActivityCode,
-      ACT_URL: tempURL,
-      ACT_BLURB: tempBlurb,
-      ACT_JOIN_INFO: tempJoinInfo,
+    const data = {
+      Description: tempBlurb,
+      JoinInfo: tempJoinInfo,
+      Url: tempURL,
     };
     await involvementService.editActivity(involvementInfo.ActivityCode, data);
     setInvolvementInfo((i) => ({
@@ -169,8 +168,11 @@ const InvolvementProfile = () => {
     }));
 
     if (photoUpdated === true) {
-      await involvementService.setActivityImage(involvementInfo.ActivityCode, image);
-      setInvolvementInfo((i) => ({ ...i, ActivityImagePath: image }));
+      const { ActivityImagePath: newImagePath } = await involvementService.setActivityImage(
+        involvementInfo.ActivityCode,
+        image,
+      );
+      setInvolvementInfo((i) => ({ ...i, ActivityImagePath: newImagePath }));
     }
     setIsEditDialogOpen(false);
   };


### PR DESCRIPTION
Depends on gordon-cs/gordon-360-api#698

This PR fixes involvement updates. Since upgrading the API, involvement updates have been broken because of type mismatches between the API and the UI. I have resolved those mismatches, but it required the introduction of a new type, InvolvementUpdate, which is introduced to the API in gordon-cs/gordon-360-api#698. Therefore, this PR will not work without that API PR. This is not a breaking change because the functionality targeted is already broken 😅.