### PR TITLE
Create new 409 Error 'Conflict' to give a 'Member Already Added' error message for involvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4887,9 +4887,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
@@ -12544,9 +12544,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-proxy": {
       "version": "1.18.1",

--- a/src/services/error.ts
+++ b/src/services/error.ts
@@ -16,6 +16,15 @@ class NotFoundError implements Error {
   }
 }
 
+class ConflictError implements Error {
+  name: string;
+  message: string;
+  constructor(message: string | undefined) {
+    this.name = 'ConflictError';
+    this.message = message || 'Specified resource already exists';
+  }
+}
+
 /**
  * Create an error object based on an HTTP error from the backend
  *
@@ -28,9 +37,11 @@ const createError = (err: Error, res: Response): Error | AuthError | NotFoundErr
     return new AuthError(err.message);
   } else if (res.status === 404) {
     return new NotFoundError(err.message);
+  } else if (res.status === 409) {
+    return new ConflictError(err.message);
   }
 
   return err;
 };
 
-export { AuthError, createError, NotFoundError };
+export { AuthError, createError, NotFoundError, ConflictError };

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,8 +1,8 @@
 import { DateTime } from 'luxon';
 import { Platform, platforms, socialMediaInfo } from 'services/socialMedia';
 import CliftonStrengthsService, { CliftonStrengths } from './cliftonStrengths';
-import { Class } from './peopleSearch';
 import http from './http';
+import { Class } from './peopleSearch';
 import { Override } from './utils';
 
 type CLWCredits = {
@@ -249,7 +249,7 @@ const getBirthdate = async (): Promise<DateTime> =>
 
 const isBirthdayToday = async () => {
   const birthday = await getBirthdate();
-  return birthday?.toISODate() === DateTime.now().toISODate();
+  return birthday?.month === DateTime.now().month && birthday?.day === DateTime.now().day;
 };
 
 // TODO: Add type info

--- a/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
@@ -21,6 +21,7 @@ import membershipService from 'services/membership';
 import { stripDomain } from 'services/utils';
 import { gordonColors } from 'theme';
 import RequestsReceived from './components/RequestsReceived';
+import { ConflictError, NotFoundError } from 'services/error';
 
 const headerStyle = {
   backgroundColor: gordonColors.primary.blue,
@@ -71,14 +72,13 @@ const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddM
       onAddMember();
       setIsDialogOpen(false);
     } catch (error) {
-      switch (error.name) {
-        case 'NotFoundError':
-          createSnackbar('Nobody with that username was found', 'error');
-          break;
-
-        default:
-          createSnackbar('This member could not be added', 'error');
-          console.log(error);
+      if (error instanceof ConflictError) {
+        createSnackbar(`${username} is already a member`, 'info');
+      } else if (error instanceof NotFoundError) {
+        createSnackbar('Nobody with that username was found', 'error');
+      } else {
+        createSnackbar('An error has occured', 'error');
+        console.log(error);
       }
     }
   };

--- a/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
@@ -79,7 +79,6 @@ const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddM
         default:
           createSnackbar('This member could not be added', 'error');
           console.log(error);
-          break;
       }
     }
   };

--- a/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
@@ -71,18 +71,15 @@ const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddM
       onAddMember();
       setIsDialogOpen(false);
     } catch (error) {
-      if (error.Message === 'The Person is already part of the activity.') {
-        createSnackbar(`${username} is already a member`, 'info');
-      } else {
-        switch (error.name) {
-          case 'NotFoundError':
-            createSnackbar('Nobody with that username was found', 'error');
-            break;
+      switch (error.name) {
+        case 'NotFoundError':
+          createSnackbar('Nobody with that username was found', 'error');
+          break;
 
-          default:
-            console.log(error);
-            break;
-        }
+        default:
+          createSnackbar('This member could not be added', 'error');
+          console.log(error);
+          break;
       }
     }
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig, loadEnv, splitVendorChunkPlugin } from 'vite';
 import react from '@vitejs/plugin-react';
+import { defineConfig, loadEnv, splitVendorChunkPlugin } from 'vite';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
@@ -9,6 +9,8 @@ const config = ({ mode }) => {
   return defineConfig({
     plugins: [react(), viteTsconfigPaths(), splitVendorChunkPlugin()],
     server: {
+      port: parseInt(process.env.VITE_PORT ?? "5173"),
+      host: process.env.VITE_HOST ?? "localhost",
       proxy: {
         '/api': {
           target: process.env.VITE_API_URL,


### PR DESCRIPTION
The current mode for catching 'Member Already Added' exceptions/errors is bypassed because the error message does not return exactly what is expected by the code (replicated by trying to add an already existing member to a club/involvement). 
As a result, there is currently no visual/UI response when trying to add a member that already exists. There is only a console error.

~~This PR redirects the catching of the error to the default of a switch/case statement so that a snackbar shows (at the very least) that an error has occurred.~~

~~Bennett and I discussed this very abruptly during our last weekly team meeting so I'm not certain if this is the best way to approach this issue. It may require or benefit from a fix on the API side?~~

This PR creates a new error 'Conflict Error' which is caught when trying to add an already existing member. The caught error will product a snackbar that states that `'username' is already a member`.

Fixes #1701 