### PR TITLE
User-managed Clifton Strengths privacy

### DIFF
--- a/src/components/Profile/components/Identification/index.js
+++ b/src/components/Profile/components/Identification/index.js
@@ -116,7 +116,7 @@ const Identification = ({ profile, myProf, network, createSnackbar }) => {
         // then this, means that the currently signed-in user is not allowed to see the default picture.
         setDefaultUserImage(defaultImage);
 
-        const colorFrequencies = profile.CliftonStrengths?.reduce(
+        const colorFrequencies = profile.CliftonStrengths?.Themes.reduce(
           (colorFrequencies, strength) => ({
             ...colorFrequencies,
             [strength.color]: (colorFrequencies[strength.color] || 0) + 1,

--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -26,7 +26,7 @@ import ProfileInfoListItem from '../ProfileInfoListItem';
 import UpdatePhone from './components/UpdatePhoneDialog/index.js';
 import styles from './PersonalInfoList.module.css';
 import AlumniUpdateForm from './components/AlumniUpdateForm';
-import { togglePrivacy } from 'services/cliftonStrengths';
+import CliftonStrengthsService from 'services/cliftonStrengths';
 
 const PRIVATE_INFO = 'Private as requested.';
 
@@ -131,7 +131,7 @@ const PersonalInfoList = ({ myProf, profile, createSnackbar }) => {
 
   const handleChangeCliftonStrengthsPrivacy = async () => {
     try {
-      const newPrivacy = await togglePrivacy();
+      const newPrivacy = await CliftonStrengthsService.togglePrivacy();
       setIsCliftonStrengthsPrivate(newPrivacy);
 
       createSnackbar(

--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -26,6 +26,7 @@ import ProfileInfoListItem from '../ProfileInfoListItem';
 import UpdatePhone from './components/UpdatePhoneDialog/index.js';
 import styles from './PersonalInfoList.module.css';
 import AlumniUpdateForm from './components/AlumniUpdateForm';
+import { togglePrivacy } from 'services/cliftonStrengths';
 
 const PRIVATE_INFO = 'Private as requested.';
 
@@ -40,6 +41,9 @@ const formatPhone = (phone) => {
 const PersonalInfoList = ({ myProf, profile, createSnackbar }) => {
   const [isMobilePhonePrivate, setIsMobilePhonePrivate] = useState(
     Boolean(profile.IsMobilePhonePrivate && profile.MobilePhone !== PRIVATE_INFO),
+  );
+  const [isCliftonStrengthsPrivate, setIsCliftonStrengthsPrivate] = useState(
+    profile.CliftonStrengths.Private,
   );
   const [openAlumniUpdateForm, setOpenAlumniUpdateForm] = useState(false);
   const [mailCombo, setMailCombo] = useState();
@@ -118,6 +122,20 @@ const PersonalInfoList = ({ myProf, profile, createSnackbar }) => {
         isHomePhonePrivate
           ? 'Personal Info Visible (This change may take several minutes)'
           : 'Personal Info Hidden (This change may take several minutes)',
+        'success',
+      );
+    } catch {
+      createSnackbar('Privacy Change Failed', 'error');
+    }
+  };
+
+  const handleChangeCliftonStrengthsPrivacy = async () => {
+    try {
+      const newPrivacy = await togglePrivacy();
+      setIsCliftonStrengthsPrivate(newPrivacy);
+
+      createSnackbar(
+        newPrivacy ? 'Clifton Strengths Hidden' : 'Clifton Strengths Public',
         'success',
       );
     } catch {
@@ -241,33 +259,51 @@ const PersonalInfoList = ({ myProf, profile, createSnackbar }) => {
     <ProfileInfoListItem title={'Graduation Year:'} contentText={profile.PreferredClassYear} />
   ) : null;
 
-  const cliftonStrengths = profile.CliftonStrengths.length ? (
-    <ProfileInfoListItem
-      title="Clifton Strengths:"
-      contentText={
-        <Typography>
-          {profile.CliftonStrengths.map((strength) => (
-            <Link href={strength.link} target="_blank" rel="noopener" key={strength.name}>
-              <b style={{ color: strength.color }}>{strength.name}</b>
-            </Link>
-          )).reduce((prev, curr) => [prev, ', ', curr])}
-          <GordonTooltip
-            title={
-              <span style={{ fontSize: '0.8rem' }}>
-                Categories:&nbsp;
-                <span style={{ color: '#60409f' }}>Executing</span>,{' '}
-                <span style={{ color: '#c88a2e' }}>Influencing</span>,{' '}
-                <span style={{ color: '#04668f' }}>Relationship</span>,{' '}
-                <span style={{ color: '#2c8b0f' }}>Thinking</span>
-              </span>
-            }
-            enterTouchDelay={50}
-            leaveTouchDelay={5000}
-          />
-        </Typography>
-      }
-    />
-  ) : null;
+  const cliftonStrengths =
+    profile.CliftonStrengths && (myProf || !profile.CliftonStrengths.Private) ? (
+      <ProfileInfoListItem
+        title="Clifton Strengths:"
+        contentText={
+          <Typography>
+            {profile.CliftonStrengths.Themes.map((strength) => (
+              <Link href={strength.link} target="_blank" rel="noopener" key={strength.name}>
+                <b style={{ color: strength.color }}>{strength.name}</b>
+              </Link>
+            )).reduce((prev, curr) => [prev, ', ', curr])}
+            <GordonTooltip
+              title={
+                <span style={{ fontSize: '0.8rem' }}>
+                  Categories:&nbsp;
+                  <span style={{ color: '#60409f' }}>Executing</span>,{' '}
+                  <span style={{ color: '#c88a2e' }}>Influencing</span>,{' '}
+                  <span style={{ color: '#04668f' }}>Relationship</span>,{' '}
+                  <span style={{ color: '#2c8b0f' }}>Thinking</span>
+                </span>
+              }
+              enterTouchDelay={50}
+              leaveTouchDelay={5000}
+            />
+          </Typography>
+        }
+        ContentIcon={
+          myProf && (
+            <FormControlLabel
+              control={
+                <Switch
+                  onChange={handleChangeCliftonStrengthsPrivacy}
+                  checked={!isCliftonStrengthsPrivate}
+                />
+              }
+              label={isCliftonStrengthsPrivate ? 'Private' : 'Public'}
+              labelPlacement="bottom"
+              disabled={!isOnline}
+            />
+          )
+        }
+        privateInfo={profile.CliftonStrengths.Private}
+        myProf={myProf}
+      />
+    ) : null;
 
   const advisors =
     myProf && isStudent ? (

--- a/src/services/cliftonStrengths.ts
+++ b/src/services/cliftonStrengths.ts
@@ -132,11 +132,27 @@ enum CliftonStrengthLinks {
   Strategic = 'https://www.gallup.com/cliftonstrengths/en/252350/strategic-theme.aspx',
 }
 
-export type CliftonStrength = {
+type CliftonStrength = {
   name: CliftonStrengthName;
   category: CliftonStrengthsCategory;
   color: CliftonStrengthColors;
   link: string;
+};
+
+type CliftonStrengthsViewModel = {
+  AccessCode: string;
+  Email: string;
+  DateCompleted: string;
+  Themes: CliftonStrengthName[];
+  Private: boolean;
+};
+
+export type CliftonStrengths = {
+  AccessCode: string;
+  Email: string;
+  DateCompleted: Date;
+  Themes: CliftonStrength[];
+  Private: boolean;
 };
 
 const strengthDetails = (name: CliftonStrengthName): CliftonStrength => {
@@ -149,5 +165,16 @@ const strengthDetails = (name: CliftonStrengthName): CliftonStrength => {
   };
 };
 
-export const getCliftonStrengths = async (username: string): Promise<CliftonStrength[]> =>
-  http.get<CliftonStrengthName[]>(`profiles/clifton/${username}/`).then(map(strengthDetails));
+export const getCliftonStrengths = async (username: string): Promise<CliftonStrengths | null> =>
+  http.get<CliftonStrengthsViewModel | null>(`profiles/${username}/clifton/`).then((cs) =>
+    cs
+      ? {
+          ...cs,
+          Themes: cs.Themes.map(strengthDetails),
+          DateCompleted: new Date(cs.DateCompleted),
+        }
+      : null,
+  );
+
+export const togglePrivacy = async (): Promise<boolean> =>
+  http.get<boolean>(`profiles/clifton/privacy`);

--- a/src/services/cliftonStrengths.ts
+++ b/src/services/cliftonStrengths.ts
@@ -1,5 +1,4 @@
 import http from './http';
-import { map } from './utils';
 
 type CliftonStrengthName =
   | 'Achiever'

--- a/src/services/cliftonStrengths.ts
+++ b/src/services/cliftonStrengths.ts
@@ -164,7 +164,7 @@ const strengthDetails = (name: CliftonStrengthName): CliftonStrength => {
   };
 };
 
-export const getCliftonStrengths = async (username: string): Promise<CliftonStrengths | null> =>
+const getCliftonStrengths = async (username: string): Promise<CliftonStrengths | null> =>
   http.get<CliftonStrengthsViewModel | null>(`profiles/${username}/clifton/`).then((cs) =>
     cs
       ? {
@@ -175,5 +175,11 @@ export const getCliftonStrengths = async (username: string): Promise<CliftonStre
       : null,
   );
 
-export const togglePrivacy = async (): Promise<boolean> =>
-  http.get<boolean>(`profiles/clifton/privacy`);
+const togglePrivacy = async (): Promise<boolean> => http.get<boolean>(`profiles/clifton/privacy`);
+
+const CliftonStrengthsService = {
+  getCliftonStrengths,
+  togglePrivacy,
+};
+
+export default CliftonStrengthsService;

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 import { Platform, platforms, socialMediaInfo } from 'services/socialMedia';
-import { CliftonStrengths, getCliftonStrengths } from './cliftonStrengths';
+import CliftonStrengthsService, { CliftonStrengths } from './cliftonStrengths';
 import { Class } from './goStalk';
 import http from './http';
 import { Override } from './utils';
@@ -256,7 +256,7 @@ const getProfileInfo = async (username: string = ''): Promise<Profile> => {
           ...profile,
           fullName,
           Advisors: await getAdvisors(profile.AD_Username),
-          CliftonStrengths: await getCliftonStrengths(profile.AD_Username),
+          CliftonStrengths: await CliftonStrengthsService.getCliftonStrengths(profile.AD_Username),
           Majors: [
             profile.Major1Description,
             profile.Major2Description,

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 import { Platform, platforms, socialMediaInfo } from 'services/socialMedia';
-import { CliftonStrength, getCliftonStrengths } from './cliftonStrengths';
+import { CliftonStrengths, getCliftonStrengths } from './cliftonStrengths';
 import { Class } from './goStalk';
 import http from './http';
 import { Override } from './utils';
@@ -67,7 +67,7 @@ type BaseProfileInfo = {
   LinkedIn: string;
   PersonType: string;
   fullName?: string;
-  CliftonStrengths?: CliftonStrength[];
+  CliftonStrengths?: CliftonStrengths | null;
 };
 
 export type UnformattedStaffProfileInfo = BaseProfileInfo & {


### PR DESCRIPTION
Now that gordon-cs/gordon-360-api#700 has been deployed, the API enables users to manage the privacy of their Clifton Strengths. This PR adds a graphical affordance to the My Profile page that allows users to see and manage the privacy of their Clifton Strengths data. It also updates the Public Profile page to respect the privacy setting of Clifton Strengths.

Closes #1485 