### PR TITLE
Fix dining balance days left chart

### DIFF
--- a/src/views/Home/components/DiningBalance/index.js
+++ b/src/views/Home/components/DiningBalance/index.js
@@ -26,7 +26,7 @@ const style = {
 const DiningBalance = () => {
   const [loading, setLoading] = useState(true);
   const [diningInfo, setDiningInfo] = useState(null);
-  const [[daysRemaining, daysCompleted], setDaysLeft] = useState([null, null]);
+  const [[daysRemaining, daysInSession], setDaysLeft] = useState([null, null]);
 
   useEffect(() => {
     Promise.all([user.getDiningInfo(), session.getDaysLeft()]).then(([diningInfo, daysLeft]) => {
@@ -83,8 +83,8 @@ const DiningBalance = () => {
     const guestCurr = diningInfo.GuestSwipes.CurrentBalance;
     const guestUsed = guestInit - guestCurr;
 
-    const daysLeftRounded = Math.min(daysRemaining, 0);
-    const daysFinished = daysCompleted - daysLeftRounded;
+    const daysLeftRounded = Math.max(daysRemaining, 0);
+    const daysFinished = daysInSession - daysLeftRounded;
 
     const options = {
       cutoutPercentage: 0,


### PR DESCRIPTION
The DiningBalance donut chart was displaying days left in the semester incorrectly, because the code called `Math.min` instead of `Math.max` (so that we never try to display a chart with negative days left).