### PR TITLE
Drop Mail Location from Involvement Profile page

### DIFF
--- a/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.jsx
@@ -154,10 +154,6 @@ const MemberListItem = ({
   let content;
   let options;
 
-  let mailLoc = Number(member.Mail_Location)
-    ? `Box #${member.Mail_Location}`
-    : member.Mail_Location || null;
-
   if (isAdmin || isSiteAdmin) {
     const disabled = participationDescription === 'Guest' || participationDescription === 'Member';
     // Can't make guests or members a group admin
@@ -281,10 +277,7 @@ const MemberListItem = ({
           <Grid item xs={4} style={rowComponentStyle}>
             <Typography>{title ? title : participationDescription}</Typography>
           </Grid>
-          <Grid item xs={2} style={rowComponentStyle}>
-            <Typography>{profile.Mail_Location}</Typography>
-          </Grid>
-          <Grid item xs={2} style={rowComponentStyle}>
+          <Grid item xs={4} style={rowComponentStyle}>
             {options}
           </Grid>
         </Grid>
@@ -345,7 +338,6 @@ const MemberListItem = ({
               </Grid>
               <Grid item xs={3} sm={2}>
                 <Typography>{member.ParticipationDescription} </Typography>
-                <Typography>{mailLoc}</Typography>
               </Grid>
             </Grid>
           </AccordionSummary>
@@ -381,7 +373,7 @@ const MemberListItem = ({
               {!avatar && <PlaceHolderAvatar />}
             </Avatar>
           </Grid>
-          <Grid item xs={3} style={rowStyle}>
+          <Grid item xs={5} style={rowStyle}>
             {profile.PersonType?.includes?.('stu') && member.IsAlumni ? (
               <Typography>
                 {member.FirstName} {member.LastName}
@@ -396,9 +388,6 @@ const MemberListItem = ({
           </Grid>
           <Grid item xs={4} style={rowStyle}>
             <Typography>{title ? title : participationDescription}</Typography>
-          </Grid>
-          <Grid item xs={2} style={rowStyle}>
-            <Typography>{mailLoc}</Typography>
           </Grid>
           <Grid item xs={2} style={rowStyle}>
             {options}

--- a/src/views/InvolvementProfile/components/Membership/components/MemberList/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/MemberList/index.jsx
@@ -70,9 +70,7 @@ const MemberList = ({
           <Grid item xs={4}>
             Title/Participation
           </Grid>
-          <Grid item xs={2}>
-            Mail #
-          </Grid>
+          <Grid item xs={2} />
           <Grid item xs={2}>
             Admin
           </Grid>
@@ -86,14 +84,11 @@ const MemberList = ({
       title={
         <Grid container direction="row">
           <Grid item xs={1} />
-          <Grid item xs={3}>
+          <Grid item xs={5}>
             Name
           </Grid>
-          <Grid item xs={4}>
+          <Grid item xs={6}>
             Title/Participation
-          </Grid>
-          <Grid item xs={4}>
-            Mail #
           </Grid>
         </Grid>
       }


### PR DESCRIPTION
This pr removes Mail Location from the Involvement Profile page. If anyone wants to know the mail location of another member, they can simply click the link to other's profile and view it there.

PS: this pr was originally planned to solve the duplicate mail location bug, but turned out we decided to move forward with another approach without Mail Location.

Here is the new UI for Involvement Profile page.

Full screen
![image](https://user-images.githubusercontent.com/78691207/224335949-222422ad-cfd3-495f-a555-13f775a33eb5.png)

Mobile view
![image](https://user-images.githubusercontent.com/78691207/224336074-3bcefd82-50f7-4202-9bc4-bd98998a9fdd.png)

< Admin View >
Full screen
![image](https://user-images.githubusercontent.com/78691207/224339962-2c0a40ae-836c-40ae-b528-4f22b868cdd3.png)

Mobile view
![image](https://user-images.githubusercontent.com/78691207/224340089-fc345cd4-7767-42b7-a68c-725a717a0597.png)