### PR TITLE
Fix membership request property key

### DIFF
--- a/src/services/request.ts
+++ b/src/services/request.ts
@@ -2,7 +2,7 @@ import http from './http';
 import { MEMBERSHIP, Participation, ParticipationDesc } from './membership';
 import { filter } from './utils';
 
-enum RequestStatus {
+export enum RequestStatus {
   Pending = 'Pending',
   Approved = 'Approved',
   Denied = 'Denied',

--- a/src/views/InvolvementProfile/components/Membership/components/NonMemberButtons/index.js
+++ b/src/views/InvolvementProfile/components/Membership/components/NonMemberButtons/index.js
@@ -13,7 +13,7 @@ import { useUser } from 'hooks';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 import involvementService from 'services/activity';
-import requestService from 'services/request';
+import requestService, { RequestStatus } from 'services/request';
 
 const NonMemberButtons = ({
   isGuest,
@@ -51,7 +51,7 @@ const NonMemberButtons = ({
       PART_CDE: participationCode,
       DATE_SENT: new Date().toLocaleString(),
       COMMENT_TXT: titleComment,
-      APPROVED: 'Pending',
+      STATUS: RequestStatus.Pending,
     };
 
     try {


### PR DESCRIPTION
The `STATUS` property of membership requests was mistakenly being sent as `Approved`, which was causing the API to reject with a validation error. I have updated the request so that it passes validation and works as expected.