### PR TITLE
Student news post More Details button pops up new tab

### DIFF
--- a/src/views/News/index.js
+++ b/src/views/News/index.js
@@ -561,7 +561,11 @@ const StudentNews = (props) => {
                     Student News is intended for announcing Gordon sponsored events, lost and found,
                     rides, etc. All submissions must follow the Student News guidelines and will be
                     reviewed at the discretion of The Office of Student Life...
-                    <a href="https://gordonedu.sharepoint.com/:b:/g/StudentLife/admin/EY22_o3g6vFEsfT2nYY-8JwB34OlYmA1oaE1f4FTGD2gew">
+                    <a
+                      href="https://gordonedu.sharepoint.com/:b:/g/StudentLife/admin/EY22_o3g6vFEsfT2nYY-8JwB34OlYmA1oaE1f4FTGD2gew"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
                       More Details
                     </a>
                   </Typography>


### PR DESCRIPTION
Now, the More Details button in Student news pops up new tab by adding `target="_blank"`.
`rel="noreferrer"` was also added due to potential security risk in older browser suggested by VSCode.