### PR TITLE
Fix Hot Module Reloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "stylelint": "^14.9.0",
         "stylelint-config-recommended-scss": "^5.0.2",
         "vite": "^4.0.4",
+        "vite-plugin-rewrite-all": "^1.0.1",
         "vite-tsconfig-paths": "^4.0.3"
       }
     },
@@ -3018,6 +3019,15 @@
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
     },
+    "node_modules/connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -5439,9 +5449,9 @@
       }
     },
     "node_modules/jsdoc": {
-      "version": "3.6.10",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.10.tgz",
-      "integrity": "sha512-IdQ8ppSo5LKZ9o3M+LKIIK8i00DIe5msDvG3G81Km+1dhy0XrOWD0Ji8H61ElgyEj/O9KRLokgKbAM9XX9CJAg==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
+      "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.9.4",
@@ -5450,7 +5460,7 @@
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
-        "klaw": "^4.0.1",
+        "klaw": "^3.0.0",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^8.4.1",
         "marked": "^4.0.10",
@@ -5464,7 +5474,7 @@
         "jsdoc": "jsdoc.js"
       },
       "engines": {
-        "node": ">=8.15.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
@@ -5649,12 +5659,12 @@
       }
     },
     "node_modules/klaw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
-      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
       "dev": true,
-      "engines": {
-        "node": ">=14.14.0"
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/known-css-properties": {
@@ -8880,6 +8890,21 @@
         }
       }
     },
+    "node_modules/vite-plugin-rewrite-all": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-rewrite-all/-/vite-plugin-rewrite-all-1.0.1.tgz",
+      "integrity": "sha512-W0DAchC8ynuQH0lYLIu5/5+JGfYlUTRD8GGNtHFXRJX4FzzB9MajtqHBp26zq/ly9sDt5BqrfdT08rv3RbB0LQ==",
+      "dev": true,
+      "dependencies": {
+        "connect-history-api-fallback": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/vite-tsconfig-paths": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.0.3.tgz",
@@ -11162,6 +11187,12 @@
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
     },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -12927,9 +12958,9 @@
       }
     },
     "jsdoc": {
-      "version": "3.6.10",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.10.tgz",
-      "integrity": "sha512-IdQ8ppSo5LKZ9o3M+LKIIK8i00DIe5msDvG3G81Km+1dhy0XrOWD0Ji8H61ElgyEj/O9KRLokgKbAM9XX9CJAg==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
+      "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
@@ -12938,7 +12969,7 @@
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
-        "klaw": "^4.0.1",
+        "klaw": "^3.0.0",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^8.4.1",
         "marked": "^4.0.10",
@@ -13107,10 +13138,13 @@
       "dev": true
     },
     "klaw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
-      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
     },
     "known-css-properties": {
       "version": "0.25.0",
@@ -15470,6 +15504,15 @@
             "fsevents": "~2.3.2"
           }
         }
+      }
+    },
+    "vite-plugin-rewrite-all": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-rewrite-all/-/vite-plugin-rewrite-all-1.0.1.tgz",
+      "integrity": "sha512-W0DAchC8ynuQH0lYLIu5/5+JGfYlUTRD8GGNtHFXRJX4FzzB9MajtqHBp26zq/ly9sDt5BqrfdT08rv3RbB0LQ==",
+      "dev": true,
+      "requires": {
+        "connect-history-api-fallback": "^1.6.0"
       }
     },
     "vite-tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "stylelint": "^14.9.0",
     "stylelint-config-recommended-scss": "^5.0.2",
     "vite": "^4.0.4",
+    "vite-plugin-rewrite-all": "^1.0.1",
     "vite-tsconfig-paths": "^4.0.3"
   },
   "scripts": {

--- a/src/components/Providers/components/AuthProvider/index.tsx
+++ b/src/components/Providers/components/AuthProvider/index.tsx
@@ -1,0 +1,47 @@
+import { MsalProvider } from '@azure/msal-react';
+import {
+  AuthenticationResult,
+  EventMessage,
+  EventType,
+  PublicClientApplication,
+} from '@azure/msal-browser';
+
+const msalConfig = {
+  auth: {
+    clientId: import.meta.env.VITE_AZURE_AD_CLIENT as string,
+    authority: `https://login.microsoftonline.com/${import.meta.env.VITE_AZURE_AD_TENANT}`,
+    postLogoutRedirectUri: window.location.origin,
+    redirectUri: window.location.origin,
+    validateAuthority: true,
+    // After being redirected to the "redirectUri" page, should user
+    // be redirected back to the Url where their login originated from?
+    navigateToLoginRequestUrl: true,
+  },
+  cache: {
+    cacheLocation: 'localStorage', // This configures where your cache will be stored
+    storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+  },
+};
+
+export const msalInstance = new PublicClientApplication(msalConfig);
+if (!msalInstance.getActiveAccount() && msalInstance.getAllAccounts().length > 0) {
+  msalInstance.setActiveAccount(msalInstance.getAllAccounts()[0]);
+}
+
+// this will update account state if a user signs in from another tab or window
+msalInstance.enableAccountStorageEvents();
+
+// Update msalInstance when user logs in successfully
+msalInstance.addEventCallback((event: EventMessage) => {
+  if (event.eventType === EventType.LOGIN_SUCCESS && event.payload) {
+    const payload = event.payload as AuthenticationResult;
+    const account = payload.account;
+    msalInstance.setActiveAccount(account);
+  }
+});
+
+const AuthProvider = ({ children }: { children: JSX.Element }) => (
+  <MsalProvider instance={msalInstance}>{children}</MsalProvider>
+);
+
+export default AuthProvider;

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -1,0 +1,20 @@
+import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
+import UserContextProvider from 'contexts/UserContext';
+import 'app.global.css';
+import NetworkContextProvider from 'contexts/NetworkContext';
+import theme from 'theme';
+import AuthProvider from './components/AuthProvider';
+
+const Providers = ({ children }: { children: JSX.Element }) => (
+  <AuthProvider>
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={theme}>
+        <NetworkContextProvider>
+          <UserContextProvider>{children}</UserContextProvider>
+        </NetworkContextProvider>
+      </ThemeProvider>
+    </StyledEngineProvider>
+  </AuthProvider>
+);
+
+export default Providers;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,33 +1,14 @@
-import { PublicClientApplication } from '@azure/msal-browser';
-import { MsalProvider } from '@azure/msal-react';
-import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
-import UserContextProvider from 'contexts/UserContext';
+import Providers from 'components/Providers';
 import { register } from 'pwa';
-import React from 'react';
 import ReactDOM from 'react-dom';
-import { configureMSAL, msalConfig } from 'services/auth';
 import App from './app';
 import './app.global.css';
-import NetworkContextProvider from './contexts/NetworkContext';
-import theme from './theme';
 
-export const msalInstance = new PublicClientApplication(msalConfig);
-configureMSAL(msalInstance);
-
-const AppWithProviders = () => (
-  <MsalProvider instance={msalInstance}>
-    <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={theme}>
-        <NetworkContextProvider>
-          <UserContextProvider>
-            <App />
-          </UserContextProvider>
-        </NetworkContextProvider>
-      </ThemeProvider>
-    </StyledEngineProvider>
-  </MsalProvider>
+ReactDOM.render(
+  <Providers>
+    <App />
+  </Providers>,
+  document.getElementById('root'),
 );
-
-ReactDOM.render(<AppWithProviders />, document.getElementById('root'));
 
 register();

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,53 +1,9 @@
-import {
-  AuthenticationResult,
-  EventMessage,
-  EventType,
-  InteractionRequiredAuthError,
-  PublicClientApplication,
-  SilentRequest,
-} from '@azure/msal-browser';
-import { msalInstance } from 'index';
+import { InteractionRequiredAuthError, SilentRequest } from '@azure/msal-browser';
+import { msalInstance } from 'components/Providers/components/AuthProvider';
 import storage from './storage';
-
-export const msalConfig = {
-  auth: {
-    clientId: import.meta.env.VITE_AZURE_AD_CLIENT as string,
-    authority: `https://login.microsoftonline.com/${import.meta.env.VITE_AZURE_AD_TENANT}`,
-    postLogoutRedirectUri: window.location.origin,
-    redirectUri: window.location.origin,
-    validateAuthority: true,
-    // After being redirected to the "redirectUri" page, should user
-    // be redirected back to the Url where their login originated from?
-    navigateToLoginRequestUrl: true,
-  },
-  cache: {
-    cacheLocation: 'localStorage', // This configures where your cache will be stored
-    storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
-  },
-};
 
 const apiRequest = {
   scopes: ['api://b19c300a-00dc-4adc-bcd1-b678b25d7ad1/access_as_user'],
-};
-
-export const configureMSAL = (msalInstance: PublicClientApplication) => {
-  if (!msalInstance.getActiveAccount() && msalInstance.getAllAccounts().length > 0) {
-    msalInstance.setActiveAccount(msalInstance.getAllAccounts()[0]);
-  }
-
-  // this will update account state if a user signs in from another tab or window
-  msalInstance.enableAccountStorageEvents();
-
-  msalInstance.addEventCallback((event: EventMessage) => {
-    if (event.eventType === EventType.LOGIN_SUCCESS && event.payload) {
-      const payload = event.payload as AuthenticationResult;
-      const account = payload.account;
-      msalInstance.setActiveAccount(account);
-    } else if (event.eventType === EventType.ACQUIRE_TOKEN_SUCCESS && event.payload) {
-    }
-  });
-
-  return msalInstance;
 };
 
 const authenticate = async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,17 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig, loadEnv, splitVendorChunkPlugin } from 'vite';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
+import pluginRewriteAll from 'vite-plugin-rewrite-all';
 
 // https://vitejs.dev/config/
 const config = ({ mode }) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
 
   return defineConfig({
-    plugins: [react(), viteTsconfigPaths(), splitVendorChunkPlugin()],
+    plugins: [react(), viteTsconfigPaths(), splitVendorChunkPlugin(), pluginRewriteAll()],
     server: {
-      port: parseInt(process.env.VITE_PORT ?? "5173"),
-      host: process.env.VITE_HOST ?? "localhost",
+      port: parseInt(process.env.VITE_PORT ?? '5173'),
+      host: process.env.VITE_HOST ?? 'localhost',
       proxy: {
         '/api': {
           target: process.env.VITE_API_URL,


### PR DESCRIPTION
Hot Module Reloading was broken in two ways with the recent migration to Vite.
1. HMR doesn't work because of Circular Dependencies:

   - The Microsoft Authentication Library (MSAL) package we use for Auth requires a single instance of the PublicClientApplication to be created at runtime. This instance requires some complex configuration, which was kept in `src/services/auth.ts`, but the instance has to be created once at runtime when the app starts up, so it was being done in `src/index.tsx`. The problem is that all the other methods in `auth.ts` require a reference to the MSAL instance, so `auth.ts` was importing the instantiated object from `index.tsx`. This created a circular dependency where index.tsx imports from auth.ts and then auth.ts imports from index.tsx.

     The solution is to move the MSAL instance configuration out of auth.ts and into the component where the initialization actually happens. That way, index.tsx does not import auth.ts at all, resolving the circular dependency. Because that configuration logic is large and not especially relevant to the app initialization that is done in index.tsx, I extracted it (and the rest of the Context Provider logic) into separate components.

2. URLs with `.` in them aren't rewritten for React Router, causing the page to break on reload.
   - This is an issue with Vite's URL rewriter, which doesn't handle `.` properly. Because of this, any URL with a `.` is not redirected to the root file to be handled by React Router. The package `vite-plugin-rewrite-all` is a small, self-contained plugin to reconfigure Vite's URL rewriter to handle this case.