### PR TITLE
Don't redirect on auth errors

### DIFF
--- a/src/services/checkIn.ts
+++ b/src/services/checkIn.ts
@@ -1,3 +1,4 @@
+import { AuthError } from '@azure/msal-browser';
 import { NotFoundError } from './error';
 import http from './http';
 
@@ -63,7 +64,9 @@ type EnrollmentCheckin = {
   Demographic;
 
 const getStatus = (): Promise<boolean> =>
-  http.get<boolean>(`checkIn/status`).catch((err) => err instanceof NotFoundError);
+  http
+    .get<boolean>(`checkIn/status`)
+    .catch((err) => err instanceof NotFoundError || err instanceof AuthError);
 
 const markCompleted = (): Promise<void> => http.put(`checkIn/status`);
 


### PR DESCRIPTION
There is some disconnect that happens momentarily when the user first opens the site after a significant time away, where `useIsAuthenticated` from MSAL returns `true`, but the token provided by MSAL is not valid according to the API. I suspect this may involve token refreshing, but don't know for certain.

This disconnect was causing issues with the `AppRedirect` component, which was redirecting users erroneously to the Enrollment Check In page. The problem was that AppRedirect requests the user's enrollment check in status when `useIsAuthenticated` returns true, but in the brief milliseconds where the token is still invalid, the API was returning a `401 Unauthorized` response. AppRedirect caught the resulting `AuthError`, but was only expecting instances of `NotFoundError`, and so was treating the response as a trigger to redirect the user to the enrollment check in page.

The solution is to simply treat `AuthError` responses as non-redirects.