### PR TITLE
HOTFIX: Fix people search navigation

### DIFF
--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -84,7 +84,7 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   return (
     <>
       <VisibilitySensor onChange={handleVisibilityChange}>
-        <Link className="gc360_link" to={`profile/${person.AD_Username}`}>
+        <Link className="gc360_link" to={`/profile/${person.AD_Username}`}>
           <Card className={styles.result} elevation={0}>
             {avatar && (
               <CardMedia src={avatar} title={fullName} component="img" className={styles.avatar} />


### PR DESCRIPTION
As @russtuck points out ( closes #1607 ), people search is currently linking users to a broken page from the results objects. This is because the link is using a relative path (starting from `/people`) rather than a static path (starting from `/`). This PR sets the path as static.