### PR TITLE
Update Contributors for 2021/2022 School Year

### DIFF
--- a/src/views/About/contributors.json
+++ b/src/views/About/contributors.json
@@ -34,5 +34,9 @@
   {
     "title": "Software Development Team, Summer 2021",
     "body": "Cameron Abbot '23, David Gurge '23, Hyungyu Park '22, Joshua Peters '23, Kaiwen Chu '23, Roddy Ngolomingi '22, Silas White '23, \nDr. Russ Tuck, Dr. Jonathan Senning '85, Summer Practicum in Computer Science (2021)"
+  },
+  {
+    "title": "Software Development Team, 2021/2022",
+    "body": "Bethany Ruggerio '23, Cameron Abbot '23, Kaiwen Chu '23, Hyungyu Park '22, Silas White '23\nBennett Forkner, Evan Platzer '20, Information Systems Group"
   }
 ]


### PR DESCRIPTION
Looks like we missed this update last Spring. Adding developers that worked in the Fall of 2021 while they were able.