### PR TITLE
FIXED - MemberListItem pointing to the wrong URL on mobile.

### DIFF
--- a/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.jsx
@@ -335,7 +335,7 @@ const MemberListItem = ({
                         {member.FirstName} {member.LastName}
                       </Typography>
                     ) : (
-                      <Link href={`/profile/${member.AD_Username}`} underline="hover">
+                      <Link href={`/profile/${member.Username}`} underline="hover">
                         <Typography>
                           {member.FirstName} {member.LastName}
                         </Typography>
@@ -388,7 +388,7 @@ const MemberListItem = ({
                 {member.FirstName} {member.LastName}
               </Typography>
             ) : (
-              <Link href={`/profile/${member.AD_Username}`} underline="hover">
+              <Link href={`/profile/${member.Username}`} underline="hover">
                 <Typography>
                   {member.FirstName} {member.LastName}
                 </Typography>


### PR DESCRIPTION
Changed `AD_Username` property to `Username` of the `member` object.