### PR TITLE
Handle null Clifton Strengths (and 404)

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.js
+++ b/src/components/Profile/components/PersonalInfoList/index.js
@@ -43,7 +43,7 @@ const PersonalInfoList = ({ myProf, profile, createSnackbar }) => {
     Boolean(profile.IsMobilePhonePrivate && profile.MobilePhone !== PRIVATE_INFO),
   );
   const [isCliftonStrengthsPrivate, setIsCliftonStrengthsPrivate] = useState(
-    profile.CliftonStrengths.Private,
+    profile.CliftonStrengths?.Private,
   );
   const [openAlumniUpdateForm, setOpenAlumniUpdateForm] = useState(false);
   const [mailCombo, setMailCombo] = useState();

--- a/src/services/cliftonStrengths.ts
+++ b/src/services/cliftonStrengths.ts
@@ -165,15 +165,18 @@ const strengthDetails = (name: CliftonStrengthName): CliftonStrength => {
 };
 
 const getCliftonStrengths = async (username: string): Promise<CliftonStrengths | null> =>
-  http.get<CliftonStrengthsViewModel | null>(`profiles/${username}/clifton/`).then((cs) =>
-    cs
-      ? {
-          ...cs,
-          Themes: cs.Themes.map(strengthDetails),
-          DateCompleted: new Date(cs.DateCompleted),
-        }
-      : null,
-  );
+  http
+    .get<CliftonStrengthsViewModel | null>(`profiles/${username}/clifton/`)
+    .then((cs) =>
+      cs
+        ? {
+            ...cs,
+            Themes: cs.Themes.map(strengthDetails),
+            DateCompleted: new Date(cs.DateCompleted),
+          }
+        : null,
+    )
+    .catch(() => null);
 
 const togglePrivacy = async (): Promise<boolean> => http.get<boolean>(`profiles/clifton/privacy`);
 


### PR DESCRIPTION
The UI was hanging for profiles when Clifton Strengths were null (or the API returned a 404). This PR fixes both cases.