### PR TITLE
[Rec-IM] Fix datetime

### DIFF
--- a/src/views/RecIM/components/Forms/CreateActivityForm/index.js
+++ b/src/views/RecIM/components/Forms/CreateActivityForm/index.js
@@ -49,14 +49,14 @@ const CreateActivityForm = ({
     {
       label: 'Registration Start',
       name: 'registrationStart',
-      type: 'text',
+      type: 'datetime',
       error: errorStatus.registrationStart,
       helperText: '*Required',
     },
     {
       label: 'Registration End',
       name: 'registrationEnd',
-      type: 'text',
+      type: 'datetime',
       error: errorStatus.registrationEnd,
       helperText: '*Required',
     },

--- a/src/views/RecIM/components/Forms/components/ConfirmationRow/index.js
+++ b/src/views/RecIM/components/Forms/components/ConfirmationRow/index.js
@@ -1,6 +1,7 @@
 import { Typography, Grid } from '@mui/material';
 import styles from './ConfirmationRow.module.css';
 import { Check, Remove } from '@mui/icons-material';
+import { isValid, format } from 'date-fns';
 
 const ConfirmationRow = ({ field }) => {
   const isCheckbox = typeof field.Value === 'boolean';
@@ -15,7 +16,8 @@ const ConfirmationRow = ({ field }) => {
     truthIcon(field.Value)
   ) : (
     <Typography variant="body2" className={styles.text_current}>
-      {`${field.Value}`}
+      {/* if datetime, format appropriately */}
+      {isValid(field.Value) ? format(field.Value, 'MMM dd, y hh:mm aa') : `${field.Value}`}
     </Typography>
   );
 

--- a/src/views/RecIM/components/Forms/components/InformationField/index.js
+++ b/src/views/RecIM/components/Forms/components/InformationField/index.js
@@ -10,7 +10,7 @@ import {
 } from '@mui/material';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import styles from './InformationField.module.css';
 
 const InformationField = ({
@@ -75,7 +75,7 @@ const InformationField = ({
       break;
     case 'datetime':
       field = (
-        <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
           <DateTimePicker
             renderInput={(props) => <TextField {...props} variant="filled" />}
             label={label}


### PR DESCRIPTION
Fixes couple DateTime things:
- DateTime pickers re-added after being removed in previous merge conflicts
- Package dependency swapped from dayjs to date-fns, which is what 360 currently uses
- Confirmation window now shows DateTime as a properly formatted (with timezone) string

Noted a bug where activities are all showing time of midnight... Is this a DB or API issue that we are already aware of?