### PR TITLE
Only show page after profile and data is loaded

### DIFF
--- a/src/views/EnrollmentCheckIn/index.js
+++ b/src/views/EnrollmentCheckIn/index.js
@@ -151,10 +151,11 @@ const EnrollmentCheckIn = (props) => {
           setActiveStep(6);
         }
       }
-      setLoading(false);
+      // We only want to stop loading now if the profile has already been loaded.
+      setLoading(loadingProfile);
     };
     loadData();
-  }, [profile]);
+  }, [profile, loadingProfile]);
 
   useEffect(() => {
     props.history.replace('/enrollmentcheckin', { step: activeStep });


### PR DESCRIPTION
We were setting `loading` to false while the profile was still loading, before data loaded. That meant that as soon as the profile loaded (and before the data was all loaded), we were showing the page, which is not supposed to happen. Now, we only show the page after the profile and data has loaded (even if the loaded value is null).