### PR TITLE
Fac/Staff Personal Info Toggle Visual Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "stylelint": "^14.9.0",
         "stylelint-config-recommended-scss": "^5.0.2",
         "vite": "^4.0.4",
+        "vite-plugin-rewrite-all": "^1.0.1",
         "vite-tsconfig-paths": "^4.0.3"
       }
     },
@@ -3018,6 +3019,15 @@
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
     },
+    "node_modules/connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -5439,9 +5449,9 @@
       }
     },
     "node_modules/jsdoc": {
-      "version": "3.6.10",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.10.tgz",
-      "integrity": "sha512-IdQ8ppSo5LKZ9o3M+LKIIK8i00DIe5msDvG3G81Km+1dhy0XrOWD0Ji8H61ElgyEj/O9KRLokgKbAM9XX9CJAg==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
+      "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.9.4",
@@ -5450,7 +5460,7 @@
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
-        "klaw": "^4.0.1",
+        "klaw": "^3.0.0",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^8.4.1",
         "marked": "^4.0.10",
@@ -5464,7 +5474,7 @@
         "jsdoc": "jsdoc.js"
       },
       "engines": {
-        "node": ">=8.15.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
@@ -5649,12 +5659,12 @@
       }
     },
     "node_modules/klaw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
-      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
       "dev": true,
-      "engines": {
-        "node": ">=14.14.0"
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/known-css-properties": {
@@ -8880,6 +8890,21 @@
         }
       }
     },
+    "node_modules/vite-plugin-rewrite-all": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-rewrite-all/-/vite-plugin-rewrite-all-1.0.1.tgz",
+      "integrity": "sha512-W0DAchC8ynuQH0lYLIu5/5+JGfYlUTRD8GGNtHFXRJX4FzzB9MajtqHBp26zq/ly9sDt5BqrfdT08rv3RbB0LQ==",
+      "dev": true,
+      "dependencies": {
+        "connect-history-api-fallback": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/vite-tsconfig-paths": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.0.3.tgz",
@@ -11162,6 +11187,12 @@
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
     },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -12927,9 +12958,9 @@
       }
     },
     "jsdoc": {
-      "version": "3.6.10",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.10.tgz",
-      "integrity": "sha512-IdQ8ppSo5LKZ9o3M+LKIIK8i00DIe5msDvG3G81Km+1dhy0XrOWD0Ji8H61ElgyEj/O9KRLokgKbAM9XX9CJAg==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
+      "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
@@ -12938,7 +12969,7 @@
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
-        "klaw": "^4.0.1",
+        "klaw": "^3.0.0",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^8.4.1",
         "marked": "^4.0.10",
@@ -13107,10 +13138,13 @@
       "dev": true
     },
     "klaw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
-      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
     },
     "known-css-properties": {
       "version": "0.25.0",
@@ -15470,6 +15504,15 @@
             "fsevents": "~2.3.2"
           }
         }
+      }
+    },
+    "vite-plugin-rewrite-all": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-rewrite-all/-/vite-plugin-rewrite-all-1.0.1.tgz",
+      "integrity": "sha512-W0DAchC8ynuQH0lYLIu5/5+JGfYlUTRD8GGNtHFXRJX4FzzB9MajtqHBp26zq/ly9sDt5BqrfdT08rv3RbB0LQ==",
+      "dev": true,
+      "requires": {
+        "connect-history-api-fallback": "^1.6.0"
       }
     },
     "vite-tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "stylelint": "^14.9.0",
     "stylelint-config-recommended-scss": "^5.0.2",
     "vite": "^4.0.4",
+    "vite-plugin-rewrite-all": "^1.0.1",
     "vite-tsconfig-paths": "^4.0.3"
   },
   "scripts": {

--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -79,8 +79,6 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
   const isCampusLocationPrivate = isStudent && keepPrivate && profile.OnOffCampus !== PRIVATE_INFO;
 
   // Students' home phone is always private. FacStaffs' home phone is private for private users
-  // Why isHomePhonePrivate always no/false?
-  // For some reason, showing the disclaimer text...
   const [isHomePhonePrivate, setIsHomePhonePrivate] = useState(isStudent || keepPrivate);
 
   // Street address info is always private, and City/State/Country info is private for private users
@@ -116,6 +114,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
 
   const handleChangeHomePhonePrivacy = async () => {
     try {
+      // this user service currently sets mobile_privacy to true or false - same as setMobilePhonePrivacy, which is NOT optimal or sensical. See user.ts
       await userService.setHomePhonePrivacy(!isHomePhonePrivate);
       setIsHomePhonePrivate(!isHomePhonePrivate);
 
@@ -473,7 +472,11 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
 
   const disclaimer =
     !myProf &&
-    (isAddressPrivate || isMobilePhonePrivate || isCampusLocationPrivate || isSpousePrivate) ? (
+    (isHomePhonePrivate ||
+      isAddressPrivate ||
+      isMobilePhonePrivate ||
+      isCampusLocationPrivate ||
+      isSpousePrivate) ? (
       <Typography align="left" className={styles.disclaimer}>
         Private by request, visible only to faculty and staff
       </Typography>
@@ -497,13 +500,13 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
           </Grid>
           <Grid item xs={4} align="right">
             {/* visible only for fac/staff on their profile */}
+            {/* isHomePhonePrivate is a misleading name for determining if personal information should be shown */}
             {isFacStaff && myProf ? (
               <FormControlLabel
                 control={
                   <Switch
                     onChange={handleChangeHomePhonePrivacy}
                     color="secondary"
-                    // saying isHomePhonePrivate is always returning 'no' - which means it is always public
                     checked={!isHomePhonePrivate}
                   />
                 }

--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -79,9 +79,9 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
   const isCampusLocationPrivate = isStudent && keepPrivate && profile.OnOffCampus !== PRIVATE_INFO;
 
   // Students' home phone is always private. FacStaffs' home phone is private for private users
-  const [isHomePhonePrivate, setIsHomePhonePrivate] = useState(
-    (isStudent || keepPrivate) && Boolean(profile.HomePhone),
-  );
+  // Why isHomePhonePrivate always no/false?
+  // For some reason, showing the disclaimer text...
+  const [isHomePhonePrivate, setIsHomePhonePrivate] = useState(isStudent || keepPrivate);
 
   // Street address info is always private, and City/State/Country info is private for private users
   const isAddressPrivate =
@@ -473,11 +473,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
 
   const disclaimer =
     !myProf &&
-    (isHomePhonePrivate ||
-      isAddressPrivate ||
-      isMobilePhonePrivate ||
-      isCampusLocationPrivate ||
-      isSpousePrivate) ? (
+    (isAddressPrivate || isMobilePhonePrivate || isCampusLocationPrivate || isSpousePrivate) ? (
       <Typography align="left" className={styles.disclaimer}>
         Private by request, visible only to faculty and staff
       </Typography>
@@ -507,6 +503,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
                   <Switch
                     onChange={handleChangeHomePhonePrivacy}
                     color="secondary"
+                    // saying isHomePhonePrivate is always returning 'no' - which means it is always public
                     checked={!isHomePhonePrivate}
                   />
                 }

--- a/src/components/Providers/components/AuthProvider/index.tsx
+++ b/src/components/Providers/components/AuthProvider/index.tsx
@@ -1,0 +1,47 @@
+import { MsalProvider } from '@azure/msal-react';
+import {
+  AuthenticationResult,
+  EventMessage,
+  EventType,
+  PublicClientApplication,
+} from '@azure/msal-browser';
+
+const msalConfig = {
+  auth: {
+    clientId: import.meta.env.VITE_AZURE_AD_CLIENT as string,
+    authority: `https://login.microsoftonline.com/${import.meta.env.VITE_AZURE_AD_TENANT}`,
+    postLogoutRedirectUri: window.location.origin,
+    redirectUri: window.location.origin,
+    validateAuthority: true,
+    // After being redirected to the "redirectUri" page, should user
+    // be redirected back to the Url where their login originated from?
+    navigateToLoginRequestUrl: true,
+  },
+  cache: {
+    cacheLocation: 'localStorage', // This configures where your cache will be stored
+    storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+  },
+};
+
+export const msalInstance = new PublicClientApplication(msalConfig);
+if (!msalInstance.getActiveAccount() && msalInstance.getAllAccounts().length > 0) {
+  msalInstance.setActiveAccount(msalInstance.getAllAccounts()[0]);
+}
+
+// this will update account state if a user signs in from another tab or window
+msalInstance.enableAccountStorageEvents();
+
+// Update msalInstance when user logs in successfully
+msalInstance.addEventCallback((event: EventMessage) => {
+  if (event.eventType === EventType.LOGIN_SUCCESS && event.payload) {
+    const payload = event.payload as AuthenticationResult;
+    const account = payload.account;
+    msalInstance.setActiveAccount(account);
+  }
+});
+
+const AuthProvider = ({ children }: { children: JSX.Element }) => (
+  <MsalProvider instance={msalInstance}>{children}</MsalProvider>
+);
+
+export default AuthProvider;

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -1,0 +1,20 @@
+import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
+import UserContextProvider from 'contexts/UserContext';
+import 'app.global.css';
+import NetworkContextProvider from 'contexts/NetworkContext';
+import theme from 'theme';
+import AuthProvider from './components/AuthProvider';
+
+const Providers = ({ children }: { children: JSX.Element }) => (
+  <AuthProvider>
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={theme}>
+        <NetworkContextProvider>
+          <UserContextProvider>{children}</UserContextProvider>
+        </NetworkContextProvider>
+      </ThemeProvider>
+    </StyledEngineProvider>
+  </AuthProvider>
+);
+
+export default Providers;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,33 +1,14 @@
-import { PublicClientApplication } from '@azure/msal-browser';
-import { MsalProvider } from '@azure/msal-react';
-import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
-import UserContextProvider from 'contexts/UserContext';
+import Providers from 'components/Providers';
 import { register } from 'pwa';
-import React from 'react';
 import ReactDOM from 'react-dom';
-import { configureMSAL, msalConfig } from 'services/auth';
 import App from './app';
 import './app.global.css';
-import NetworkContextProvider from './contexts/NetworkContext';
-import theme from './theme';
 
-export const msalInstance = new PublicClientApplication(msalConfig);
-configureMSAL(msalInstance);
-
-const AppWithProviders = () => (
-  <MsalProvider instance={msalInstance}>
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={theme}>
-        <NetworkContextProvider>
-          <UserContextProvider>
-            <App />
-          </UserContextProvider>
-        </NetworkContextProvider>
-      </ThemeProvider>
-    </StyledEngineProvider>
-  </MsalProvider>
+ReactDOM.render(
+  <Providers>
+    <App />
+  </Providers>,
+  document.getElementById('root'),
 );
-
-ReactDOM.render(<AppWithProviders />, document.getElementById('root'));
 
 register();

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,53 +1,9 @@
-import {
-  AuthenticationResult,
-  EventMessage,
-  EventType,
-  InteractionRequiredAuthError,
-  PublicClientApplication,
-  SilentRequest,
-} from '@azure/msal-browser';
-import { msalInstance } from 'index';
+import { InteractionRequiredAuthError, SilentRequest } from '@azure/msal-browser';
+import { msalInstance } from 'components/Providers/components/AuthProvider';
 import storage from './storage';
-
-export const msalConfig = {
-  auth: {
-    clientId: import.meta.env.VITE_AZURE_AD_CLIENT as string,
-    authority: `https://login.microsoftonline.com/${import.meta.env.VITE_AZURE_AD_TENANT}`,
-    postLogoutRedirectUri: window.location.origin,
-    redirectUri: window.location.origin,
-    validateAuthority: true,
-    // After being redirected to the "redirectUri" page, should user
-    // be redirected back to the Url where their login originated from?
-    navigateToLoginRequestUrl: true,
-  },
-  cache: {
-    cacheLocation: 'localStorage', // This configures where your cache will be stored
-    storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
-  },
-};
 
 const apiRequest = {
   scopes: ['api://b19c300a-00dc-4adc-bcd1-b678b25d7ad1/access_as_user'],
-};
-
-export const configureMSAL = (msalInstance: PublicClientApplication) => {
-  if (!msalInstance.getActiveAccount() && msalInstance.getAllAccounts().length > 0) {
-    msalInstance.setActiveAccount(msalInstance.getAllAccounts()[0]);
-  }
-
-  // this will update account state if a user signs in from another tab or window
-  msalInstance.enableAccountStorageEvents();
-
-  msalInstance.addEventCallback((event: EventMessage) => {
-    if (event.eventType === EventType.LOGIN_SUCCESS && event.payload) {
-      const payload = event.payload as AuthenticationResult;
-      const account = payload.account;
-      msalInstance.setActiveAccount(account);
-    } else if (event.eventType === EventType.ACQUIRE_TOKEN_SUCCESS && event.payload) {
-    }
-  });
-
-  return msalInstance;
 };
 
 const authenticate = async () => {

--- a/src/services/checkIn.ts
+++ b/src/services/checkIn.ts
@@ -1,5 +1,4 @@
-import { AuthError } from '@azure/msal-browser';
-import { NotFoundError } from './error';
+import { AuthError, NotFoundError } from './error';
 import http from './http';
 
 /**

--- a/src/services/checkIn.ts
+++ b/src/services/checkIn.ts
@@ -1,3 +1,4 @@
+import { AuthError } from '@azure/msal-browser';
 import { NotFoundError } from './error';
 import http from './http';
 
@@ -63,7 +64,9 @@ type EnrollmentCheckin = {
   Demographic;
 
 const getStatus = (): Promise<boolean> =>
-  http.get<boolean>(`checkIn/status`).catch((err) => err instanceof NotFoundError);
+  http
+    .get<boolean>(`checkIn/status`)
+    .catch((err) => err instanceof NotFoundError || err instanceof AuthError);
 
 const markCompleted = (): Promise<void> => http.put(`checkIn/status`);
 

--- a/src/services/error.ts
+++ b/src/services/error.ts
@@ -16,6 +16,15 @@ class NotFoundError implements Error {
   }
 }
 
+class ConflictError implements Error {
+  name: string;
+  message: string;
+  constructor(message: string | undefined) {
+    this.name = 'ConflictError';
+    this.message = message || 'Specified resource already exists';
+  }
+}
+
 /**
  * Create an error object based on an HTTP error from the backend
  *
@@ -28,9 +37,11 @@ const createError = (err: Error, res: Response): Error | AuthError | NotFoundErr
     return new AuthError(err.message);
   } else if (res.status === 404) {
     return new NotFoundError(err.message);
+  } else if (res.status === 409) {
+    return new ConflictError(err.message);
   }
 
   return err;
 };
 
-export { AuthError, createError, NotFoundError };
+export { AuthError, createError, NotFoundError, ConflictError };

--- a/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
@@ -21,6 +21,7 @@ import membershipService from 'services/membership';
 import { stripDomain } from 'services/utils';
 import { gordonColors } from 'theme';
 import RequestsReceived from './components/RequestsReceived';
+import { ConflictError, NotFoundError } from 'services/error';
 
 const headerStyle = {
   backgroundColor: gordonColors.primary.blue,
@@ -74,14 +75,13 @@ const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddM
       if (error.Message === 'The Person is already part of the activity.') {
         createSnackbar(`${username} is already a member`, 'info');
       } else {
-        switch (error.name) {
-          case 'NotFoundError':
-            createSnackbar('Nobody with that username was found', 'error');
-            break;
-
-          default:
-            console.log(error);
-            break;
+        if (error instanceof ConflictError) {
+          createSnackbar(`${username} is already a member`, 'info');
+        } else if (error instanceof NotFoundError) {
+          createSnackbar('Nobody with that username was found', 'error');
+        } else {
+          createSnackbar('An error has occured', 'error');
+          console.log(error);
         }
       }
     }

--- a/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.jsx
@@ -154,10 +154,6 @@ const MemberListItem = ({
   let content;
   let options;
 
-  let mailLoc = Number(member.Mail_Location)
-    ? `Box #${member.Mail_Location}`
-    : member.Mail_Location || null;
-
   if (isAdmin || isSiteAdmin) {
     const disabled = participationDescription === 'Guest' || participationDescription === 'Member';
     // Can't make guests or members a group admin
@@ -281,10 +277,7 @@ const MemberListItem = ({
           <Grid item xs={4} style={rowComponentStyle}>
             <Typography>{title ? title : participationDescription}</Typography>
           </Grid>
-          <Grid item xs={2} style={rowComponentStyle}>
-            <Typography>{profile.Mail_Location}</Typography>
-          </Grid>
-          <Grid item xs={2} style={rowComponentStyle}>
+          <Grid item xs={4} style={rowComponentStyle}>
             {options}
           </Grid>
         </Grid>
@@ -345,7 +338,6 @@ const MemberListItem = ({
               </Grid>
               <Grid item xs={3} sm={2}>
                 <Typography>{member.ParticipationDescription} </Typography>
-                <Typography>{mailLoc}</Typography>
               </Grid>
             </Grid>
           </AccordionSummary>
@@ -381,7 +373,7 @@ const MemberListItem = ({
               {!avatar && <PlaceHolderAvatar />}
             </Avatar>
           </Grid>
-          <Grid item xs={3} style={rowStyle}>
+          <Grid item xs={5} style={rowStyle}>
             {profile.PersonType?.includes?.('stu') && member.IsAlumni ? (
               <Typography>
                 {member.FirstName} {member.LastName}
@@ -396,9 +388,6 @@ const MemberListItem = ({
           </Grid>
           <Grid item xs={4} style={rowStyle}>
             <Typography>{title ? title : participationDescription}</Typography>
-          </Grid>
-          <Grid item xs={2} style={rowStyle}>
-            <Typography>{mailLoc}</Typography>
           </Grid>
           <Grid item xs={2} style={rowStyle}>
             {options}

--- a/src/views/InvolvementProfile/components/Membership/components/MemberList/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/MemberList/index.jsx
@@ -70,9 +70,7 @@ const MemberList = ({
           <Grid item xs={4}>
             Title/Participation
           </Grid>
-          <Grid item xs={2}>
-            Mail #
-          </Grid>
+          <Grid item xs={2} />
           <Grid item xs={2}>
             Admin
           </Grid>
@@ -86,14 +84,11 @@ const MemberList = ({
       title={
         <Grid container direction="row">
           <Grid item xs={1} />
-          <Grid item xs={3}>
+          <Grid item xs={5}>
             Name
           </Grid>
-          <Grid item xs={4}>
+          <Grid item xs={6}>
             Title/Participation
-          </Grid>
-          <Grid item xs={4}>
-            Mail #
           </Grid>
         </Grid>
       }

--- a/src/views/News/index.jsx
+++ b/src/views/News/index.jsx
@@ -455,6 +455,7 @@ const StudentNews = () => {
                       zoom={onCropperZoom}
                       zoomable={false}
                       dragMode={'none'}
+                      checkCrossOrigin={false}
                     />
                   </div>
                 )}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,17 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig, loadEnv, splitVendorChunkPlugin } from 'vite';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
+import pluginRewriteAll from 'vite-plugin-rewrite-all';
 
 // https://vitejs.dev/config/
 const config = ({ mode }) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
 
   return defineConfig({
-    plugins: [react(), viteTsconfigPaths(), splitVendorChunkPlugin()],
+    plugins: [react(), viteTsconfigPaths(), splitVendorChunkPlugin(), pluginRewriteAll()],
     server: {
-      port: parseInt(process.env.VITE_PORT ?? "5173"),
-      host: process.env.VITE_HOST ?? "localhost",
+      port: parseInt(process.env.VITE_PORT ?? '5173'),
+      host: process.env.VITE_HOST ?? 'localhost',
       proxy: {
         '/api': {
           target: process.env.VITE_API_URL,


### PR DESCRIPTION
This PR fixes state logic for showing which selection (from private or public) personal information currently is. Previously, the logic for setting the state of the toggle always returned false when there was no Home phone no. added (it seems), which automatically set the toggle to 'true' (which is shown as public by the toggler). So whether or not you set your profile as private or public with the toggle, it would show that it was set to public (see #1653). 

More testing and logic handling is required before this is ready. It seems to work when there is no home phone no. associated with a profile, but have not been able to test it with a profile with a home phone no.

This might be good to discuss in a meeting while looking through the code together.
