### PR TITLE
Fix Case for Showing no Events Message

### DIFF
--- a/src/components/EventList/index.jsx
+++ b/src/components/EventList/index.jsx
@@ -65,7 +65,7 @@ const EventList = ({ events }) => {
       <CardHeader title={header} className={styles.header} />
       <Grid>
         <List className="gc360_event_list" disablePadding>
-          {events?.length <= 0
+          {events?.length < 1
             ? noEvents
             : events.map((event) => <EventItem event={event} key={event.Event_ID} />)}
         </List>

--- a/src/components/EventList/index.jsx
+++ b/src/components/EventList/index.jsx
@@ -65,7 +65,7 @@ const EventList = ({ events }) => {
       <CardHeader title={header} className={styles.header} />
       <Grid>
         <List className="gc360_event_list" disablePadding>
-          {events?.length < 0
+          {events?.length <= 0
             ? noEvents
             : events.map((event) => <EventItem event={event} key={event.Event_ID} />)}
         </List>


### PR DESCRIPTION
This check to see if there are any events with the current filters is checking for `length < 0` which is a case that will never occur. This PR updates the logic to check `length <= 0` instead.