### PR TITLE
Allow additional format of xlsx upload

### DIFF
--- a/src/components/SpreadsheetUploader/index.js
+++ b/src/components/SpreadsheetUploader/index.js
@@ -8,7 +8,11 @@ import { Link } from 'react-router-dom';
 import { read, utils } from 'xlsx';
 import styles from './SpreadsheetUploader.module.css';
 
-const acceptedTypes = ['application/vnd.ms-excel', 'text/csv'];
+const acceptedTypes = [
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'text/csv'
+];
 
 const SpreadsheetUploader = ({
   open,


### PR DESCRIPTION
@ChrisImagineer noticed that our spreadsheet uploader was actually not working for excel ".XLSX" files even though we were stating that it should on the upload page.

I did some research and discovered that there is actually another format for Excel files that we have to allow. This change adds that format to the acceptedTypes variable.