### PR TITLE
Fix react router Navigate

### DIFF
--- a/src/components/AppRedirect/index.js
+++ b/src/components/AppRedirect/index.js
@@ -1,6 +1,6 @@
 import { useIsAuthenticated } from '@azure/msal-react';
 import { useEffect, useState } from 'react';
-import { Route, useLocation } from 'react-router';
+import { Navigate, useLocation } from 'react-router';
 import checkInService from 'services/checkIn';
 
 const AppRedirect = () => {
@@ -20,7 +20,7 @@ const AppRedirect = () => {
     location.pathname !== '/enrollmentcheckin' &&
     location.pathname !== '/wellness'
   ) {
-    return <Route to="/enrollmentcheckin" />;
+    return <Navigate to="/enrollmentcheckin" />;
   }
 
   return null;

--- a/src/views/EnrollmentCheckIn/index.js
+++ b/src/views/EnrollmentCheckIn/index.js
@@ -3,6 +3,7 @@ import GordonUnauthorized from 'components/GordonUnauthorized';
 import GordonLoader from 'components/Loader';
 import { useUser } from 'hooks';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
 import checkInService from 'services/checkIn';
 import EmergencyContactUpdate from 'views/EnrollmentCheckIn/components/EmergencyContactUpdate';
 import EnrollmentCheckInWelcome from 'views/EnrollmentCheckIn/components/EnrollmentCheckInWelcome';
@@ -24,6 +25,7 @@ const steps = [
 ];
 
 const EnrollmentCheckIn = (props) => {
+  const navigate = useNavigate();
   const [activeStep, setActiveStep] = useState(0);
   const { profile, loading: loadingProfile } = useUser();
 
@@ -157,16 +159,16 @@ const EnrollmentCheckIn = (props) => {
   }, [profile, loadingProfile]);
 
   useEffect(() => {
-    props.history.replace('/enrollmentcheckin', { step: activeStep });
-  }, [activeStep, props.history]);
+    navigate('/enrollmentcheckin', { replace: true, state: { step: activeStep } });
+  }, [activeStep, navigate]);
 
   const handleNext = () => {
-    props.history.push('/enrollmentcheckin', { step: activeStep });
+    navigate('/enrollmentcheckin', { state: { step: activeStep } });
     setActiveStep((nextStep) => nextStep + 1);
   };
 
   const handlePrev = () => {
-    props.history.push('/enrollmentcheckin', { step: activeStep });
+    navigate('/enrollmentcheckin', { state: { step: activeStep } });
     setActiveStep((previousStep) => previousStep - 1);
   };
 

--- a/src/views/PublicProfile/index.js
+++ b/src/views/PublicProfile/index.js
@@ -5,7 +5,7 @@ import GordonLoader from 'components/Loader';
 import Profile from 'components/Profile';
 import useNetworkStatus from 'hooks/useNetworkStatus';
 import { useEffect, useState } from 'react';
-import { Route } from 'react-router';
+import { Navigate } from 'react-router';
 import { useParams } from 'react-router-dom';
 import userService from 'services/user';
 
@@ -41,7 +41,7 @@ const PublicProfile = () => {
   }
 
   if ((error && error.name === 'NotFoundError') || !profile) {
-    return <Route to="/profilenotfound" />;
+    return <Navigate to="/profilenotfound" />;
   }
 
   if (loading) {


### PR DESCRIPTION
There were a couple lingering components that broke on upgrade to react-router, mainly because of using `props.history` or `Route` instead of `Navigate`. I have fixed these last few.