### PR TITLE
Reload redirect data on navigate.

### DIFF
--- a/src/components/AppRedirect/index.js
+++ b/src/components/AppRedirect/index.js
@@ -12,7 +12,7 @@ const AppRedirect = () => {
     if (isAuthenticated) {
       checkInService.getStatus().then((status) => setEnrollmentCheckinComplete(status ?? true));
     }
-  }, [isAuthenticated]);
+  }, [isAuthenticated, location]);
 
   if (
     isAuthenticated &&


### PR DESCRIPTION
The AppRedirect component previously only updated it's data when the user's authentication status changed. This meant that, for example, when a user completed enrollment check in, AppRedirect would not be made aware of the change in check in status until the user refreshed the page (or signed out and back in).