### PR TITLE
remove alumni profile link in involvement page when the user is student

### DIFF
--- a/src/services/membership.ts
+++ b/src/services/membership.ts
@@ -15,6 +15,7 @@ export type Membership = {
   GroupAdmin: boolean;
   IDNumber: number;
   LastName: string;
+  IsAlumni: boolean;
   MembershipID: number;
   Participation: Participation;
   ParticipationDescription: ParticipationDesc;

--- a/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.js
+++ b/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.js
@@ -266,11 +266,17 @@ const MemberListItem = ({
             </Avatar>
           </Grid>
           <Grid item xs={3}>
-            <Link href={`/profile/${member.AD_Username}`} underline="hover">
+            {profile.PersonType?.includes?.('stu') && member.IsAlumni ? (
               <Typography>
                 {member.FirstName} {member.LastName}
               </Typography>
-            </Link>
+            ) : (
+              <Link href={`/profile/${member.AD_Username}`} underline="hover">
+                <Typography>
+                  {member.FirstName} {member.LastName}
+                </Typography>
+              </Link>
+            )}
           </Grid>
           <Grid item xs={4} style={rowStyle}>
             <Typography>{title ? title : participationDescription}</Typography>
@@ -323,11 +329,17 @@ const MemberListItem = ({
                     </Avatar>
                   </Grid>
                   <Grid>
-                    <Link href={`/profile/${member.AD_Username}`} underline="hover">
+                    {profile.PersonType?.includes?.('stu') && member.IsAlumni ? (
                       <Typography>
                         {member.FirstName} {member.LastName}
                       </Typography>
-                    </Link>
+                    ) : (
+                      <Link href={`/profile/${member.AD_Username}`} underline="hover">
+                        <Typography>
+                          {member.FirstName} {member.LastName}
+                        </Typography>
+                      </Link>
+                    )}
                   </Grid>
                 </Grid>
               </Grid>
@@ -370,11 +382,17 @@ const MemberListItem = ({
             </Avatar>
           </Grid>
           <Grid item xs={3} style={rowStyle}>
-            <Link href={`/profile/${member.AD_Username}`} underline="hover">
+            {profile.PersonType?.includes?.('stu') && member.IsAlumni ? (
               <Typography>
                 {member.FirstName} {member.LastName}
               </Typography>
-            </Link>
+            ) : (
+              <Link href={`/profile/${member.AD_Username}`} underline="hover">
+                <Typography>
+                  {member.FirstName} {member.LastName}
+                </Typography>
+              </Link>
+            )}
           </Grid>
           <Grid item xs={4} style={rowStyle}>
             <Typography>{title ? title : participationDescription}</Typography>


### PR DESCRIPTION
This PR removes the alumni profile link in involvement page when the user is student, for students should not have access to alumni profile even if the API returns `NotFound()` and the UI redirects them to `NotFound` page.

As the image shows, the second user is black, which means the name is not linked to profile.
![image](https://user-images.githubusercontent.com/78691207/201541276-a11e1331-6d8c-4653-a1eb-ec6601badc87.png)

Links #1553.
API PR: https://github.com/gordon-cs/gordon-360-api/pull/747.