### PR TITLE
Beautify Guest welcome

### DIFF
--- a/src/views/Home/components/GuestWelcome/GuestWelcome.module.scss
+++ b/src/views/Home/components/GuestWelcome/GuestWelcome.module.scss
@@ -4,6 +4,8 @@ div.gw_card {
   background-color: $primary-blue;
   color: $neutral-white;
   opacity: 0.92;
+  max-width: 25rem;
+  padding: 1rem;
 }
 
 .gw_container {

--- a/src/views/Home/components/GuestWelcome/index.js
+++ b/src/views/Home/components/GuestWelcome/index.js
@@ -1,9 +1,19 @@
-import { Card, CardContent, CardHeader, CardMedia, Fab, Grid, Typography } from '@material-ui/core';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardMedia,
+  Fab,
+  Grid,
+  Typography,
+} from '@material-ui/core';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import PWAInstructions from 'components/PWAInstructions/index';
 import useNetworkStatus from 'hooks/useNetworkStatus';
 import { useEffect, useState } from 'react';
 import { ga } from 'react-ga';
+import { authenticate } from 'services/auth';
 import styles from './GuestWelcome.module.css';
 import GordonLogoVerticalWhite from './images/gordon-logo-vertical-white.svg';
 
@@ -67,6 +77,9 @@ const GuestWelcome = () => {
                 <Typography>
                   As a guest, you have access to a limited view of the site. Login for full access.
                 </Typography>
+                <Button variant="contained" color="secondary" onClick={authenticate}>
+                  Login
+                </Button>
               </CardContent>
             </Card>
           </Grid>

--- a/src/views/Home/components/GuestWelcome/index.js
+++ b/src/views/Home/components/GuestWelcome/index.js
@@ -1,9 +1,11 @@
 import {
   Button,
   Card,
+  CardActions,
   CardContent,
   CardHeader,
   CardMedia,
+  Container,
   Fab,
   Grid,
   Typography,
@@ -77,10 +79,14 @@ const GuestWelcome = () => {
                 <Typography>
                   As a guest, you have access to a limited view of the site. Login for full access.
                 </Typography>
-                <Button variant="contained" color="secondary" onClick={authenticate}>
-                  Login
-                </Button>
               </CardContent>
+              <CardActions>
+                <Container>
+                  <Button variant="contained" color="secondary" onClick={authenticate}>
+                    Login
+                  </Button>
+                </Container>
+              </CardActions>
             </Card>
           </Grid>
         </Grid>


### PR DESCRIPTION
The Guest Welcome page changed shape once the old login form was removed. I have updated it to be slightly more appealing by putting a max width on the card and adding a (technically redundant but still helpful) login button.
# Before
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/35319956/186765556-09cc463c-c6a5-439d-8bb2-983e968e6f8d.png">

# After
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/35319956/186765604-de827107-973a-4e5d-b2c0-469537f4df70.png">
