### PR TITLE
Fix Happy Birthday Message

### DIFF
--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,8 +1,8 @@
 import { DateTime } from 'luxon';
 import { Platform, platforms, socialMediaInfo } from 'services/socialMedia';
 import CliftonStrengthsService, { CliftonStrengths } from './cliftonStrengths';
-import { Class } from './peopleSearch';
 import http from './http';
+import { Class } from './peopleSearch';
 import { Override } from './utils';
 
 type CLWCredits = {
@@ -249,7 +249,7 @@ const getBirthdate = async (): Promise<DateTime> =>
 
 const isBirthdayToday = async () => {
   const birthday = await getBirthdate();
-  return birthday?.toISODate() === DateTime.now().toISODate();
+  return birthday?.month === DateTime.now().month && birthday?.day === DateTime.now().day;
 };
 
 // TODO: Add type info


### PR DESCRIPTION
The "is birthday today" logic in the user service was comparing date ISO formats to see if a user's birthday was the current date. Unfortunately, the user's birthday in ISO format also includes the year that they were born so this will essentially never resolve to true.

This PR updates the logic so that it compares the month number and the day of the month (1-30ish) rather than the ISO date string.

This change will officially activate the "Happy Birthday" message feature for the first time in Production.