### PR TITLE
Pass `authentication` to class components

### DIFF
--- a/src/views/CoCurricularTranscript/index.js
+++ b/src/views/CoCurricularTranscript/index.js
@@ -1,3 +1,4 @@
+import { useIsAuthenticated } from '@azure/msal-react';
 import { Button, Card, CardContent, Typography } from '@mui/material';
 import GordonUnauthorized from 'components/GordonUnauthorized';
 import GordonLoader from 'components/Loader';
@@ -12,7 +13,12 @@ import Experience from './Components/CoCurricularTranscriptExperience';
 //This component creates the overall interface for the CoCurricularTranscript (card, heading,
 //download button), and contains a InvolvementsList object for displaying the content
 
-export default class Transcript extends Component {
+// TODO: Temporary fix until IDUploader is a function component and can use hooks.
+const withAuth = () => (WrappedComponent) => (props) => {
+  const isAuthenticated = useIsAuthenticated();
+  return <WrappedComponent {...props} authentication={isAuthenticated} />;
+};
+class Transcript extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -358,3 +364,5 @@ export default class Transcript extends Component {
     }
   }
 }
+
+export default withAuth()(Transcript);

--- a/src/views/IDUploader/index.js
+++ b/src/views/IDUploader/index.js
@@ -1,3 +1,4 @@
+import { useIsAuthenticated } from '@azure/msal-react';
 import {
   Button,
   Card,
@@ -27,6 +28,11 @@ import IdCardTop from './image-top.png';
 
 // FIXME checkout https://mui.com/components/use-media-query/#migrating-from-withwidth
 const withWidth = () => (WrappedComponent) => (props) => <WrappedComponent {...props} width="xs" />;
+// TODO: Temporary fix until IDUploader is a function component and can use hooks.
+const withAuth = () => (WrappedComponent) => (props) => {
+  const isAuthenticated = useIsAuthenticated();
+  return <WrappedComponent {...props} authentication={isAuthenticated} />;
+};
 
 const CROP_DIM = 1200; // pixels
 class IDUploader extends Component {
@@ -468,4 +474,4 @@ class IDUploader extends Component {
   }
 }
 
-export default withWidth()(IDUploader);
+export default withAuth()(withWidth()(IDUploader));


### PR DESCRIPTION
Some class components were still depending on the `authentication` prop to know whether the user is logged in. However, when we upgraded to React Router v6, we removed this prop in favor of the `useIsAuthenicated` hook. The simplest way to use this hook with the class components is by passing it as a prop via a Higher Order Component.