### PR TITLE
Update continuous deployment for Vite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: build-train
-          path: build
+          path: dist
 
       - name: Upload master build artifacts for deployment
         if: ${{ github.ref == 'refs/heads/master' }}
         uses: actions/upload-artifact@v3
         with:
           name: build-prod
-          path: build
+          path: dist


### PR DESCRIPTION
The output path of our builds has changed from `/build` to `/dist` since upgrading to Vite, so the CD script needs to be updated.