### PR TITLE
Rename prop `isSuperAdmin` -> `isSiteAdmin`

### DIFF
--- a/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.js
+++ b/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.js
@@ -27,7 +27,7 @@ const headerStyle = {
   padding: '10px',
 };
 
-const AdminCard = ({ createSnackbar, isSuperAdmin, involvementDescription, onAddMember }) => {
+const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddMember }) => {
   const [isRosterClosed, setIsRosterClosed] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [username, setUsername] = useState('');
@@ -110,7 +110,7 @@ const AdminCard = ({ createSnackbar, isSuperAdmin, involvementDescription, onAdd
               </Button>
             </Grid>
             <Grid item>
-              {(!isRosterClosed || isSuperAdmin) && (
+              {(!isRosterClosed || isSiteAdmin) && (
                 <Button
                   variant="contained"
                   color="primary"

--- a/src/views/InvolvementProfile/components/Membership/components/MemberList/index.js
+++ b/src/views/InvolvementProfile/components/Membership/components/MemberList/index.js
@@ -14,7 +14,7 @@ const headerStyle = {
 const MemberList = ({
   members,
   isAdmin,
-  isSuperAdmin,
+  isSiteAdmin,
   createSnackbar,
   onLeave,
   onToggleIsAdmin,
@@ -59,7 +59,7 @@ const MemberList = ({
 
   const header = isMobileView ? (
     <CardHeader title="Members" style={headerStyle} />
-  ) : isAdmin || isSuperAdmin ? (
+  ) : isAdmin || isSiteAdmin ? (
     <CardHeader
       title={
         <Grid container direction="row">
@@ -109,7 +109,7 @@ const MemberList = ({
             member={member}
             key={member.MembershipID}
             isAdmin={isAdmin}
-            isSuperAdmin={isSuperAdmin}
+            isSiteAdmin={isSiteAdmin}
             createSnackbar={createSnackbar}
             isMobileView={isMobileView}
             onLeave={onLeave}


### PR DESCRIPTION
I somehow missed renaming the props for MemberList and AdminCard even though I renamed the props for the other components (including their child components). This fixes that mistake so that the correct prop is passed all the way through the component tree. 