### PR TITLE
[Rec-IM] Allow Form Submit on Button Key Press

### DIFF
--- a/src/components/GordonDialogBox/index.js
+++ b/src/components/GordonDialogBox/index.js
@@ -1,4 +1,5 @@
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+// import { useEffect } from 'react';
 import { Alert, AlertTitle } from '@mui/material';
 import styles from './GordonDialogBox.module.css';
 
@@ -31,6 +32,18 @@ const GordonDialogBox = ({
   children,
   ...otherProps
 }) => {
+  // useEffect(() => {
+  //   const listener = (event) => {
+  //     if (event.code === "Enter" || event.code === "NumpadEnter") {
+  //       buttonClicked();
+  //     }
+  //   };
+  //   document.addEventListener("keypress", listener);
+  //   return () => {
+  //     document.removeEventListener("keypress", listener);
+  //   };
+  // }, [buttonClicked]);
+
   return (
     <Dialog
       className={styles.gc360_gordondialogbox}

--- a/src/views/RecIM/components/Forms/ActivityForm/index.js
+++ b/src/views/RecIM/components/Forms/ActivityForm/index.js
@@ -278,6 +278,20 @@ const ActivityForm = ({
     setNewInfo(currentInfo);
   };
 
+  useEffect(() => {
+    const listener = (event) => {
+      if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+        if (!openConfirmWindow && !disableUpdateButton) {
+          setOpenConfirmWindow(true);
+        }
+      }
+    };
+    document.addEventListener('keypress', listener);
+    return () => {
+      document.removeEventListener('keypress', listener);
+    };
+  }, [openConfirmWindow, disableUpdateButton]);
+
   /**
    * @param {Array<{name: string, label: string, type: string, menuItems: string[]}>} fields array of objects defining the properties of the input field
    * @returns JSX correct input for each field based on type


### PR DESCRIPTION
This is going to remain a draft for a while I believe, and may end up morphing into the branch that handles our form cleanup. Essentially, we could put a listener for an enter keypress on the GordonDialogBox component, but that makes it so if we press enter once, both the form submits and the confirmation is dismissed (if Cam has any advice for this you can see the commented code in GordonDialogBox file). I opted to place the listener in our activity page. I did not make it activate the handle submit, as it would need to be wrapped in a useCallback hook. Right now, the keypress will open the confirmation page, if it is able to be opened but I would like some input before I move further in this direction.