### PR TITLE
[Rec-IM] Edit Team functionality integration + Admin/Team-Captain permissions

### DIFF
--- a/src/services/recim/activity.ts
+++ b/src/services/recim/activity.ts
@@ -66,12 +66,10 @@ const createActivity = (newActivity: UploadActivity): Promise<CreatedActivity> =
 
 const getActivityByID = (ID: number): Promise<Activity> => http.get(`recim/activities/${ID}`);
 
-const getAllActivities = (
-  active: boolean,
-  time: String,
-  registrationOpen: boolean,
-): Promise<Activity[]> =>
-  http.get(`recim/activities?active=${active}&time=${time}&registrationOpen=${registrationOpen}`);
+const getAllActivities = (active: boolean, time: String): Promise<Activity[]> => {
+  if (time) return http.get(`recim/activities?active=${active}&time=${time}`);
+  return http.get(`recim/activities?active=${active}`);
+};
 
 const getActivityStatusTypes = (): Promise<Lookup[]> =>
   http.get(`recim/activities/lookup?type=status`);

--- a/src/views/RecIM/components/Forms/TeamForm/index.js
+++ b/src/views/RecIM/components/Forms/TeamForm/index.js
@@ -9,7 +9,14 @@ import { ContentCard } from '../components/ContentCard';
 import GordonLoader from 'components/Loader';
 import { useUser } from 'hooks';
 
-const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, activityID }) => {
+const TeamForm = ({
+  isAdmin,
+  team,
+  closeWithSnackbar,
+  openTeamForm,
+  setOpenTeamForm,
+  activityID,
+}) => {
   const [errorStatus, setErrorStatus] = useState({
     Name: false,
     ActivityID: false,
@@ -28,7 +35,7 @@ const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, acti
       setLoading(false);
     };
     loadData();
-  }, []);
+  }, [profile]);
 
   const createTeamFields = [
     {
@@ -39,7 +46,8 @@ const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, acti
       helperText: '*Required',
     },
   ];
-  if (team) {
+  console.log(isAdmin);
+  if (team && isAdmin) {
     createTeamFields.push({
       label: 'Team Status',
       name: 'StatusID',

--- a/src/views/RecIM/components/Forms/TeamForm/index.js
+++ b/src/views/RecIM/components/Forms/TeamForm/index.js
@@ -56,8 +56,6 @@ const TeamForm = ({ team, closeWithSnackbar, openTeamForm, setOpenTeamForm, acti
 
   const currentInfo = useMemo(() => {
     if (team) {
-      console.log(teamStatus);
-      console.log(teamStatus.find((type) => type.Description === team.Status));
       return {
         Name: team.Name,
         ActivityID: Number(activityID),

--- a/src/views/RecIM/components/Forms/TeamForm/index.js
+++ b/src/views/RecIM/components/Forms/TeamForm/index.js
@@ -46,7 +46,6 @@ const TeamForm = ({
       helperText: '*Required',
     },
   ];
-  console.log(isAdmin);
   if (team && isAdmin) {
     createTeamFields.push({
       label: 'Team Status',

--- a/src/views/RecIM/components/List/Listing/index.js
+++ b/src/views/RecIM/components/List/Listing/index.js
@@ -75,6 +75,7 @@ const SeriesListing = ({ series }) => {
 };
 
 const ActivityListing = ({ activity }) => {
+  console.log(activity);
   let registrationStart = DateTime.fromISO(activity.RegistrationStart);
   let registrationEnd = DateTime.fromISO(activity.RegistrationEnd);
   return (
@@ -88,13 +89,16 @@ const ActivityListing = ({ activity }) => {
             <Grid item xs={10}>
               <Chip
                 icon={<EventAvailableIcon />}
-                label="registration open"
-                color="success"
+                label={activity.RegistrationOpen ? 'registration open' : 'registration closed'}
+                color={activity.RegistrationOpen ? 'success' : 'info'}
                 size="small"
               ></Chip>
             </Grid>
             <Grid item xs={10}>
-              <Typography>Registration closes {standardDate(registrationEnd, false)}</Typography>
+              <Typography>
+                Registration close{activity.RegistrationOpen ? 's' : 'd'}{' '}
+                {standardDate(registrationEnd, false)}
+              </Typography>
               <Typography sx={{ color: 'gray', fontSize: '0.7em' }}>
                 <i>
                   testing purposes: {standardDate(registrationStart, true)} -{' '}

--- a/src/views/RecIM/components/List/Listing/index.js
+++ b/src/views/RecIM/components/List/Listing/index.js
@@ -75,7 +75,6 @@ const SeriesListing = ({ series }) => {
 };
 
 const ActivityListing = ({ activity }) => {
-  console.log(activity);
   let registrationStart = DateTime.fromISO(activity.RegistrationStart);
   let registrationEnd = DateTime.fromISO(activity.RegistrationEnd);
   return (

--- a/src/views/RecIM/components/List/Listing/index.js
+++ b/src/views/RecIM/components/List/Listing/index.js
@@ -149,7 +149,6 @@ const TeamListing = ({ team }) => {
 const ParticipantListing = ({ participant, minimal, callbackFunction, showParticipantOptions }) => {
   const { teamID } = useParams();
   const [avatar, setAvatar] = useState('');
-
   const [anchorEl, setAnchorEl] = useState(null);
   const moreOptionsOpen = Boolean(anchorEl);
   const handleClose = () => {
@@ -166,8 +165,8 @@ const ParticipantListing = ({ participant, minimal, callbackFunction, showPartic
   };
 
   const handleRemoveFromTeam = () => {
-    editTeamParticipant(participant.Username, teamID, 6) // Role 6 is inactive
-  }
+    editTeamParticipant(participant.Username, teamID, 6); // Role 6 is inactive
+  };
 
   useEffect(() => {
     const loadAvatar = async () => {
@@ -207,7 +206,7 @@ const ParticipantListing = ({ participant, minimal, callbackFunction, showPartic
               variant="rounded"
             ></Avatar>
           </ListItemAvatar>
-          <ListItemText primary={participant.Username} />
+          <ListItemText primary={participant.Username} secondary={participant.Role} />
         </ListItemButton>
         {showParticipantOptions ? (
           <Menu open={moreOptionsOpen} onClose={handleClose} anchorEl={anchorEl}>

--- a/src/views/RecIM/views/Activity/Activity.module.scss
+++ b/src/views/RecIM/views/Activity/Activity.module.scss
@@ -22,6 +22,10 @@
   text-transform: none;
 }
 
+.gridItemStack {
+  margin-bottom: 1em;
+}
+
 // if desired, this should just be a global change and
 // universally applied to all 360 cards
 .cardHeader {

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -23,6 +23,7 @@ import TeamForm from '../../components/Forms/TeamForm';
 import { getActivityByID } from 'services/recim/activity';
 import { Link as LinkRouter } from 'react-router-dom';
 import CreateSeriesForm from 'views/RecIM/components/Forms/CreateSeriesForm';
+import { getParticipantByUsername } from 'services/recim/participant';
 
 const Activity = () => {
   const { activityID } = useParams();
@@ -32,6 +33,7 @@ const Activity = () => {
   const [openActivityForm, setOpenActivityForm] = useState(false);
   const [openTeamForm, setOpenTeamForm] = useState(false);
   const [openCreateSeriesForm, setOpenCreateSeriesForm] = useState(false);
+  const [participant, setParticipant] = useState({});
   const subElementStyle = {
     marginBottom: '1em',
   };
@@ -40,10 +42,13 @@ const Activity = () => {
     const loadData = async () => {
       setLoading(true);
       setActivity(await getActivityByID(activityID));
+      if (profile) {
+        setParticipant(await getParticipantByUsername(profile.AD_Username));
+      }
       setLoading(false);
     };
     loadData();
-  }, [activityID, openTeamForm, openCreateSeriesForm, openActivityForm]);
+  }, [profile, activityID, openTeamForm, openCreateSeriesForm, openActivityForm]);
   // ^ May be bad practice, but will refresh page on dialog close
 
   const handleTeamForm = (status) => {
@@ -95,13 +100,15 @@ const Activity = () => {
               <Grid item xs={8} md={5}>
                 <Typography variant="h5" className={styles.activityTitle}>
                   {activity.Name}
-                  <IconButton>
-                    <EditIcon
-                      onClick={() => {
-                        setOpenActivityForm(true);
-                      }}
-                    />
-                  </IconButton>
+                  {participant.IsAdmin == true ? (
+                    <IconButton>
+                      <EditIcon
+                        onClick={() => {
+                          setOpenActivityForm(true);
+                        }}
+                      />
+                    </IconButton>
+                  ) : null}
                 </Typography>
                 <Typography variant="h6" className={styles.activitySubtitle}>
                   <i>Description of activity</i>
@@ -169,22 +176,23 @@ const Activity = () => {
             </Typography>
           )}
           <Grid container justifyContent="center">
-            <Button
-              variant="contained"
-              color="warning"
-              startIcon={<AddCircleRoundedIcon />}
-              className={styles.actionButton}
-              onClick={() => {
-                setOpenCreateSeriesForm(true);
-              }}
-            >
-              Create a New Series
-            </Button>
+            {participant.IsAdmin == true ? (
+              <Button
+                variant="contained"
+                color="warning"
+                startIcon={<AddCircleRoundedIcon />}
+                className={styles.actionButton}
+                onClick={() => {
+                  setOpenCreateSeriesForm(true);
+                }}
+              >
+                Create a New Series
+              </Button>
+            ) : null}
           </Grid>
         </CardContent>
       </Card>
     );
-
     return (
       <Grid container spacing={2}>
         <Grid item alignItems="center" xs={12}>

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -219,10 +219,10 @@ const Activity = () => {
             {scheduleCard}
           </Grid>
           <Grid item direction={'column'} xs={12} md={6}>
-            <Grid item style={subElementStyle}>
+            <Grid item style={styles.gridItemStack}>
               {seriesCard}
             </Grid>
-            <Grid item style={subElementStyle}>
+            <Grid item style={styles.gridItemStack}>
               {teamsCard}
             </Grid>
           </Grid>

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -29,12 +29,12 @@ const Activity = () => {
   const { activityID } = useParams();
   const { profile } = useUser();
   const [loading, setLoading] = useState(true);
-  const [activity, setActivity] = useState({});
+  const [activity, setActivity] = useState(null);
   const [openActivityForm, setOpenActivityForm] = useState(false);
   const [openTeamForm, setOpenTeamForm] = useState(false);
   const [openCreateSeriesForm, setOpenCreateSeriesForm] = useState(false);
-  const [participant, setParticipant] = useState({});
-  const [participantTeams, setParticipantTeams] = useState([]);
+  const [participant, setParticipant] = useState(null);
+  const [participantTeams, setParticipantTeams] = useState(null);
   const [canCreateTeam, setCanCreateTeam] = useState(true);
   const subElementStyle = {
     marginBottom: '1em',
@@ -57,11 +57,13 @@ const Activity = () => {
   // disable create team if participant already is participating in this activity,
   // unless they're an admin
   useEffect(() => {
-    setCanCreateTeam(activity.RegistrationOpen);
     if (participantTeams && participant) {
+      let participating = false;
+      setCanCreateTeam(activity.RegistrationOpen);
       participantTeams.forEach((team) => {
-        if (team.ActivityID === activity.ID) setCanCreateTeam(false || participant.IsAdmin);
+        if (team.ActivityID === activity.ID) participating = true;
       });
+      setCanCreateTeam(participating || participant.IsAdmin);
     }
   }, [activity, participant, participantTeams]);
   const handleTeamForm = (status) => {

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -100,7 +100,7 @@ const Activity = () => {
               <Grid item xs={8} md={5}>
                 <Typography variant="h5" className={styles.activityTitle}>
                   {activity.Name}
-                  {participant.IsAdmin == true ? (
+                  {participant.IsAdmin === true ? (
                     <IconButton>
                       <EditIcon
                         onClick={() => {
@@ -176,7 +176,7 @@ const Activity = () => {
             </Typography>
           )}
           <Grid container justifyContent="center">
-            {participant.IsAdmin == true ? (
+            {participant.IsAdmin === true ? (
               <Button
                 variant="contained"
                 color="warning"

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -60,7 +60,7 @@ const Activity = () => {
     setCanCreateTeam(activity.RegistrationOpen);
     if (participantTeams && participant) {
       participantTeams.forEach((team) => {
-        if (team.ActivityID == activityID) setCanCreateTeam(false || participant.IsAdmin);
+        if (team.ActivityID === activity.ID) setCanCreateTeam(false || participant.IsAdmin);
       });
     }
   }, [activity, participant, participantTeams]);

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -36,9 +36,6 @@ const Activity = () => {
   const [participant, setParticipant] = useState(null);
   const [participantTeams, setParticipantTeams] = useState(null);
   const [canCreateTeam, setCanCreateTeam] = useState(true);
-  const subElementStyle = {
-    marginBottom: '1em',
-  };
 
   useEffect(() => {
     const loadData = async () => {

--- a/src/views/RecIM/views/Activity/index.js
+++ b/src/views/RecIM/views/Activity/index.js
@@ -216,10 +216,10 @@ const Activity = () => {
             {scheduleCard}
           </Grid>
           <Grid item direction={'column'} xs={12} md={6}>
-            <Grid item style={styles.gridItemStack}>
+            <Grid item className={styles.gridItemStack}>
               {seriesCard}
             </Grid>
-            <Grid item style={styles.gridItemStack}>
+            <Grid item className={styles.gridItemStack}>
               {teamsCard}
             </Grid>
           </Grid>

--- a/src/views/RecIM/views/Home/Home.module.scss
+++ b/src/views/RecIM/views/Home/Home.module.scss
@@ -7,6 +7,10 @@
   color: $neutral-white;
 }
 
+.gridItemStack {
+  margin-bottom: 1em;
+}
+
 .homeHeaderTitle {
   font-weight: bold;
   color: $neutral-dark-gray2;

--- a/src/views/RecIM/views/Home/index.js
+++ b/src/views/RecIM/views/Home/index.js
@@ -14,7 +14,6 @@ import { getParticipantTeams, getParticipantByUsername } from 'services/recim/pa
 import WaiverForm from 'views/RecIM/components/Forms/WaiverForm';
 import CreateSeriesForm from 'views/RecIM/components/Forms/CreateSeriesForm';
 
-
 const Home = () => {
   const { profile } = useUser();
   const [loading, setLoading] = useState(true);
@@ -25,7 +24,7 @@ const Home = () => {
   const [participant, setParticipant] = useState([]);
   const [openWaiver, setOpenWaiver] = useState(false);
   const [createdActivity, setCreatedActivity] = useState({ ID: null });
-
+  const [hasPermissions, setHasPermissions] = useState(false);
   // profile hook used for future authentication
   // Administration privs will use AuthGroups -> example can be found in
   //           src/components/Header/components/NavButtonsRightCorner
@@ -46,8 +45,10 @@ const Home = () => {
 
   useEffect(() => {
     setOpenWaiver(participant == null);
+    if (participant) {
+      setHasPermissions(participant.IsAdmin);
+    }
   }, [participant]);
-
 
   const createActivityButton = (
     <Grid container justifyContent="center">
@@ -95,14 +96,15 @@ const Home = () => {
           <ActivityList activities={activities} />
         ) : (
           <Typography variant="body1" paragraph>
-            It looks like there aren't any Rec-IM events currently open for registration :(
+            It looks like there aren't any Rec-IM events currently open for registration T_T
           </Typography>
         )}
 
-        {createActivityButton}
+        {hasPermissions ? createActivityButton : null}
       </CardContent>
     </Card>
   );
+  // I changed the face because the linting was giving me an "error" since :( counted as an open paran
 
   // CARD - my teams
   let myTeamsCard = (

--- a/src/views/RecIM/views/Home/index.js
+++ b/src/views/RecIM/views/Home/index.js
@@ -181,10 +181,10 @@ const Home = () => {
         </Grid>
         <Grid item container justifyContent="center" spacing={2}>
           <Grid item xs={12} md={8}>
-            <Grid item style={styles.gridItemStack}>
+            <Grid item className={styles.gridItemStack}>
               {upcomingActivitiesCard}
             </Grid>
-            <Grid item style={styles.gridItemStack}>
+            <Grid item className={styles.gridItemStack}>
               {ongoingActivitiesCard}
             </Grid>
           </Grid>

--- a/src/views/RecIM/views/Home/index.js
+++ b/src/views/RecIM/views/Home/index.js
@@ -26,9 +26,6 @@ const Home = () => {
   const [openWaiver, setOpenWaiver] = useState(false);
   const [createdActivity, setCreatedActivity] = useState({ ID: null });
   const [hasPermissions, setHasPermissions] = useState(false);
-  const subElementStyle = {
-    marginBottom: '1em',
-  };
 
   // profile hook used for future authentication
   // Administration privs will use AuthGroups -> example can be found in
@@ -184,10 +181,10 @@ const Home = () => {
         </Grid>
         <Grid item container justifyContent="center" spacing={2}>
           <Grid item xs={12} md={8}>
-            <Grid item style={subElementStyle}>
+            <Grid item style={styles.gridItemStack}>
               {upcomingActivitiesCard}
             </Grid>
-            <Grid item style={subElementStyle}>
+            <Grid item style={styles.gridItemStack}>
               {ongoingActivitiesCard}
             </Grid>
           </Grid>

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -26,7 +26,6 @@ import TeamForm from 'views/RecIM/components/Forms/TeamForm';
 //expensive, comment on line 36
 import { getActivityByID } from 'services/recim/activity';
 
-
 const Team = () => {
   const { activityID, teamID } = useParams();
   const { profile } = useUser();
@@ -37,18 +36,12 @@ const Team = () => {
   //this is expensive, so optimally we would want another way to check that registration is open
   const [activity, setActivity] = useState(null);
   const [hasPermissions, setHasPermissions] = useState(false);
-  const [openInviteParticipantForm, setOpenInviteParticipantForm] = useState(false);
-  const handleInviteParticipantForm = (status) => {
-    //if you want to do something with the message make a snackbar function here
-    setOpenInviteParticipantForm(false);
-  };
 
   const [openInviteParticipantForm, setOpenInviteParticipantForm] = useState(false);
   const handleInviteParticipantForm = (status) => {
     //if you want to do something with the message make a snackbar function here
     setOpenInviteParticipantForm(false);
   };
-
 
   useEffect(() => {
     const loadTeamData = async () => {

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -25,7 +25,6 @@ import EditIcon from '@mui/icons-material/Edit';
 import TeamForm from 'views/RecIM/components/Forms/TeamForm';
 //expensive, comment on line 36
 import { getActivityByID } from 'services/recim/activity';
-import { DateTime } from 'luxon';
 
 const Team = () => {
   const { activityID, teamID } = useParams();

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -162,19 +162,21 @@ const Team = () => {
               <ParticipantList participants={team.Participant} />
             )}
           </CardContent>
-          <Grid container justifyContent="center">
-            <Button
-              variant="contained"
-              color="warning"
-              startIcon={<AddCircleRoundedIcon />}
-              className={styles.actionButton}
-              onClick={() => {
-                setOpenInviteParticipantForm(true);
-              }}
-            >
-              Invite Participant
-            </Button>
-          </Grid>
+          {hasPermissions ? (
+            <Grid container justifyContent="center">
+              <Button
+                variant="contained"
+                color="warning"
+                startIcon={<AddCircleRoundedIcon />}
+                className={styles.actionButton}
+                onClick={() => {
+                  setOpenInviteParticipantForm(true);
+                }}
+              >
+                Invite Participant
+              </Button>
+            </Grid>
+          ) : null}
         </CardContent>
         <InviteParticipantForm
           closeWithSnackbar={(status) => {

--- a/src/views/RecIM/views/Team/index.js
+++ b/src/views/RecIM/views/Team/index.js
@@ -227,6 +227,7 @@ const Team = () => {
             setOpenTeamForm={(bool) => setOpenTeamForm(bool)}
             activityID={activityID}
             team={team}
+            isAdmin={participant.IsAdmin}
           />
         ) : null}
       </Grid>


### PR DESCRIPTION
Additions
- Basic Edit Team Form
- Added On-going Activities on Home Page

Permissions Created:
Home Page
- Admins are the only ones allowed to create Activity

Activity Page
- Admins are the only ones allowed to EDIT the Activity
- Admins are the only ones allowed to Create a Series
- Students can only Create a Team if they are not already participating in the Activity
- Admins can Create a Team whenever

Team Page
- Only Admins can edit Team Status
- Student Captains/Co-Captains can edit Team Name and Invite Participants WHEN registration is open
- Admins are not restricted by the clause above
