### PR TITLE
Update Workflows for Node v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
+      - name: Cache npm files
+        uses: actions/cache@v3
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            ${{ runner.os }}-node-
 
       - name: Install Dependencies
         run: npm install
@@ -51,14 +48,14 @@ jobs:
 
       - name: Upload develop build artifacts for deployment
         if: ${{ github.ref == 'refs/heads/develop' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-train
           path: build
 
       - name: Upload master build artifacts for deployment
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-prod
           path: build


### PR DESCRIPTION
GitHub is bumping the minimum Node Version of their actions to Node v16, which requires updating the action versions in our workflows.