### PR TITLE
Update lists to MUI and abstract List Components

### DIFF
--- a/src/views/RecIM/components/List/Listing/Listing.module.scss
+++ b/src/views/RecIM/components/List/Listing/Listing.module.scss
@@ -1,4 +1,4 @@
-@import '../../../../vars';
+@import '../../../../../vars';
 
 .listing {
   background-color: $neutral-light-gray;

--- a/src/views/RecIM/components/List/Listing/index.js
+++ b/src/views/RecIM/components/List/Listing/index.js
@@ -4,37 +4,38 @@ import { Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import user from 'services/user';
 
-const ActivityListing = ({ activityID }) => {
+const ActivityListing = ({ activity }) => {
   return (
-    <>
-      <Link to={`/recim/activity/${activityID}`} className="gc360_link">
-        <Grid container className={styles.listing}>
-          <Grid item>Activity Listing</Grid>
-          {/* include: 
+    <ListItem button component={Link} to={`/recim/activity/${activity.ID}`} className="gc360_link">
+      <Grid container className={styles.listing}>
+        <Grid item>Activity Listing</Grid>
+        {/* include:
           - activity type (activity, tournament, one-off)
           - registration deadline IF there is one (start date as well for admin only)
           - date(s) of activity (ex. season date range or tournament date)
           */}
-        </Grid>
-      </Link>
-    </>
+      </Grid>
+    </ListItem>
   );
 };
 
-const TeamListing = ({ activityID, teamID }) => {
+const TeamListing = ({ team }) => {
   return (
-    <>
-      <Link to={`/recim/activity/${activityID}/team/${teamID}`} className="gc360_link">
-        <Grid container className={styles.listing}>
-          <Grid item>Team Listing</Grid>
-        </Grid>
-      </Link>
-    </>
+    <ListItem
+      button
+      component={Link}
+      to={`/recim/activity/${team.activityID}/team/${team.ID}`}
+      className="gc360_link"
+    >
+      <Grid container className={styles.listing}>
+        <Grid item>Team Listing</Grid>
+      </Grid>
+    </ListItem>
   );
 };
 
 // We could also use ParticipantID (not student ID) if we have that and prefer it to AD_Username
-const ParticipantListing = ({ username }) => {
+const ParticipantListing = ({ participant }) => {
   const [avatar, setAvatar] = useState('');
 
   // const [name, setName] = useState({
@@ -44,15 +45,17 @@ const ParticipantListing = ({ username }) => {
 
   useEffect(() => {
     const loadAvatar = async () => {
-      if (username) {
-        const { def: defaultImage, pref: preferredImage } = await user.getImage(username);
+      if (participant.username) {
+        const { def: defaultImage, pref: preferredImage } = await user.getImage(
+          participant.username,
+        );
         setAvatar(preferredImage || defaultImage);
       }
     };
     loadAvatar();
-  }, [username]);
+  }, [participant.username]);
   return (
-    <ListItem key={username} disableGutters={true}>
+    <ListItem key={participant.username} disableGutters={true}>
       <Grid container alignItems="center" className={styles.listing}>
         <ListItemAvatar>
           <Avatar
@@ -61,23 +64,26 @@ const ParticipantListing = ({ username }) => {
             variant="rounded"
           ></Avatar>
         </ListItemAvatar>
-        <Link to={`/profile/${username}`} className="gc360_link">
-          <ListItemText primary={username} />
+        <Link to={`/profile/${participant.username}`} className="gc360_link">
+          <ListItemText primary={participant.username} />
         </Link>
       </Grid>
     </ListItem>
   );
 };
 
-const MatchListing = ({ activityID, matchID }) => {
+const MatchListing = ({ match }) => {
   return (
-    <>
-      <Link to={`/recim/activity/${activityID}/match/${matchID}`} className="gc360_link">
-        <Grid container className={styles.listing}>
-          <Grid item>Team A vs Team B</Grid>
-        </Grid>
-      </Link>
-    </>
+    <ListItem
+      button
+      component={Link}
+      to={`/recim/activity/${match.activityID}/match/${match.ID}`}
+      className="gc360_link"
+    >
+      <Grid container className={styles.listing}>
+        <Grid item>Team A vs Team B</Grid>
+      </Grid>
+    </ListItem>
   );
 };
 

--- a/src/views/RecIM/components/List/index.js
+++ b/src/views/RecIM/components/List/index.js
@@ -1,0 +1,24 @@
+import { List } from '@material-ui/core';
+import { ActivityListing, MatchListing, ParticipantListing, TeamListing } from './Listing';
+
+const ActivityList = ({ activities }) => {
+  let content = activities.map((activity) => <ActivityListing activity={activity} />);
+  return <List>{content}</List>;
+};
+
+const ParticipantList = ({ participants }) => {
+  let content = participants.map((participant) => <ParticipantListing participant={participant} />);
+  return <List>{content}</List>;
+};
+
+const MatchList = ({ matches }) => {
+  let content = matches.map((match) => <MatchListing match={match} />);
+  return <List>{content}</List>;
+};
+
+const TeamList = ({ teams }) => {
+  let content = teams.map((team) => <TeamListing team={team} />);
+  return <List>{content}</List>;
+};
+
+export { ActivityList, ParticipantList, MatchList, TeamList };

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -12,7 +12,7 @@ let scheduleCard = (
     <CardHeader title="Schedule" className={styles.cardHeader} />
     <CardContent>
       {/* if there are games scheduled, map them here */}
-      <MatchList matches={[{ activityID: "123456", ID: "789"}]} />
+      <MatchList matches={[{ activityID: '123456', ID: '789' }]} />
       {/* else "no schedule yet set" */}
       <Typography variant="body1" paragraph>
         Games have not yet been scheduled.
@@ -27,7 +27,12 @@ let teamsCard = (
     <CardHeader title="Teams" className={styles.cardHeader} />
     <CardContent>
       {/* if I am apart of any active teams, map them here */}
-      <TeamList teams={[{ activityID:"123456", ID: "789" }, { activityID:"12345", ID: "987" }]} />
+      <TeamList
+        teams={[
+          { activityID: '123456', ID: '789' },
+          { activityID: '12345', ID: '987' },
+        ]}
+      />
       {/* else "no teams" */}
       <Typography variant="body1" paragraph>
         Be the first to create a team!

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -3,8 +3,8 @@ import { useParams } from 'react-router';
 import { useUser } from 'hooks';
 import GordonLoader from 'components/Loader';
 import GordonUnauthorized from 'components/GordonUnauthorized';
-import { MatchListing } from 'views/RecIM/components/Listing';
 import styles from './Activity.module.css';
+import { MatchList, TeamList } from './../../components/List';
 
 // CARD - schedule
 let scheduleCard = (
@@ -12,12 +12,7 @@ let scheduleCard = (
     <CardHeader title="Schedule" className={styles.cardHeader} />
     <CardContent>
       {/* if there are games scheduled, map them here */}
-      <div className={styles.listing}>
-        <MatchListing activityID={123456} matchID={321} />
-      </div>
-      <div className={styles.listing}>
-        <MatchListing activityID={123456} matchID={654} />
-      </div>
+      <MatchList matches={[{ activityID: "123456", ID: "789"}]} />
       {/* else "no schedule yet set" */}
       <Typography variant="body1" paragraph>
         Games have not yet been scheduled.
@@ -32,8 +27,7 @@ let teamsCard = (
     <CardHeader title="Teams" className={styles.cardHeader} />
     <CardContent>
       {/* if I am apart of any active teams, map them here */}
-      <div className={styles.listing}>{/* <TeamListing activityID={123456} teamID={789} /> */}</div>
-      <div className={styles.listing}>{/* <TeamListing activityID={12345} teamID={987} /> */}</div>
+      <TeamList teams={[{ activityID:"123456", ID: "789" }, { activityID:"12345", ID: "987" }]} />
       {/* else "no teams" */}
       <Typography variant="body1" paragraph>
         Be the first to create a team!

--- a/src/views/RecIM/views/Home/index.js
+++ b/src/views/RecIM/views/Home/index.js
@@ -4,10 +4,9 @@ import CreateActivityForm from '../../components/CreateActivityForm';
 import { useUser } from 'hooks';
 import { useState } from 'react';
 import GordonLoader from 'components/Loader';
-import { ActivityListing } from '../../components/Listing';
-import { TeamListing } from '../../components/Listing';
 import styles from './Home.module.css';
 import recimLogo from './../../recim_logo.png';
+import { ActivityList, TeamList } from './../../components/List';
 
 const Home = () => {
   const { profile, loading } = useUser();
@@ -38,12 +37,7 @@ const Home = () => {
       <CardHeader title="Upcoming Rec-IM Events" className={styles.cardHeader} />
       <CardContent>
         {/* if there are upcoming events, map them here */}
-        <div className={styles.listing}>
-          <ActivityListing activityID={123456} />
-        </div>
-        <div className={styles.listing}>
-          <ActivityListing activityID={12345} />
-        </div>
+        <ActivityList activities={[{ ID: "123456" }, { ID:"12345" }]}/>
         {createActivityButton}
         <Typography variant="body1" paragraph>
           {/* else "no upcoming events" */}
@@ -59,12 +53,7 @@ const Home = () => {
       <CardHeader title="My Teams" className={styles.cardHeader} />
       <CardContent>
         {/* if I am apart of any active teams, map them here */}
-        <div className={styles.listing}>
-          <TeamListing activityID={123456} teamID={789} />
-        </div>
-        <div className={styles.listing}>
-          <TeamListing activityID={12345} teamID={987} />
-        </div>
+        <TeamList teams={[{ activityID:"123456", ID: "789" }, { activityID:"12345", ID: "987" }]} />
         {/* else "no teams" */}
         <Typography variant="body1" paragraph>
           You're not yet apart of any teams; join one to get started!

--- a/src/views/RecIM/views/Home/index.js
+++ b/src/views/RecIM/views/Home/index.js
@@ -37,7 +37,7 @@ const Home = () => {
       <CardHeader title="Upcoming Rec-IM Events" className={styles.cardHeader} />
       <CardContent>
         {/* if there are upcoming events, map them here */}
-        <ActivityList activities={[{ ID: "123456" }, { ID:"12345" }]}/>
+        <ActivityList activities={[{ ID: '123456' }, { ID: '12345' }]} />
         {createActivityButton}
         <Typography variant="body1" paragraph>
           {/* else "no upcoming events" */}
@@ -53,7 +53,12 @@ const Home = () => {
       <CardHeader title="My Teams" className={styles.cardHeader} />
       <CardContent>
         {/* if I am apart of any active teams, map them here */}
-        <TeamList teams={[{ activityID:"123456", ID: "789" }, { activityID:"12345", ID: "987" }]} />
+        <TeamList
+          teams={[
+            { activityID: '123456', ID: '789' },
+            { activityID: '12345', ID: '987' },
+          ]}
+        />
         {/* else "no teams" */}
         <Typography variant="body1" paragraph>
           You're not yet apart of any teams; join one to get started!

--- a/src/views/RecIM/views/Match/index.js
+++ b/src/views/RecIM/views/Match/index.js
@@ -1,10 +1,10 @@
-import { Grid, Typography, Card, CardHeader, CardContent, List } from '@material-ui/core/';
+import { Grid, Typography, Card, CardHeader, CardContent } from '@material-ui/core/';
 import { useParams } from 'react-router';
 import { useUser } from 'hooks';
 import GordonLoader from 'components/Loader';
 import GordonUnauthorized from 'components/GordonUnauthorized';
-import { ParticipantListing } from 'views/RecIM/components/Listing';
 import styles from './Match.module.css';
+import { ParticipantList } from './../../components/List';
 
 // CARD - main
 const MainCard = () => {
@@ -54,10 +54,7 @@ const RosterCard = (teamID) => {
       <CardHeader title="Team Name" className={styles.cardHeader} />
       <CardContent>
         {/* if I am apart of any active teams, map them here */}
-        <List>
-          <ParticipantListing username={'silas.white'} />
-          <ParticipantListing username={'amos.cha'} />
-        </List>
+        <ParticipantList participants={[{ username:"silas.white"}, { username:"cameron.abbot" }]} />
       </CardContent>
     </Card>
   );

--- a/src/views/RecIM/views/Match/index.js
+++ b/src/views/RecIM/views/Match/index.js
@@ -54,7 +54,9 @@ const RosterCard = (teamID) => {
       <CardHeader title="Team Name" className={styles.cardHeader} />
       <CardContent>
         {/* if I am apart of any active teams, map them here */}
-        <ParticipantList participants={[{ username:"silas.white"}, { username:"cameron.abbot" }]} />
+        <ParticipantList
+          participants={[{ username: 'silas.white' }, { username: 'cameron.abbot' }]}
+        />
       </CardContent>
     </Card>
   );

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -1,10 +1,10 @@
-import { Grid, Typography, Card, CardHeader, CardContent, List } from '@material-ui/core/';
+import { Grid, Typography, Card, CardHeader, CardContent } from '@material-ui/core/';
 import { useParams } from 'react-router';
 import styles from './Team.module.css';
-import { ParticipantListing, MatchListing } from '../../components/Listing';
 import GordonLoader from 'components/Loader';
 import GordonUnauthorized from 'components/GordonUnauthorized';
 import { useUser } from 'hooks';
+import { ParticipantList, MatchList } from './../../components/List';
 
 let rosterCard = (
   <Card>
@@ -12,10 +12,9 @@ let rosterCard = (
     <CardContent>
       {/*This is hardcoded data for now, in the future, roster card should
         be a react component that takes a set of users and maps them here*/}
-      <List>
-        <ParticipantListing username={'silas.white'} />
-        <ParticipantListing username={'amos.cha'} />
-      </List>
+      <ParticipantList
+        participants={[{ username: 'silas.white' }, { username: 'cameron.abbot' }]}
+      />
     </CardContent>
   </Card>
 );
@@ -26,12 +25,7 @@ let scheduleCard = (
     <CardHeader title="Schedule" className={styles.cardHeader} />
     <CardContent>
       {/* if there are games scheduled, map them here */}
-      <div className={styles.listing}>
-        <MatchListing activityID={123456} matchID={321} />
-      </div>
-      <div className={styles.listing}>
-        <MatchListing activityID={123456} matchID={654} />
-      </div>
+      <MatchList matches={[{ activityID: '123456', ID: '789' }]} />
       {/* else "no schedule yet set" */}
       <Typography variant="body1" paragraph>
         Games have not yet been scheduled.


### PR DESCRIPTION
This PR abstracts the listing we were doing with divs, to using MUI lists to link our pages together. It also moves these lists to a component file so they can be reused in different sections of the RecIM pages. Here is a picture of what it looks like with the new lists,

![image](https://user-images.githubusercontent.com/78440076/198707246-93731bd6-65a0-4098-bd07-7bf4ad48a7ea.png)

Ignore the PR I accidentally put into the merge into develop category!