### PR TITLE
Fix Grad Year Check for Co-Curricular Transcript

### DIFF
--- a/src/views/CoCurricularTranscript/index.js
+++ b/src/views/CoCurricularTranscript/index.js
@@ -201,7 +201,7 @@ export default class Transcript extends Component {
   // Returns: the graduation date of the current user, or nothing if they have no declared grad date
   getGradCohort() {
     let gradDate = this.state.profile.GradDate;
-    if (gradDate === undefined || gradDate === '') {
+    if (!gradDate) {
       return null;
     } else {
       return 'Class of ' + gradDate.split(' ')[3];


### PR DESCRIPTION
The CCT is currently broken for members of the community who do not have a graduation date (most facstaff). This is because the value check does not account for possible `null` values. This PR modifies the inspection to cover all "empty" values with a simple boolean inverse.