### PR TITLE
Release: Fix Enrollment Check In Loading and Text

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,7 @@
 # Refers to a production environment, which may be either train or prod
 
 # @PROD
-REACT_APP_API_URL=https://360Api.gordon.edu/
+REACT_APP_API_URL=https://360Api1.gordon.edu/
 REACT_APP_FONT_URL=https://cloud.typography.com/7763712/6754392/css/fonts.css
 REACT_APP_ANALYTICS_ID=UA-3559968-3
 


### PR DESCRIPTION
This release includes #1491, which fixes Enrollment Check In to only show the page after the profile and data is loaded, preventing users from continuing to check in before their holds have been loaded.

It also reapplies #1483, which was undone by the previous release.