### PR TITLE
HOTFIX: Involvement Membership Loading

### DIFF
--- a/src/views/InvolvementProfile/components/Membership/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/index.jsx
@@ -33,7 +33,7 @@ const Membership = ({ isAdmin, isSiteAdmin, involvementDescription, toggleIsAdmi
         setFollowersNum(followersNum);
         setMembersNum(membersNum);
 
-        if (membership?.Participation !== Participation.Guest || isSiteAdmin) {
+        if ((membership && membership.Participation !== Participation.Guest) || isSiteAdmin) {
           setMembers(await membershipService.get({ involvementCode, sessionCode }));
         }
 
@@ -101,16 +101,18 @@ const Membership = ({ isAdmin, isSiteAdmin, involvementDescription, toggleIsAdmi
               />
             </Grid>
           )}
-          <Grid item>
-            <MemberList
-              members={members}
-              isAdmin={isAdmin}
-              isSiteAdmin={isSiteAdmin}
-              createSnackbar={createSnackbar}
-              onLeave={handleLeave}
-              onToggleIsAdmin={toggleIsAdmin}
-            />
-          </Grid>
+          {members.length > 0 && (
+            <Grid item>
+              <MemberList
+                members={members}
+                isAdmin={isAdmin}
+                isSiteAdmin={isSiteAdmin}
+                createSnackbar={createSnackbar}
+                onLeave={handleLeave}
+                onToggleIsAdmin={toggleIsAdmin}
+              />
+            </Grid>
+          )}
         </>
       );
     } else {


### PR DESCRIPTION
Involvement memberships are currently not loading for non-site-admins unless they are a member of the involvement. This is caused by a null coalesce with a user's personal membership to check if their participation is of type guest. If they are not a guest, they are allowed to see the membership. Unfortunately `membership?.ParticipationType` resolves to `null` when the current user is not a member of the involvement, and the comparison `membership.Participation !== Participation.Guest` resolves to `true`.

This PR fixes the issue by first checking if the membership is not falsey (aka not null).

I also added a UI cleanup that does not show the members block if the memberships array is empty. Otherwise it could cause some confusion if a user is seeing a blank table whereas others see members in it. Hiding the entire table is better for UX since it is clearer that they don't have access to the component.

Closes #845