### PR TITLE
Read Vite Port and Host From Env File

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig, loadEnv, splitVendorChunkPlugin } from 'vite';
 import react from '@vitejs/plugin-react';
+import { defineConfig, loadEnv, splitVendorChunkPlugin } from 'vite';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
@@ -9,6 +9,8 @@ const config = ({ mode }) => {
   return defineConfig({
     plugins: [react(), viteTsconfigPaths(), splitVendorChunkPlugin()],
     server: {
+      port: parseInt(process.env.VITE_PORT ?? "5173"),
+      host: process.env.VITE_HOST ?? "localhost",
       proxy: {
         '/api': {
           target: process.env.VITE_API_URL,


### PR DESCRIPTION
This PR will change the VITE configuration so that it allows the user to specify the hostname and port that they want VITE to try to run on as an option. It reads this information from the env files as `VITE_PORT` and `VITE_HOST`.