### PR TITLE
Add state updates after Addmember function to 'clear' the form after close.

### DIFF
--- a/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
@@ -85,9 +85,6 @@ const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddM
         }
       }
     }
-    setUsername('');
-    setParticipationCode('');
-    setTitleComment('');
   };
 
   return (
@@ -149,7 +146,6 @@ const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddM
                 Participation
               </InputLabel>
               <Select
-                value={participationCode}
                 onChange={(event) => setParticipationCode(event.target.value)}
                 labelId="involvement-profile-add-member-select-participation"
               >
@@ -167,7 +163,6 @@ const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddM
               type="search"
               fullWidth
               onChange={(event) => setTitleComment(event.target.value)}
-              value={titleComment}
             />
           </Grid>
         </Grid>

--- a/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
@@ -85,6 +85,9 @@ const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddM
         }
       }
     }
+    setUsername('');
+    setParticipationCode('');
+    setTitleComment('');
   };
 
   return (


### PR DESCRIPTION
This PR will fix the issue where the involvement member form saves with the previously inputted values after closing it. This will update it so that after closing the member form list, it clears it out.