### PR TITLE
Clifton Strengths to show on both Fac/Staff and Student Profiles

### DIFF
--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -262,13 +262,16 @@ const getProfileInfo = async (username: string = ''): Promise<Profile | undefine
   if (!profile) return undefined;
 
   const fullName = `${profile?.FirstName} ${profile?.LastName}`;
+  const getCliftonStrengths = await CliftonStrengthsService.getCliftonStrengths(
+    profile.AD_Username,
+  );
 
   if (isStudent(profile)) {
     return {
       ...profile,
       fullName,
       Advisors: await getAdvisors(profile.AD_Username),
-      CliftonStrengths: await CliftonStrengthsService.getCliftonStrengths(profile.AD_Username),
+      CliftonStrengths: getCliftonStrengths,
       Majors: [
         profile.Major1Description,
         profile.Major2Description,
@@ -285,6 +288,7 @@ const getProfileInfo = async (username: string = ''): Promise<Profile | undefine
     return {
       ...profile,
       fullName,
+      CliftonStrengths: getCliftonStrengths,
     };
   }
 };

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -262,16 +262,14 @@ const getProfileInfo = async (username: string = ''): Promise<Profile | undefine
   if (!profile) return undefined;
 
   const fullName = `${profile?.FirstName} ${profile?.LastName}`;
-  const getCliftonStrengths = await CliftonStrengthsService.getCliftonStrengths(
-    profile.AD_Username,
-  );
+  const cliftonStrengths = await CliftonStrengthsService.getCliftonStrengths(profile.AD_Username);
 
   if (isStudent(profile)) {
     return {
       ...profile,
       fullName,
       Advisors: await getAdvisors(profile.AD_Username),
-      CliftonStrengths: getCliftonStrengths,
+      CliftonStrengths: cliftonStrengths,
       Majors: [
         profile.Major1Description,
         profile.Major2Description,
@@ -288,7 +286,7 @@ const getProfileInfo = async (username: string = ''): Promise<Profile | undefine
     return {
       ...profile,
       fullName,
-      CliftonStrengths: getCliftonStrengths,
+      CliftonStrengths: cliftonStrengths,
     };
   }
 };


### PR DESCRIPTION
This PR fixes some logic in fetching a user profile so that Clifton Strengths show on the profiles of both Fac/Staff and Students if it is available (and/or public?). 

Fixes #1642 