### PR TITLE
[Rec-IM] Edit Team functionality integration + Admin/Team-Captain permissions

### DIFF
--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -71,8 +71,7 @@ const del = <TResponse>(endpoint: string): Promise<TResponse> => makeRequest(end
  *    - `src/setupProxy.js`
  *    - https://developer.mozilla.org/en-US/docs/Web/HTTP/
  */
-const apiBaseURL =
-  process.env.NODE_ENV === 'development' ? '/' : (process.env.REACT_APP_API_URL as string);
+const apiBaseURL = process.env.REACT_APP_API_URL as string;
 
 /**
  * Make a request to the API

--- a/src/services/recim/activity.ts
+++ b/src/services/recim/activity.ts
@@ -79,8 +79,7 @@ const getActivityStatusTypes = (): Promise<Lookup[]> =>
 const getActivityTypes = (): Promise<Lookup[]> => http.get(`recim/activities/lookup?type=activity`);
 
 const editActivity = (ID: number, updatedActivity: PatchActivity): Promise<CreatedActivity[]> => {
-  console.log(updatedActivity);
-  return http.patch(`recim/activities/${ID}`, { name: 'Flag Football' });
+  return http.patch(`recim/activities/${ID}`, updatedActivity);
 };
 
 export {

--- a/src/services/recim/activity.ts
+++ b/src/services/recim/activity.ts
@@ -66,12 +66,10 @@ const createActivity = (newActivity: UploadActivity): Promise<CreatedActivity> =
 
 const getActivityByID = (ID: number): Promise<Activity> => http.get(`recim/activities/${ID}`);
 
-const getAllActivities = (
-  active: boolean,
-  time: String,
-  registrationOpen: boolean,
-): Promise<Activity[]> =>
-  http.get(`recim/activities?active=${active}&time=${time}&registrationOpen=${registrationOpen}`);
+const getAllActivities = (active: boolean, time: String): Promise<Activity[]> => {
+  if (time) return http.get(`recim/activities?active=${active}&time=${time}`);
+  return http.get(`recim/activities?active=${active}`);
+};
 
 const getActivityStatusTypes = (): Promise<Lookup[]> =>
   http.get(`recim/activities/lookup?type=status`);

--- a/src/views/RecIM/components/Forms/ActivityForm/index.js
+++ b/src/views/RecIM/components/Forms/ActivityForm/index.js
@@ -184,7 +184,7 @@ const ActivityForm = ({
 
   //re spreads fetched data to map to drop-down's once data has been loaded
   useEffect(() => {
-    setNewInfo({ ...newInfo, ...currentInfo });
+    setNewInfo(currentInfo);
   }, [currentInfo]);
 
   // Field Validation
@@ -277,6 +277,7 @@ const ActivityForm = ({
 
   const handleWindowClose = () => {
     setOpenConfirmWindow(false);
+    setOpenActivityForm(false);
     setNewInfo(currentInfo);
   };
 

--- a/src/views/RecIM/components/Forms/ActivityForm/index.js
+++ b/src/views/RecIM/components/Forms/ActivityForm/index.js
@@ -165,7 +165,7 @@ const ActivityForm = ({
       maxCapacity: '',
       soloRegistration: false,
     };
-  }, [activityTypes, activityStatusTypes, sports]);
+  }, [activity, activityTypes, activityStatusTypes, sports]);
 
   const [newInfo, setNewInfo] = useState(currentInfo);
   const [openConfirmWindow, setOpenConfirmWindow] = useState(false);
@@ -241,18 +241,15 @@ const ActivityForm = ({
 
   const handleConfirm = () => {
     setSaving(true);
-
     let activityRequest = { ...currentInfo, ...newInfo };
-    activityRequest.sportID = sports.filter(
-      (sport) => sport.Name === activityRequest.sportID,
-    )[0].ID;
-    activityRequest.typeID = activityTypes.filter(
+    activityRequest.sportID = sports.find((sport) => sport.Name === activityRequest.sportID).ID;
+    activityRequest.typeID = activityTypes.find(
       (type) => type.Description === activityRequest.typeID,
-    )[0].ID;
+    ).ID;
     if (activity) {
-      activityRequest.statusID = activityStatusTypes.filter(
-        (type) => type.Description === activityStatusTypes.statusID,
-      )[0].ID;
+      activityRequest.statusID = activityStatusTypes.find(
+        (type) => type.Description === activityRequest.statusID,
+      ).ID;
       editActivity(activity.ID, activityRequest).then((res) => {
         setSaving(false);
         closeWithSnackbar({

--- a/src/views/RecIM/components/Forms/ActivityForm/index.js
+++ b/src/views/RecIM/components/Forms/ActivityForm/index.js
@@ -13,7 +13,6 @@ import {
   editActivity,
 } from 'services/recim/activity';
 import { getAllSports } from 'services/recim/sport';
-import { isUndefined } from 'lodash';
 
 const ActivityForm = ({
   activity,

--- a/src/views/RecIM/components/Forms/TeamForm/index.js
+++ b/src/views/RecIM/components/Forms/TeamForm/index.js
@@ -9,7 +9,14 @@ import { ContentCard } from '../components/ContentCard';
 import GordonLoader from 'components/Loader';
 import { useUser } from 'hooks';
 
-const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, activityID }) => {
+const TeamForm = ({
+  isAdmin,
+  team,
+  closeWithSnackbar,
+  openTeamForm,
+  setOpenTeamForm,
+  activityID,
+}) => {
   const [errorStatus, setErrorStatus] = useState({
     Name: false,
     ActivityID: false,
@@ -28,7 +35,7 @@ const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, acti
       setLoading(false);
     };
     loadData();
-  }, []);
+  }, [profile]);
 
   const createTeamFields = [
     {
@@ -39,7 +46,8 @@ const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, acti
       helperText: '*Required',
     },
   ];
-  if (team) {
+  console.log(isAdmin);
+  if (team && isAdmin) {
     createTeamFields.push({
       label: 'Team Status',
       name: 'StatusID',

--- a/src/views/RecIM/components/Forms/TeamForm/index.js
+++ b/src/views/RecIM/components/Forms/TeamForm/index.js
@@ -56,8 +56,6 @@ const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, acti
 
   const currentInfo = useMemo(() => {
     if (team) {
-      console.log(teamStatus);
-      console.log(teamStatus.find((type) => type.Description === team.Status));
       return {
         Name: team.Name,
         ActivityID: Number(activityID),

--- a/src/views/RecIM/components/Forms/TeamForm/index.js
+++ b/src/views/RecIM/components/Forms/TeamForm/index.js
@@ -1,7 +1,7 @@
 import { Grid } from '@mui/material';
 import { useState, useMemo, useEffect } from 'react';
 import GordonDialogBox from 'components/GordonDialogBox';
-import { createTeam } from 'services/recim/team';
+import { createTeam, editTeam, getTeamStatusTypes } from 'services/recim/team';
 import { InformationField } from '../components/InformationField';
 import { ConfirmationWindowHeader } from '../components/ConfirmationHeader';
 import { ConfirmationRow } from '../components/ConfirmationRow';
@@ -9,19 +9,26 @@ import { ContentCard } from '../components/ContentCard';
 import GordonLoader from 'components/Loader';
 import { useUser } from 'hooks';
 
-const CreateTeamForm = ({
-  closeWithSnackbar,
-  openCreateTeamForm,
-  setOpenCreateTeamForm,
-  activityID,
-}) => {
+const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, activityID }) => {
   const [errorStatus, setErrorStatus] = useState({
     Name: false,
     ActivityID: false,
     Logo: false,
+    statusID: false,
   });
 
   const { profile } = useUser();
+  const [teamStatus, setTeamStatus] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      setTeamStatus(await getTeamStatusTypes());
+      setLoading(false);
+    };
+    loadData();
+  }, []);
 
   const createTeamFields = [
     {
@@ -32,16 +39,41 @@ const CreateTeamForm = ({
       helperText: '*Required',
     },
   ];
+  if (team) {
+    createTeamFields.push({
+      label: 'Team Status',
+      name: 'StatusID',
+      type: 'select',
+      menuItems: teamStatus.map((type) => {
+        return type.Description;
+      }),
+      error: errorStatus.statusID,
+      helperText: '*Required',
+    });
+  }
 
   const allFields = [createTeamFields].flat();
 
   const currentInfo = useMemo(() => {
+    if (team) {
+      console.log(teamStatus);
+      console.log(teamStatus.find((type) => type.Description === team.Status));
+      return {
+        Name: team.Name,
+        ActivityID: Number(activityID),
+        StatusID:
+          teamStatus.find((type) => type.Description === team.Status) == null
+            ? ''
+            : teamStatus.find((type) => type.Description === team.Status).Description,
+        Logo: 'NONE',
+      };
+    }
     return {
       Name: '',
       ActivityID: Number(activityID),
-      Logo: 'NULL', // Placeholder (for error checking0)
+      Logo: 'NONE', // Placeholder (for error checking0)
     };
-  }, [activityID]);
+  }, [activityID, teamStatus]);
 
   const [newInfo, setNewInfo] = useState(currentInfo);
   const [isSaving, setSaving] = useState(false);
@@ -57,6 +89,11 @@ const CreateTeamForm = ({
     };
     setErrorStatus(getCurrentErrorStatus);
   };
+
+  // refresh dropdown select once fetch is complete
+  useEffect(() => {
+    setNewInfo(currentInfo);
+  }, [currentInfo]);
 
   // Field Validation
   useEffect(() => {
@@ -112,21 +149,37 @@ const CreateTeamForm = ({
 
   const handleConfirm = () => {
     setSaving(true);
+    let teamRequest = { ...currentInfo, ...newInfo };
 
-    let teamCreationRequest = { ...currentInfo, ...newInfo };
+    if (team) {
+      teamRequest.StatusID = teamStatus.find(
+        (type) => type.Description === teamRequest.StatusID,
+      ).ID;
 
-    createTeam(profile.AD_Username, teamCreationRequest).then(() => {
-      closeWithSnackbar({
-        type: 'success',
-        message: 'Team created successfully',
+      editTeam(team.ID, teamRequest).then(() => {
+        setSaving(false);
+        closeWithSnackbar({
+          type: 'success',
+          message: 'Team created successfully',
+        });
+
+        handleWindowClose();
       });
+    } else {
+      createTeam(profile.AD_Username, teamRequest).then(() => {
+        setSaving(false);
+        closeWithSnackbar({
+          type: 'success',
+          message: 'Team created successfully',
+        });
 
-      handleWindowClose();
-    });
+        handleWindowClose();
+      });
+    }
   };
 
   const handleWindowClose = () => {
-    setOpenCreateTeamForm(false);
+    setOpenTeamForm(false);
     setOpenConfirmWindow(false);
     setNewInfo(currentInfo);
   };
@@ -154,10 +207,10 @@ const CreateTeamForm = ({
       />
     ));
   };
-
+  if (loading) return <GordonLoader />;
   return (
     <GordonDialogBox
-      open={openCreateTeamForm}
+      open={openTeamForm}
       title="Create a Team"
       fullWidth
       maxWidth="sm"
@@ -166,7 +219,7 @@ const CreateTeamForm = ({
       buttonName="Submit"
       cancelButtonClicked={() => {
         setNewInfo(currentInfo);
-        setOpenCreateTeamForm(false);
+        setOpenTeamForm(false);
       }}
       cancelButtonName="cancel"
     >
@@ -195,4 +248,4 @@ const CreateTeamForm = ({
   );
 };
 
-export default CreateTeamForm;
+export default TeamForm;

--- a/src/views/RecIM/components/Forms/TeamForm/index.js
+++ b/src/views/RecIM/components/Forms/TeamForm/index.js
@@ -73,7 +73,7 @@ const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, acti
       ActivityID: Number(activityID),
       Logo: 'NONE', // Placeholder (for error checking0)
     };
-  }, [activityID, teamStatus]);
+  }, [activityID, team, teamStatus]);
 
   const [newInfo, setNewInfo] = useState(currentInfo);
   const [isSaving, setSaving] = useState(false);

--- a/src/views/RecIM/components/Forms/TeamForm/index.js
+++ b/src/views/RecIM/components/Forms/TeamForm/index.js
@@ -46,7 +46,6 @@ const TeamForm = ({
       helperText: '*Required',
     },
   ];
-  console.log(isAdmin);
   if (team && isAdmin) {
     createTeamFields.push({
       label: 'Team Status',

--- a/src/views/RecIM/components/List/Listing/index.js
+++ b/src/views/RecIM/components/List/Listing/index.js
@@ -75,6 +75,7 @@ const SeriesListing = ({ series }) => {
 };
 
 const ActivityListing = ({ activity }) => {
+  console.log(activity);
   let registrationStart = DateTime.fromISO(activity.RegistrationStart);
   let registrationEnd = DateTime.fromISO(activity.RegistrationEnd);
   return (
@@ -88,13 +89,16 @@ const ActivityListing = ({ activity }) => {
             <Grid item xs={10}>
               <Chip
                 icon={<EventAvailableIcon />}
-                label="registration open"
-                color="success"
+                label={activity.RegistrationOpen ? 'registration open' : 'registration closed'}
+                color={activity.RegistrationOpen ? 'success' : 'info'}
                 size="small"
               ></Chip>
             </Grid>
             <Grid item xs={10}>
-              <Typography>Registration closes {standardDate(registrationEnd, false)}</Typography>
+              <Typography>
+                Registration close{activity.RegistrationOpen ? 's' : 'd'}{' '}
+                {standardDate(registrationEnd, false)}
+              </Typography>
               <Typography sx={{ color: 'gray', fontSize: '0.7em' }}>
                 <i>
                   testing purposes: {standardDate(registrationStart, true)} -{' '}

--- a/src/views/RecIM/components/List/Listing/index.js
+++ b/src/views/RecIM/components/List/Listing/index.js
@@ -75,7 +75,6 @@ const SeriesListing = ({ series }) => {
 };
 
 const ActivityListing = ({ activity }) => {
-  console.log(activity);
   let registrationStart = DateTime.fromISO(activity.RegistrationStart);
   let registrationEnd = DateTime.fromISO(activity.RegistrationEnd);
   return (

--- a/src/views/RecIM/components/List/Listing/index.js
+++ b/src/views/RecIM/components/List/Listing/index.js
@@ -149,7 +149,6 @@ const TeamListing = ({ team }) => {
 const ParticipantListing = ({ participant, minimal, callbackFunction, showParticipantOptions }) => {
   const { teamID } = useParams();
   const [avatar, setAvatar] = useState('');
-
   const [anchorEl, setAnchorEl] = useState(null);
   const moreOptionsOpen = Boolean(anchorEl);
   const handleClose = () => {
@@ -166,8 +165,8 @@ const ParticipantListing = ({ participant, minimal, callbackFunction, showPartic
   };
 
   const handleRemoveFromTeam = () => {
-    editTeamParticipant(participant.Username, teamID, 6) // Role 6 is inactive
-  }
+    editTeamParticipant(participant.Username, teamID, 6); // Role 6 is inactive
+  };
 
   useEffect(() => {
     const loadAvatar = async () => {
@@ -207,7 +206,7 @@ const ParticipantListing = ({ participant, minimal, callbackFunction, showPartic
               variant="rounded"
             ></Avatar>
           </ListItemAvatar>
-          <ListItemText primary={participant.Username} />
+          <ListItemText primary={participant.Username} secondary={participant.Role} />
         </ListItemButton>
         {showParticipantOptions ? (
           <Menu open={moreOptionsOpen} onClose={handleClose} anchorEl={anchorEl}>

--- a/src/views/RecIM/views/Activity/Activity.module.scss
+++ b/src/views/RecIM/views/Activity/Activity.module.scss
@@ -22,6 +22,10 @@
   text-transform: none;
 }
 
+.gridItemStack {
+  margin-bottom: 1em;
+}
+
 // if desired, this should just be a global change and
 // universally applied to all 360 cards
 .cardHeader {

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -23,6 +23,7 @@ import TeamForm from '../../components/Forms/TeamForm';
 import { getActivityByID } from 'services/recim/activity';
 import { Link as LinkRouter } from 'react-router-dom';
 import CreateSeriesForm from 'views/RecIM/components/Forms/CreateSeriesForm';
+import { getParticipantByUsername } from 'services/recim/participant';
 
 const Activity = () => {
   const { activityID } = useParams();
@@ -32,6 +33,7 @@ const Activity = () => {
   const [openActivityForm, setOpenActivityForm] = useState(false);
   const [openTeamForm, setOpenTeamForm] = useState(false);
   const [openCreateSeriesForm, setOpenCreateSeriesForm] = useState(false);
+  const [participant, setParticipant] = useState({});
   const subElementStyle = {
     marginBottom: '1em',
   };
@@ -40,10 +42,13 @@ const Activity = () => {
     const loadData = async () => {
       setLoading(true);
       setActivity(await getActivityByID(activityID));
+      if (profile) {
+        setParticipant(await getParticipantByUsername(profile.AD_Username));
+      }
       setLoading(false);
     };
     loadData();
-  }, [activityID, openTeamForm, openCreateSeriesForm, openActivityForm]);
+  }, [profile, activityID, openTeamForm, openCreateSeriesForm, openActivityForm]);
   // ^ May be bad practice, but will refresh page on dialog close
 
   const handleTeamForm = (status) => {
@@ -95,13 +100,15 @@ const Activity = () => {
               <Grid item xs={8} md={5}>
                 <Typography variant="h5" className={styles.activityTitle}>
                   {activity.Name}
-                  <IconButton>
-                    <EditIcon
-                      onClick={() => {
-                        setOpenActivityForm(true);
-                      }}
-                    />
-                  </IconButton>
+                  {participant.IsAdmin == true ? (
+                    <IconButton>
+                      <EditIcon
+                        onClick={() => {
+                          setOpenActivityForm(true);
+                        }}
+                      />
+                    </IconButton>
+                  ) : null}
                 </Typography>
                 <Typography variant="h6" className={styles.activitySubtitle}>
                   <i>Description of activity</i>
@@ -169,22 +176,23 @@ const Activity = () => {
             </Typography>
           )}
           <Grid container justifyContent="center">
-            <Button
-              variant="contained"
-              color="warning"
-              startIcon={<AddCircleRoundedIcon />}
-              className={styles.actionButton}
-              onClick={() => {
-                setOpenCreateSeriesForm(true);
-              }}
-            >
-              Create a New Series
-            </Button>
+            {participant.IsAdmin == true ? (
+              <Button
+                variant="contained"
+                color="warning"
+                startIcon={<AddCircleRoundedIcon />}
+                className={styles.actionButton}
+                onClick={() => {
+                  setOpenCreateSeriesForm(true);
+                }}
+              >
+                Create a New Series
+              </Button>
+            ) : null}
           </Grid>
         </CardContent>
       </Card>
     );
-
     return (
       <Grid container spacing={2}>
         <Grid item alignItems="center" xs={12}>

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -98,7 +98,6 @@ const Activity = () => {
                   <IconButton>
                     <EditIcon
                       onClick={() => {
-                        console.log(openActivityForm);
                         setOpenActivityForm(true);
                       }}
                     />

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -219,10 +219,10 @@ const Activity = () => {
             {scheduleCard}
           </Grid>
           <Grid item direction={'column'} xs={12} md={6}>
-            <Grid item style={subElementStyle}>
+            <Grid item style={styles.gridItemStack}>
               {seriesCard}
             </Grid>
-            <Grid item style={subElementStyle}>
+            <Grid item style={styles.gridItemStack}>
               {teamsCard}
             </Grid>
           </Grid>

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -29,12 +29,12 @@ const Activity = () => {
   const { activityID } = useParams();
   const { profile } = useUser();
   const [loading, setLoading] = useState(true);
-  const [activity, setActivity] = useState({});
+  const [activity, setActivity] = useState(null);
   const [openActivityForm, setOpenActivityForm] = useState(false);
   const [openTeamForm, setOpenTeamForm] = useState(false);
   const [openCreateSeriesForm, setOpenCreateSeriesForm] = useState(false);
-  const [participant, setParticipant] = useState({});
-  const [participantTeams, setParticipantTeams] = useState([]);
+  const [participant, setParticipant] = useState(null);
+  const [participantTeams, setParticipantTeams] = useState(null);
   const [canCreateTeam, setCanCreateTeam] = useState(true);
   const subElementStyle = {
     marginBottom: '1em',
@@ -57,11 +57,13 @@ const Activity = () => {
   // disable create team if participant already is participating in this activity,
   // unless they're an admin
   useEffect(() => {
-    setCanCreateTeam(activity.RegistrationOpen);
     if (participantTeams && participant) {
+      let participating = false;
+      setCanCreateTeam(activity.RegistrationOpen);
       participantTeams.forEach((team) => {
-        if (team.ActivityID === activity.ID) setCanCreateTeam(false || participant.IsAdmin);
+        if (team.ActivityID === activity.ID) participating = true;
       });
+      setCanCreateTeam(participating || participant.IsAdmin);
     }
   }, [activity, participant, participantTeams]);
   const handleTeamForm = (status) => {

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -100,7 +100,7 @@ const Activity = () => {
               <Grid item xs={8} md={5}>
                 <Typography variant="h5" className={styles.activityTitle}>
                   {activity.Name}
-                  {participant.IsAdmin == true ? (
+                  {participant.IsAdmin === true ? (
                     <IconButton>
                       <EditIcon
                         onClick={() => {
@@ -176,7 +176,7 @@ const Activity = () => {
             </Typography>
           )}
           <Grid container justifyContent="center">
-            {participant.IsAdmin == true ? (
+            {participant.IsAdmin === true ? (
               <Button
                 variant="contained"
                 color="warning"

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -43,7 +43,6 @@ const Activity = () => {
       setLoading(false);
     };
     loadData();
-    console.log(activity.Series);
   }, [activityID, openTeamForm, openCreateSeriesForm, openActivityForm]);
   // ^ May be bad practice, but will refresh page on dialog close
 

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -60,7 +60,7 @@ const Activity = () => {
     setCanCreateTeam(activity.RegistrationOpen);
     if (participantTeams && participant) {
       participantTeams.forEach((team) => {
-        if (team.ActivityID == activityID) setCanCreateTeam(false || participant.IsAdmin);
+        if (team.ActivityID === activity.ID) setCanCreateTeam(false || participant.IsAdmin);
       });
     }
   }, [activity, participant, participantTeams]);

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -36,9 +36,6 @@ const Activity = () => {
   const [participant, setParticipant] = useState(null);
   const [participantTeams, setParticipantTeams] = useState(null);
   const [canCreateTeam, setCanCreateTeam] = useState(true);
-  const subElementStyle = {
-    marginBottom: '1em',
-  };
 
   useEffect(() => {
     const loadData = async () => {

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -19,7 +19,7 @@ import GordonUnauthorized from 'components/GordonUnauthorized';
 import styles from './Activity.module.css';
 import { MatchList, SeriesList, TeamList } from './../../components/List';
 import ActivityForm from 'views/RecIM/components/Forms/ActivityForm';
-import CreateTeamForm from '../../components/Forms/CreateTeamForm';
+import TeamForm from '../../components/Forms/TeamForm';
 import { getActivityByID } from 'services/recim/activity';
 import { Link as LinkRouter } from 'react-router-dom';
 import CreateSeriesForm from 'views/RecIM/components/Forms/CreateSeriesForm';
@@ -30,7 +30,7 @@ const Activity = () => {
   const [loading, setLoading] = useState(true);
   const [activity, setActivity] = useState({});
   const [openActivityForm, setOpenActivityForm] = useState(false);
-  const [openCreateTeamForm, setOpenCreateTeamForm] = useState(false);
+  const [openTeamForm, setOpenTeamForm] = useState(false);
   const [openCreateSeriesForm, setOpenCreateSeriesForm] = useState(false);
   const subElementStyle = {
     marginBottom: '1em',
@@ -43,12 +43,13 @@ const Activity = () => {
       setLoading(false);
     };
     loadData();
-  }, [activityID, openCreateTeamForm, openCreateSeriesForm, openActivityForm]);
+    console.log(activity.Series);
+  }, [activityID, openTeamForm, openCreateSeriesForm, openActivityForm]);
   // ^ May be bad practice, but will refresh page on dialog close
 
-  const handleCreateTeamForm = (status) => {
+  const handleTeamForm = (status) => {
     //if you want to do something with the message make a snackbar function here
-    setOpenCreateTeamForm(false);
+    setOpenTeamForm(false);
   };
   const handleCreateSeriesForm = (status) => {
     //if you want to do something with the message make a snackbar function here
@@ -147,7 +148,7 @@ const Activity = () => {
               startIcon={<AddCircleRoundedIcon />}
               className={styles.actionButton}
               onClick={() => {
-                setOpenCreateTeamForm(true);
+                setOpenTeamForm(true);
               }}
             >
               Create a New Team
@@ -203,13 +204,13 @@ const Activity = () => {
             </Grid>
           </Grid>
         </Grid>
-        {openCreateTeamForm ? (
-          <CreateTeamForm
+        {openTeamForm ? (
+          <TeamForm
             closeWithSnackbar={(status) => {
-              handleCreateTeamForm(status);
+              handleTeamForm(status);
             }}
-            openCreateTeamForm={openCreateTeamForm}
-            setOpenCreateTeamForm={(bool) => setOpenCreateTeamForm(bool)}
+            openTeamForm={openTeamForm}
+            setOpenTeamForm={(bool) => setOpenTeamForm(bool)}
             activityID={activityID}
           />
         ) : null}

--- a/src/views/RecIM/views/Home/Home.module.scss
+++ b/src/views/RecIM/views/Home/Home.module.scss
@@ -7,6 +7,10 @@
   color: $neutral-white;
 }
 
+.gridItemStack {
+  margin-bottom: 1em;
+}
+
 .homeHeaderTitle {
   font-weight: bold;
   color: $neutral-dark-gray2;

--- a/src/views/RecIM/views/Home/index.js
+++ b/src/views/RecIM/views/Home/index.js
@@ -14,7 +14,6 @@ import { getParticipantTeams, getParticipantByUsername } from 'services/recim/pa
 import WaiverForm from 'views/RecIM/components/Forms/WaiverForm';
 import CreateSeriesForm from 'views/RecIM/components/Forms/CreateSeriesForm';
 
-
 const Home = () => {
   const { profile } = useUser();
   const [loading, setLoading] = useState(true);
@@ -25,7 +24,7 @@ const Home = () => {
   const [participant, setParticipant] = useState([]);
   const [openWaiver, setOpenWaiver] = useState(false);
   const [createdActivity, setCreatedActivity] = useState({ ID: null });
-
+  const [hasPermissions, setHasPermissions] = useState(false);
   // profile hook used for future authentication
   // Administration privs will use AuthGroups -> example can be found in
   //           src/components/Header/components/NavButtonsRightCorner
@@ -46,8 +45,10 @@ const Home = () => {
 
   useEffect(() => {
     setOpenWaiver(participant == null);
+    if (participant) {
+      setHasPermissions(participant.IsAdmin);
+    }
   }, [participant]);
-
 
   const createActivityButton = (
     <Grid container justifyContent="center">
@@ -95,14 +96,15 @@ const Home = () => {
           <ActivityList activities={activities} />
         ) : (
           <Typography variant="body1" paragraph>
-            It looks like there aren't any Rec-IM events currently open for registration :(
+            It looks like there aren't any Rec-IM events currently open for registration T_T
           </Typography>
         )}
 
-        {createActivityButton}
+        {hasPermissions ? createActivityButton : null}
       </CardContent>
     </Card>
   );
+  // I changed the face because the linting was giving me an "error" since :( counted as an open paran
 
   // CARD - my teams
   let myTeamsCard = (

--- a/src/views/RecIM/views/Home/index.js
+++ b/src/views/RecIM/views/Home/index.js
@@ -26,9 +26,6 @@ const Home = () => {
   const [openWaiver, setOpenWaiver] = useState(false);
   const [createdActivity, setCreatedActivity] = useState({ ID: null });
   const [hasPermissions, setHasPermissions] = useState(false);
-  const subElementStyle = {
-    marginBottom: '1em',
-  };
 
   // profile hook used for future authentication
   // Administration privs will use AuthGroups -> example can be found in
@@ -184,10 +181,10 @@ const Home = () => {
         </Grid>
         <Grid item container justifyContent="center" spacing={2}>
           <Grid item xs={12} md={8}>
-            <Grid item style={subElementStyle}>
+            <Grid item style={styles.gridItemStack}>
               {upcomingActivitiesCard}
             </Grid>
-            <Grid item style={subElementStyle}>
+            <Grid item style={styles.gridItemStack}>
               {ongoingActivitiesCard}
             </Grid>
           </Grid>

--- a/src/views/RecIM/views/Home/index.js
+++ b/src/views/RecIM/views/Home/index.js
@@ -38,7 +38,7 @@ const Home = () => {
       setLoading(false);
     };
     loadActivities();
-  }, [profile, openActivityForm]);
+  }, [profile, openActivityForm, openCreateSeriesForm]);
 
   const createActivityButton = (
     <Grid container justifyContent="center">

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -26,7 +26,6 @@ import TeamForm from 'views/RecIM/components/Forms/TeamForm';
 //expensive, comment on line 36
 import { getActivityByID } from 'services/recim/activity';
 
-
 const Team = () => {
   const { activityID, teamID } = useParams();
   const { profile } = useUser();
@@ -37,18 +36,12 @@ const Team = () => {
   //this is expensive, so optimally we would want another way to check that registration is open
   const [activity, setActivity] = useState(null);
   const [hasPermissions, setHasPermissions] = useState(false);
-  const [openInviteParticipantForm, setOpenInviteParticipantForm] = useState(false);
-  const handleInviteParticipantForm = (status) => {
-    //if you want to do something with the message make a snackbar function here
-    setOpenInviteParticipantForm(false);
-  };
 
   const [openInviteParticipantForm, setOpenInviteParticipantForm] = useState(false);
   const handleInviteParticipantForm = (status) => {
     //if you want to do something with the message make a snackbar function here
     setOpenInviteParticipantForm(false);
   };
-
 
   useEffect(() => {
     const loadTeamData = async () => {

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -25,7 +25,6 @@ import EditIcon from '@mui/icons-material/Edit';
 import TeamForm from 'views/RecIM/components/Forms/TeamForm';
 //expensive, comment on line 36
 import { getActivityByID } from 'services/recim/activity';
-import { DateTime } from 'luxon';
 
 const Team = () => {
   const { activityID, teamID } = useParams();

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -40,12 +40,16 @@ const Team = () => {
     setOpenTeamForm(false);
   };
   const teamRecord = () => {
-    if (team)
-      return (
-        <Typography>
-          {team.TeamRecord[0].Win} W : {team.TeamRecord[0].Loss} L : {team.TeamRecord[0].Tie} T
-        </Typography>
-      );
+    if (team) {
+      if (team.TeamRecord[0]) {
+        return (
+          <Typography>
+            {team.TeamRecord[0].Win} W : {team.TeamRecord[0].Loss} L : {team.TeamRecord[0].Tie} T
+          </Typography>
+        );
+      }
+      return <Typography variant="subtitle2">Activity has not started</Typography>;
+    }
     return null;
   };
   if (loading) {

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -1,5 +1,13 @@
 import { useState, useEffect } from 'react';
-import { Grid, Typography, Card, CardHeader, CardContent, Breadcrumbs } from '@mui/material';
+import {
+  Grid,
+  Typography,
+  Card,
+  CardHeader,
+  CardContent,
+  Breadcrumbs,
+  IconButton,
+} from '@mui/material';
 import { useParams } from 'react-router';
 import styles from './Team.module.css';
 import GordonLoader from 'components/Loader';
@@ -9,12 +17,15 @@ import { ParticipantList, MatchList } from './../../components/List';
 import { getTeamByID } from 'services/recim/team';
 import { Link as LinkRouter } from 'react-router-dom';
 import HomeIcon from '@mui/icons-material/Home';
+import EditIcon from '@mui/icons-material/Edit';
+import TeamForm from 'views/RecIM/components/Forms/TeamForm';
 
 const Team = () => {
   const { activityID, teamID } = useParams();
   const { profile } = useUser();
   const [team, setTeam] = useState({});
   const [loading, setLoading] = useState(true);
+  const [openTeamForm, setOpenTeamForm] = useState(false);
 
   useEffect(() => {
     const loadTeamData = async () => {
@@ -23,8 +34,20 @@ const Team = () => {
       setLoading(false);
     };
     loadTeamData();
-  }, [teamID]);
-
+  }, [teamID, openTeamForm]);
+  const handleTeamForm = (status) => {
+    //if you want to do something with the message make a snackbar function here
+    setOpenTeamForm(false);
+  };
+  const teamRecord = () => {
+    if (team)
+      return (
+        <Typography>
+          {team.TeamRecord[0].Win} W : {team.TeamRecord[0].Loss} L : {team.TeamRecord[0].Tie} T
+        </Typography>
+      );
+    return null;
+  };
   if (loading) {
     return <GordonLoader />;
   } else if (!profile) {
@@ -66,8 +89,16 @@ const Team = () => {
               </Grid>
               <Grid item xs={8} md={5}>
                 <Typography variant="h5" className={styles.teamTitle}>
-                  Team Name
+                  {team == null ? <GordonLoader /> : team.Name}
+                  <IconButton>
+                    <EditIcon
+                      onClick={() => {
+                        setOpenTeamForm(true);
+                      }}
+                    />
+                  </IconButton>
                 </Typography>
+                {teamRecord()}
               </Grid>
             </Grid>
           </Grid>
@@ -115,6 +146,17 @@ const Team = () => {
         <p>
           Activity ID: {activityID} Team ID: {teamID} (for testing purposes only)
         </p>
+        {openTeamForm ? (
+          <TeamForm
+            closeWithSnackbar={(status) => {
+              handleTeamForm(status);
+            }}
+            openTeamForm={openTeamForm}
+            setOpenTeamForm={(bool) => setOpenTeamForm(bool)}
+            activityID={activityID}
+            team={team}
+          />
+        ) : null}
       </Grid>
     );
   }

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -162,19 +162,21 @@ const Team = () => {
               <ParticipantList participants={team.Participant} />
             )}
           </CardContent>
-          <Grid container justifyContent="center">
-            <Button
-              variant="contained"
-              color="warning"
-              startIcon={<AddCircleRoundedIcon />}
-              className={styles.actionButton}
-              onClick={() => {
-                setOpenInviteParticipantForm(true);
-              }}
-            >
-              Invite Participant
-            </Button>
-          </Grid>
+          {hasPermissions ? (
+            <Grid container justifyContent="center">
+              <Button
+                variant="contained"
+                color="warning"
+                startIcon={<AddCircleRoundedIcon />}
+                className={styles.actionButton}
+                onClick={() => {
+                  setOpenInviteParticipantForm(true);
+                }}
+              >
+                Invite Participant
+              </Button>
+            </Grid>
+          ) : null}
         </CardContent>
         <InviteParticipantForm
           closeWithSnackbar={(status) => {

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -227,6 +227,7 @@ const Team = () => {
             setOpenTeamForm={(bool) => setOpenTeamForm(bool)}
             activityID={activityID}
             team={team}
+            isAdmin={participant.IsAdmin}
           />
         ) : null}
       </Grid>


### PR DESCRIPTION
Additions
- Basic Edit Team Form
- Added On-going Activities on Home Page

Permissions Created:
Home Page
- Admins are the only ones allowed to create Activity

Activity Page
- Admins are the only ones allowed to EDIT the Activity
- Admins are the only ones allowed to Create a Series
- Students can only Create a Team if they are not already participating in the Activity
- Admins can Create a Team whenever

Team Page
- Only Admins can edit Team Status
- Student Captains/Co-Captains can edit Team Name and Invite Participants WHEN registration is open
- Admins are not restricted by the clause above
