### PR TITLE
Allow `AcademicInfoView` AuthGroup to view advisor info of students.

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -50,9 +50,10 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
   const isStudent = profile.PersonType?.includes('stu');
   const isFacStaff = profile.PersonType?.includes('fac');
   const isAlumni = profile.PersonType?.includes('alu');
-  const [isViewerPolice, canViewSensitiveInfo] = useAuthGroups(
+  const [isViewerPolice, canViewSensitiveInfo, canViewAcademicInfo] = useAuthGroups(
     AuthGroup.Police,
     AuthGroup.SensitiveInfoView,
+    AuthGroup.AcademicInfoView,
   );
 
   // KeepPrivate has different values for Students and FacStaff.
@@ -307,7 +308,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
     ) : null;
 
   const advisors =
-    myProf && isStudent ? (
+    (myProf || canViewAcademicInfo) && isStudent ? (
       <ProfileInfoListItem
         title={profile.Advisors?.length > 1 ? 'Advisors:' : 'Advisor:'}
         contentText={

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -133,6 +133,7 @@ export enum AuthGroup {
   SiteAdmin = '360-SiteAdmin-SG',
   Staff = '360-Staff-SG',
   Student = '360-Student-SG',
+  AcademicInfoView = '360-AcademicInfoView-SG',
 }
 
 export {


### PR DESCRIPTION
Faculty and staff are currently unable to physically view advisor information of students on the student's profile. To resolve this, the authentication group 'AcademicInfoView' was made so that anyone included in this auth group would be able to see the advisors in a student's profile. 

This PR allows any user in auth group AcademicInfoView to also view the advisor information of a student in the student's profile, in addition to students that can already view their own advisor information on their profiles. 
fixes #1509 