### PR TITLE
Recim image first hotfix

### DIFF
--- a/src/views/RecIM/components/Forms/ActivityForm/index.jsx
+++ b/src/views/RecIM/components/Forms/ActivityForm/index.jsx
@@ -330,9 +330,8 @@ const ActivityForm = ({
     newActivityRequest.typeID = activityTypes.find(
       (type) => type.Description === newActivityRequest.typeID,
     ).ID;
-
     newActivityRequest.Logo =
-      cropperImageData !== null
+      cropperImageData != null
         ? cropperRef.current.cropper.getCroppedCanvas({ width: CROP_DIM }).toDataURL()
         : null;
 

--- a/src/views/RecIM/components/Forms/TeamForm/index.jsx
+++ b/src/views/RecIM/components/Forms/TeamForm/index.jsx
@@ -195,7 +195,7 @@ const TeamForm = ({
   const handleSubmit = async () => {
     let newTeamRequest = { ...currentInfo, ...newInfo };
     newTeamRequest.Logo =
-      cropperImageData !== null
+      cropperImageData != null
         ? cropperRef.current.cropper.getCroppedCanvas({ width: CROP_DIM }).toDataURL()
         : null;
 


### PR DESCRIPTION
While the image is null, the UI still throws an error when you clicked the `submit` button. That's because of the following code, where on line 337 compares `cropperImageData` and `null` value. But the operator is wrong here. When we use `!==`, this compares the data type on both sides, and since `undefined` is not the same type as `null`, the code will go through line 338 which the cropper is `undefined` in `cropperRef`. So the correct operator is `!=`, where both `undefined` and `null` are false, thus the code goes through line 339 instead of line 338.

![image](https://user-images.githubusercontent.com/78691207/226074864-afb68644-1103-45a7-b81a-7e897d68363f.png)
