### PR TITLE
Hotfix: Fix Class Type in People Search

### DIFF
--- a/src/services/goStalk.ts
+++ b/src/services/goStalk.ts
@@ -66,7 +66,7 @@ const search = (
   major: string,
   minor: string,
   hall: string,
-  classType: Class | '',
+  classType: string, // The database has class types as integers
   homeCity: string,
   state: string,
   country: string,
@@ -79,7 +79,7 @@ const search = (
     major,
     minor,
     hall,
-    classType: typeof classType == 'string' ? '' : Class[classType],
+    classType,
     homeCity,
     state,
     country,


### PR DESCRIPTION
People search currently returns no results whenever a class (i.e. "Senior") is specified. This is because the database (and therefore the API) stores the class of a student as a standard number code rather than a string. This pull request reverts typescript changes that set the value to the string representation in goStalk.ts

Closes #1511