### PR TITLE
Fix clifton strengths external links

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -208,8 +208,8 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
             {profile.HomeCity === PRIVATE_INFO
               ? PRIVATE_INFO
               : profile.Country === 'United States of America' || !profile.Country
-                ? `${profile.HomeCity}, ${profile.HomeState}`
-                : profile.Country}
+              ? `${profile.HomeCity}, ${profile.HomeState}`
+              : profile.Country}
           </span>
         </>
       }
@@ -267,9 +267,9 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
         contentText={
           <Typography>
             {profile.CliftonStrengths.Themes.map((strength) => (
-              <Link href={strength.link} target="_blank" rel="noopener" key={strength.name}>
+              <a href={strength.link} target="_blank" rel="noopener noreferrer" key={strength.name}>
                 <b style={{ color: strength.color }}>{strength.name}</b>
-              </Link>
+              </a>
             )).reduce((prev, curr) => [prev, ', ', curr])}
             <GordonTooltip
               title={
@@ -455,11 +455,11 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
 
   const disclaimer =
     !myProf &&
-      (isHomePhonePrivate ||
-        isAddressPrivate ||
-        isMobilePhonePrivate ||
-        isCampusLocationPrivate ||
-        isSpousePrivate) ? (
+    (isHomePhonePrivate ||
+      isAddressPrivate ||
+      isMobilePhonePrivate ||
+      isCampusLocationPrivate ||
+      isSpousePrivate) ? (
       <Typography align="left" className={styles.disclaimer}>
         Private by request, visible only to faculty and staff
       </Typography>
@@ -468,8 +468,9 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
   return (
     <Grid item xs={12}>
       <Card
-        className={`${styles.personal_info_list}  ${myProf ? styles.my_personal_info : styles.public_personal_info
-          }`}
+        className={`${styles.personal_info_list}  ${
+          myProf ? styles.my_personal_info : styles.public_personal_info
+        }`}
       >
         <Grid
           container

--- a/src/services/cliftonStrengths.ts
+++ b/src/services/cliftonStrengths.ts
@@ -87,7 +87,7 @@ const categoryPerStrengthName = (strength: CliftonStrengthName): CliftonStrength
   }
 };
 
-export enum CliftonStrengthColors {
+enum CliftonStrengthColors {
   Executing = '#9070bf',
   Influencing = '#c88a2e',
   Relationship = '#2486af',


### PR DESCRIPTION
Clifton Strengths on the profile page is supposed to link to the Gallup introduction to each theme. However, because the link was using React Router's `Link` tag, the `href` prop (which was pointing to the correct page) was being ignored because the `Link` component requires a `to` prop instead.

Closes #1590 