### PR TITLE
Add Agreement Checkbox for Winter Housing Hosting

### DIFF
--- a/src/views/ApartmentApp/components/StudentApplication/components/Agreements/index.js
+++ b/src/views/ApartmentApp/components/StudentApplication/components/Agreements/index.js
@@ -73,6 +73,11 @@ const Agreements = ({ deleting, onChange }) => {
         label:
           'We certify that all information provided on this application is accurate, to the best of our knowledge',
       },
+      {
+        checked: false,
+        label:
+          'We agree to host other students in our apartment during the winter break recess, in accordance with the policy outlined in the student handbook',
+      },
     ];
 
     setCheckboxes(newCheckboxes);


### PR DESCRIPTION
See CTS ticket 151450

Ethan Mignard has requested that the following be added as another agreement checkbox on the apartapp agreements:

```We agree to host other students in our apartment during the winter break recess, in accordance with the policy outlined in the student handbook```

This PR adds the text.