### PR TITLE
Create new 409 Error 'Conflict' to give a 'Member Already Added' error message for involvements

### DIFF
--- a/src/services/error.ts
+++ b/src/services/error.ts
@@ -16,6 +16,15 @@ class NotFoundError implements Error {
   }
 }
 
+class ConflictError implements Error {
+  name: string;
+  message: string;
+  constructor(message: string | undefined) {
+    this.name = 'ConflictError';
+    this.message = message || 'Specified resource already exists';
+  }
+}
+
 /**
  * Create an error object based on an HTTP error from the backend
  *
@@ -28,9 +37,11 @@ const createError = (err: Error, res: Response): Error | AuthError | NotFoundErr
     return new AuthError(err.message);
   } else if (res.status === 404) {
     return new NotFoundError(err.message);
+  } else if (res.status === 409) {
+    return new ConflictError(err.message);
   }
 
   return err;
 };
 
-export { AuthError, createError, NotFoundError };
+export { AuthError, createError, NotFoundError, ConflictError };

--- a/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/AdminCard/index.jsx
@@ -21,6 +21,7 @@ import membershipService from 'services/membership';
 import { stripDomain } from 'services/utils';
 import { gordonColors } from 'theme';
 import RequestsReceived from './components/RequestsReceived';
+import { ConflictError, NotFoundError } from 'services/error';
 
 const headerStyle = {
   backgroundColor: gordonColors.primary.blue,
@@ -74,14 +75,13 @@ const AdminCard = ({ createSnackbar, isSiteAdmin, involvementDescription, onAddM
       if (error.Message === 'The Person is already part of the activity.') {
         createSnackbar(`${username} is already a member`, 'info');
       } else {
-        switch (error.name) {
-          case 'NotFoundError':
-            createSnackbar('Nobody with that username was found', 'error');
-            break;
-
-          default:
-            console.log(error);
-            break;
+        if (error instanceof ConflictError) {
+          createSnackbar(`${username} is already a member`, 'info');
+        } else if (error instanceof NotFoundError) {
+          createSnackbar('Nobody with that username was found', 'error');
+        } else {
+          createSnackbar('An error has occured', 'error');
+          console.log(error);
         }
       }
     }


### PR DESCRIPTION
The current mode for catching 'Member Already Added' exceptions/errors is bypassed because the error message does not return exactly what is expected by the code (replicated by trying to add an already existing member to a club/involvement).
As a result, there is currently no visual/UI response when trying to add a member that already exists. There is only a console error.

This PR creates a new error 'Conflict Error' which is caught when trying to add an already existing member. The caught error will product a snackbar that states that 'username' is already a member.

Fixes #1701 

This is an extension of [this PR](https://github.com/gordon-cs/gordon-360-ui/pull/1702). Extended due to some unwanted files in the original PR.