### PR TITLE
Fix enrollment check in

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,4 @@
+import AppRedirect from 'components/AppRedirect';
 import BirthdayMessage from 'components/BirthdayMessage';
 import { createBrowserHistory } from 'history';
 import { useEffect, useRef, useState } from 'react';
@@ -37,6 +38,7 @@ const App = () => {
           <main className={styles.app_main}>
             <>
               <BirthdayMessage />
+              <AppRedirect />
               <Routes>
                 {routes.map((route) => (
                   <Route key={route.path} path={route.path} element={route.element} />

--- a/src/services/checkIn.ts
+++ b/src/services/checkIn.ts
@@ -61,7 +61,7 @@ type EnrollmentCheckin = {
   MinorHolds &
   Demographic;
 
-const getStatus = (): Promise<boolean> => http.get(`checkIn/status`);
+const getStatus = (): Promise<boolean> => http.get<boolean>(`checkIn/status`).catch(() => true);
 
 const markCompleted = (): Promise<void> => http.put(`checkIn/status`);
 

--- a/src/services/checkIn.ts
+++ b/src/services/checkIn.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from './error';
 import http from './http';
 
 /**
@@ -61,7 +62,8 @@ type EnrollmentCheckin = {
   MinorHolds &
   Demographic;
 
-const getStatus = (): Promise<boolean> => http.get<boolean>(`checkIn/status`).catch(() => true);
+const getStatus = (): Promise<boolean> =>
+  http.get<boolean>(`checkIn/status`).catch((err) => err instanceof NotFoundError);
 
 const markCompleted = (): Promise<void> => http.put(`checkIn/status`);
 


### PR DESCRIPTION
Restores `AppRedirect` to automatically redirect users to Enrollment Check-in when it isn't complete, and assumes that, when a user's enrollment check-in status can't be fetched, they have completed it.