### PR TITLE
[Rec-IM] Show/Sort Series Teams by Series Records + Styling Update

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -5,7 +5,7 @@
 # VITE_ANALYTICS_ID=UA-3559968-3
 
 # @TRAIN
-# REACT_APP_API_URL=https://360ApiTrain.gordon.edu/
+# VITE_API_URL=https://360ApiTrain.gordon.edu/
 
 # @RECIM
-REACT_APP_API_URL=https://360ApiRecIM.gordon.edu/
+VITE_API_URL=https://360ApiRecIM.gordon.edu/

--- a/src/_vars.scss
+++ b/src/_vars.scss
@@ -5,9 +5,11 @@
 // Ensure that the relative path (i.e. `../../`, etc.) is correct when importing from a nested
 // component.
 
-// For use in a .js file, see `src/theme.js`.
+// For use in a .ts file, see `src/theme.ts`.
 $primary-blue: #014983;
+$primary-blue-tint: #016bc0;
 $primary-cyan: #00aeef;
+$primary-cyan-shade: #0098d0;
 $secondary-green: #b2bb1c;
 $secondary-yellow: #fdb913;
 $secondary-orange: #de571f;

--- a/src/views/RecIM/components/Forms/MatchForm/index.jsx
+++ b/src/views/RecIM/components/Forms/MatchForm/index.jsx
@@ -120,11 +120,12 @@ const MatchForm = ({ closeWithSnackbar, openMatchForm, setOpenMatchForm, activit
 
   const currentInfo = useMemo(() => {
     if (match) {
+      console.log(match);
       //I tried using inbuild javascript functions but I can't wrap my head around multiple
       //filters. You are welcome to improve on the logic below if you so desire.
       var teamIDs = [];
       match.Team.forEach((team) =>
-        teamIDs.push(match.Series.TeamStanding.find((_team) => team.ID === _team.TeamID).Name),
+        teamIDs.push(match.Series.TeamStanding.find((_team) => team.ID === _team.TeamID)?.Name),
       );
       return {
         StartTime: match.StartTime,
@@ -216,7 +217,7 @@ const MatchForm = ({ closeWithSnackbar, openMatchForm, setOpenMatchForm, activit
     });
     return updatedFields;
   }
-
+  console.log(match, activity);
   const handleConfirm = () => {
     setSaving(true);
 
@@ -232,7 +233,7 @@ const MatchForm = ({ closeWithSnackbar, openMatchForm, setOpenMatchForm, activit
     matchRequest.TeamIDs.forEach((value) => {
       if (activity) idArray.push(activity.Team.find((team) => team.Name === value).ID);
       else if (match)
-        idArray.push(match.Series.TeamStanding.find((team) => team.Name === value).TeamID);
+        idArray.push(match.Series.TeamStanding.find((team) => team.Name === value)?.TeamID);
     });
     matchRequest.TeamIDs = idArray;
 

--- a/src/views/RecIM/components/List/List.module.scss
+++ b/src/views/RecIM/components/List/List.module.scss
@@ -1,0 +1,7 @@
+@import '../../../../vars';
+
+.secondaryText {
+  margin-top: 1em;
+  color: $neutral-gray;
+  text-align: center;
+}

--- a/src/views/RecIM/components/List/Listing/Listing.module.scss
+++ b/src/views/RecIM/components/List/Listing/Listing.module.scss
@@ -25,6 +25,15 @@
   padding: 0;
 }
 
+.redButton {
+  background-color: $secondary-red;
+  color: $neutral-white;
+}
+
+.redButton:hover {
+  background-color: $alternative-red;
+}
+
 .rejectButton {
   background-color: $primary-blue;
   color: $neutral-white;

--- a/src/views/RecIM/components/List/Listing/Listing.module.scss
+++ b/src/views/RecIM/components/List/Listing/Listing.module.scss
@@ -76,9 +76,10 @@
   background-color: #ffd040;
 }
 
-@media (min-width: $break-sm) {
+@media (min-width: $break-xs) {
   .rightAlignLarge {
     text-align: right;
+    justify-content: flex-end;
   }
 }
 

--- a/src/views/RecIM/components/List/Listing/Listing.module.scss
+++ b/src/views/RecIM/components/List/Listing/Listing.module.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @import '../../../../../vars';
 
 .listing {
@@ -25,21 +26,21 @@
 }
 
 .rejectButton {
-  background-color: #900000;
+  background-color: $primary-blue;
   color: $neutral-white;
 }
 
 .rejectButton:hover {
-  background-color: #b00000;
+  background-color: $primary-blue-tint;
 }
 
 .acceptButton {
-  background-color: #007000;
+  background-color: $primary-cyan;
   color: $neutral-white;
 }
 
 .acceptButton:hover {
-  background-color: #009000;
+  background-color: $primary-cyan-shade;
 }
 
 .avatar {

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -341,7 +341,7 @@ const TeamListing = ({ team, invite, match, setTargetTeamID, callbackFunction })
                   )}
                   {invite && (
                     <Grid item>
-                      <IconButton className={styles.rejectButton} onClick={handleAcceptInvite}>
+                      <IconButton className={styles.rejectButton} onClick={handleRejectInvite}>
                         <ClearIcon />
                       </IconButton>
                     </Grid>

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -553,7 +553,6 @@ const ParticipantListing = ({
 const MatchListing = ({ match, activityID }) => {
   if (!match) return null;
   if (match.Team?.length === 2) {
-    console.log(match);
     return (
       <ListItem key={match.ID} className={styles.listingWrapper}>
         <ListItemButton
@@ -568,16 +567,16 @@ const MatchListing = ({ match, activityID }) => {
               </Grid>
             )}
             <Grid item container>
-              <Grid item xs={5}>
+              <Grid item xs={4.5}>
                 <Typography className={styles.listingTitle}>
                   {match.Team[0]?.Name ?? <i>TBD</i>}
                 </Typography>
               </Grid>
-              <Grid item xs={2} textAlign="center">
+              <Grid item xs={3} textAlign="center">
                 {/* show scores only if match is completed*/}
                 {match.Status === 'Completed' ? (
                   <Grid container direction="row">
-                    <Grid item xs={5}>
+                    <Grid item xs={5} textAlign="right">
                       <Typography>
                         {match.Scores?.find((matchTeam) => matchTeam.TeamID === match.Team[0]?.ID)
                           ?.TeamScore ?? 'TBD'}
@@ -587,7 +586,7 @@ const MatchListing = ({ match, activityID }) => {
                     <Grid item xs={2}>
                       <Typography>{':'}</Typography>{' '}
                     </Grid>
-                    <Grid item xs={5}>
+                    <Grid item xs={5} textAlign="left">
                       <Typography>
                         {match.Scores?.find((matchTeam) => matchTeam.TeamID === match.Team[1]?.ID)
                           ?.TeamScore ?? 'TBD'}
@@ -598,7 +597,7 @@ const MatchListing = ({ match, activityID }) => {
                   <Typography>vs.</Typography>
                 )}
               </Grid>
-              <Grid item xs={5} textAlign="right">
+              <Grid item xs={4.5} textAlign="right">
                 <Typography className={styles.listingTitle}>
                   {match.Team[1]?.Name ?? <i>TBD</i>}
                 </Typography>

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -539,7 +539,7 @@ const ParticipantListing = ({
               </MenuItem>
             )}
             {participant.Role !== 'Inactive' && (
-              <MenuItem dense onClick={handleRemoveFromTeam} className={styles.rejectButton}>
+              <MenuItem dense onClick={handleRemoveFromTeam} className={styles.redButton}>
                 Remove from team
               </MenuItem>
             )}

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -301,6 +301,15 @@ const TeamListing = ({ team, invite, match, setTargetTeamID, callbackFunction })
       </ListItemButton>
     );
   } else {
+    let ActivityRecord = {
+      WinCount: 0,
+      LossCount: 0,
+    };
+
+    team.TeamRecord.forEach((record) => {
+      ActivityRecord.WinCount += record.WinCount;
+      ActivityRecord.LossCount += record.LossCount;
+    });
     content = (
       <Grid container direction="row" justifyContent="center">
         <Grid item xs={12}>
@@ -311,10 +320,15 @@ const TeamListing = ({ team, invite, match, setTargetTeamID, callbackFunction })
           >
             <Grid container>
               <Grid container columnSpacing={2}>
-                <Grid item xs={12} sm={8}>
+                <Grid item xs={8} sm={6}>
                   <Typography className={styles.listingTitle}>{team.Name}</Typography>
                 </Grid>
-                <Grid item xs={12} sm={4} className={styles.rightAlignLarge}>
+                <Grid item xs={4} sm={6} className={styles.rightAlignLarge}>
+                  <Typography className={styles.listingSubtitle}>
+                    {ActivityRecord.WinCount}W : {ActivityRecord.LossCount}L
+                  </Typography>
+                </Grid>
+                <Grid item xs={12} sm={6} className={styles.listingSubtitle}>
                   <Typography className={styles.listingSubtitle}>{team.Activity?.Name}</Typography>
                 </Grid>
               </Grid>

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -10,7 +10,6 @@ import {
   IconButton,
   Menu,
   MenuItem,
-  Button,
   Checkbox,
   FormControlLabel,
 } from '@mui/material';

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -593,6 +593,8 @@ const MatchListing = ({ match, activityID }) => {
                       </Typography>
                     </Grid>
                   </Grid>
+                ) : match.Status === 'Forfeited' ? (
+                  <Typography className={styles.listingSubtitle}>Forfeited</Typography>
                 ) : (
                   <Typography>vs.</Typography>
                 )}

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -306,7 +306,7 @@ const TeamListing = ({ team, invite, match, setTargetTeamID, callbackFunction })
       LossCount: 0,
     };
 
-    team.TeamRecord.forEach((record) => {
+    team.TeamRecord?.forEach((record) => {
       ActivityRecord.WinCount += record.WinCount;
       ActivityRecord.LossCount += record.LossCount;
     });
@@ -320,48 +320,47 @@ const TeamListing = ({ team, invite, match, setTargetTeamID, callbackFunction })
           >
             <Grid container>
               <Grid container columnSpacing={2}>
-                <Grid item xs={8} sm={6}>
+                <Grid item xs={8} sm={5}>
                   <Typography className={styles.listingTitle}>{team.Name}</Typography>
                 </Grid>
-                <Grid item xs={4} sm={6} className={styles.rightAlignLarge}>
-                  <Typography className={styles.listingSubtitle}>
-                    {ActivityRecord.WinCount}W : {ActivityRecord.LossCount}L
-                  </Typography>
+                <Grid
+                  item
+                  xs={4}
+                  sm={7}
+                  container
+                  className={styles.rightAlignLarge}
+                  direction="row"
+                  spacing={1}
+                >
+                  {invite && (
+                    <Grid item>
+                      <IconButton className={styles.acceptButton} onClick={handleAcceptInvite}>
+                        <CheckIcon />
+                      </IconButton>
+                    </Grid>
+                  )}
+                  {invite && (
+                    <Grid item>
+                      <IconButton className={styles.rejectButton} onClick={handleAcceptInvite}>
+                        <ClearIcon />
+                      </IconButton>
+                    </Grid>
+                  )}
+                  {team.TeamRecord && !invite && (
+                    <Grid item>
+                      <Typography className={styles.listingSubtitle}>
+                        {ActivityRecord.WinCount}W : {ActivityRecord.LossCount}L
+                      </Typography>
+                    </Grid>
+                  )}
                 </Grid>
                 <Grid item xs={12} sm={6} className={styles.listingSubtitle}>
                   <Typography className={styles.listingSubtitle}>{team.Activity?.Name}</Typography>
                 </Grid>
               </Grid>
-              {invite && <Grid item margin={3}></Grid>}
             </Grid>
           </ListItemButton>
         </Grid>
-        {invite && (
-          <Grid item position="relative" marginTop={-6}>
-            <Grid container columnSpacing={2}>
-              <Grid item>
-                <Button
-                  variant="contained"
-                  className={styles.acceptButton}
-                  startIcon={<CheckIcon />}
-                  onClick={handleAcceptInvite}
-                >
-                  Accept
-                </Button>
-              </Grid>
-              <Grid item>
-                <Button
-                  variant="contained"
-                  className={styles.rejectButton}
-                  startIcon={<ClearIcon />}
-                  onClick={handleRejectInvite}
-                >
-                  Reject
-                </Button>
-              </Grid>
-            </Grid>
-          </Grid>
-        )}
       </Grid>
     );
   }
@@ -554,6 +553,7 @@ const ParticipantListing = ({
 const MatchListing = ({ match, activityID }) => {
   if (!match) return null;
   if (match.Team?.length === 2) {
+    console.log(match);
     return (
       <ListItem key={match.ID} className={styles.listingWrapper}>
         <ListItemButton
@@ -562,6 +562,11 @@ const MatchListing = ({ match, activityID }) => {
           className={styles.listing}
         >
           <Grid container direction="column" alignItems="center">
+            {match.Status === 'Completed' && (
+              <Grid xs={12} item>
+                <Typography className={styles.listingSubtitle}>Final</Typography>
+              </Grid>
+            )}
             <Grid item container>
               <Grid item xs={5}>
                 <Typography className={styles.listingTitle}>
@@ -569,15 +574,26 @@ const MatchListing = ({ match, activityID }) => {
                 </Typography>
               </Grid>
               <Grid item xs={2} textAlign="center">
-                {/* show scores only if match is in the present/past */}
-                {isPast(Date.parse(match.Time)) ? (
-                  <Typography>
-                    {match.Scores?.find((matchTeam) => matchTeam.TeamID === match.Team[0]?.ID)
-                      ?.TeamScore ?? 'TBD'}{' '}
-                    :{' '}
-                    {match.Scores?.find((matchTeam) => matchTeam.TeamID === match.Team[1]?.ID)
-                      ?.TeamScore ?? 'TBD'}
-                  </Typography>
+                {/* show scores only if match is completed*/}
+                {match.Status === 'Completed' ? (
+                  <Grid container direction="row">
+                    <Grid item xs={5}>
+                      <Typography>
+                        {match.Scores?.find((matchTeam) => matchTeam.TeamID === match.Team[0]?.ID)
+                          ?.TeamScore ?? 'TBD'}
+                      </Typography>
+                    </Grid>
+
+                    <Grid item xs={2}>
+                      <Typography>{':'}</Typography>{' '}
+                    </Grid>
+                    <Grid item xs={5}>
+                      <Typography>
+                        {match.Scores?.find((matchTeam) => matchTeam.TeamID === match.Team[1]?.ID)
+                          ?.TeamScore ?? 'TBD'}
+                      </Typography>
+                    </Grid>
+                  </Grid>
                 ) : (
                   <Typography>vs.</Typography>
                 )}
@@ -628,8 +644,8 @@ const MatchListing = ({ match, activityID }) => {
                   <Typography className={styles.listingTitle}>{team.Name}</Typography>
                 </Grid>
                 <Grid item xs={2}>
-                  {/* show scores only if match is in the present/past */}
-                  {isPast(Date.parse(match.Time)) ? (
+                  {/* show scores only if match is completed*/}
+                  {match.Status === 'Completed' ? (
                     <Typography>
                       {match.Scores?.find((matchTeam) => matchTeam.TeamID === team.ID)?.TeamScore ??
                         0}

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -68,7 +68,6 @@ const MatchList = ({ matches, activityID }) => {
 // setTargetTeamID is used for edit Match teams
 const TeamList = ({ teams, match, series, invite, setInvites, setTargetTeamID }) => {
   const navigate = useNavigate();
-  if (!teams?.length && !match && !series) return <Typography>No teams to show.</Typography>;
 
   const handleInviteResponse = (response, activityID, teamID) => {
     if (response === 'accepted') {

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -58,7 +58,9 @@ const ParticipantList = ({
 const MatchList = ({ matches, activityID }) => {
   if (!matches?.length || !matches[0]) return <Typography>No matches to show.</Typography>;
   let content = matches.map((match) => (
-    <MatchListing key={match.ID} match={match} activityID={activityID} />
+    <MatchListing key={match?.ID} match={match} activityID={activityID} />
+    // I have no idea why, but on ladder matches, match can't be found
+    // despite it showing up on the debugger.
   ));
 
   return <List dense>{content}</List>;

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -1,9 +1,11 @@
 import { List, Typography } from '@mui/material';
 import { ActivityListing, MatchListing, ParticipantListing, TeamListing } from './Listing';
 import { useNavigate } from 'react-router-dom';
+import styles from './List.module.css';
 
 const ActivityList = ({ activities, showActivityOptions }) => {
-  if (!activities?.length) return <Typography>No activities to show.</Typography>;
+  if (!activities?.length)
+    return <Typography className={styles.secondaryText}>No activities to show.</Typography>;
   let content = activities.map((activity) => (
     <ActivityListing
       key={activity.ID}
@@ -26,7 +28,8 @@ const ParticipantList = ({
   showInactive,
   callbackFunction,
 }) => {
-  if (!participants?.length) return <Typography>No participants to show.</Typography>;
+  if (!participants?.length)
+    return <Typography className={styles.secondaryText}>No participants to show.</Typography>;
   let content = participants.map((participant) => {
     if (!showInactive && participant.Role === 'Inactive') {
       return null;
@@ -56,7 +59,8 @@ const ParticipantList = ({
 };
 
 const MatchList = ({ matches, activityID }) => {
-  if (!matches?.length || !matches[0]) return <Typography>No matches to show.</Typography>;
+  if (!matches?.length || !matches[0])
+    return <Typography className={styles.secondaryText}>No matches to show.</Typography>;
   let content = matches.map((match) => (
     <MatchListing key={match?.ID} match={match} activityID={activityID} />
     // I have no idea why, but on ladder matches, match can't be found
@@ -65,9 +69,13 @@ const MatchList = ({ matches, activityID }) => {
 
   return <List dense>{content}</List>;
 };
+
 // setTargetTeamID is used for edit Match teams
 const TeamList = ({ teams, match, series, invite, setInvites, setTargetTeamID }) => {
   const navigate = useNavigate();
+
+  if (!teams?.length && !match && !series)
+    return <Typography className={styles.secondaryText}>No teams to show.</Typography>;
 
   const handleInviteResponse = (response, activityID, teamID) => {
     if (response === 'accepted') {

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -64,9 +64,9 @@ const MatchList = ({ matches, activityID }) => {
   return <List dense>{content}</List>;
 };
 // setTargetTeamID is used for edit Match teams
-const TeamList = ({ teams, match, invite, setInvites, setTargetTeamID }) => {
+const TeamList = ({ teams, match, series, invite, setInvites, setTargetTeamID }) => {
   const navigate = useNavigate();
-  if (!teams?.length && !match) return <Typography>No teams to show.</Typography>;
+  if (!teams?.length && !match && !series) return <Typography>No teams to show.</Typography>;
 
   const handleInviteResponse = (response, activityID, teamID) => {
     if (response === 'accepted') {
@@ -75,6 +75,28 @@ const TeamList = ({ teams, match, invite, setInvites, setTargetTeamID }) => {
       setInvites(teams.filter((team) => team.ID !== teamID));
     }
   };
+
+  var teamStanding;
+  if (series) {
+    teams = [];
+    teamStanding = series.TeamStanding.sort((a, b) => a.WinCount < b.WinCount);
+    teamStanding.forEach((team) =>
+      teams.push({
+        ID: team.TeamID,
+        Name: team.Name,
+        Activity: {
+          ID: series.ActivityID,
+        },
+        TeamRecord: [
+          {
+            WinCount: team.WinCount,
+            LossCount: team.LossCount,
+            TieCount: team.TieCount,
+          },
+        ],
+      }),
+    );
+  }
 
   let content = match
     ? match.Team.map((team) => (

--- a/src/views/RecIM/components/index.jsx
+++ b/src/views/RecIM/components/index.jsx
@@ -1,0 +1,9 @@
+const TabPanel = ({ children, value, index }) => {
+  return (
+    <div hidden={value !== index} role="tabpanel">
+      {children}
+    </div>
+  );
+};
+
+export { TabPanel };

--- a/src/views/RecIM/views/Activity/Activity.module.scss
+++ b/src/views/RecIM/views/Activity/Activity.module.scss
@@ -75,6 +75,12 @@
   color: $neutral-gray;
 }
 
+.secondaryText {
+  margin-top: 1em;
+  color: $neutral-gray;
+  text-align: center;
+}
+
 .editIconButton {
   background-color: $secondary-yellow;
   color: $neutral-black;

--- a/src/views/RecIM/views/Activity/Activity.module.scss
+++ b/src/views/RecIM/views/Activity/Activity.module.scss
@@ -92,3 +92,9 @@
 .redButton:hover {
   background-color: $alternative-red;
 }
+
+.scrollableCenteredTabs {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}

--- a/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
+++ b/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
@@ -177,7 +177,7 @@ const ScheduleList = ({ isAdmin, series, activityID, reload, setReload }) => {
       {series.Match.length ? (
         <MatchList matches={series.Match} activityID={activityID} />
       ) : (
-        <Typography variant="body1" paragraph>
+        <Typography className={styles.secondaryText}>
           Games have not yet been scheduled for this series.
         </Typography>
       )}

--- a/src/views/RecIM/views/Activity/index.jsx
+++ b/src/views/RecIM/views/Activity/index.jsx
@@ -212,9 +212,7 @@ const Activity = () => {
               );
             })
           ) : (
-            <Typography variant="body1" paragraph>
-              No series scheduled yet!
-            </Typography>
+            <Typography className={styles.secondaryTex}>No series scheduled yet!</Typography>
           )}
         </CardContent>
       </Card>
@@ -271,7 +269,7 @@ const Activity = () => {
               {activity.Team?.length ? (
                 <TeamList teams={activity.Team} />
               ) : (
-                <Typography variant="body1" paragraph>
+                <Typography className={styles.secondaryText}>
                   Be the first to create a team!
                 </Typography>
               )}

--- a/src/views/RecIM/views/Activity/index.jsx
+++ b/src/views/RecIM/views/Activity/index.jsx
@@ -280,13 +280,6 @@ const Activity = () => {
         </CardContent>
       </Card>
     );
-    console.log(
-      activity,
-      activity?.Series[0]?.StartDate,
-      selectedSeriesTab,
-      activity?.Series[0]?.StartDate < new Date().toJSON() &&
-        new Date().toJSON() < activity?.Series[0]?.EndDate,
-    );
     return (
       <>
         <Header activity={activity}>{headerContents}</Header>

--- a/src/views/RecIM/views/Activity/index.jsx
+++ b/src/views/RecIM/views/Activity/index.jsx
@@ -153,7 +153,7 @@ const Activity = () => {
                       setOpenMatchForm(true);
                     }}
                   >
-                    Create a New Match
+                    Create a Match
                   </Button>
                 </Grid>
               </Grid>
@@ -168,7 +168,7 @@ const Activity = () => {
                       setOpenCreateSeriesForm(true);
                     }}
                   >
-                    Create a New Series
+                    Create a Series
                   </Button>
                 </Grid>
               </Grid>
@@ -212,7 +212,7 @@ const Activity = () => {
                       setOpenTeamForm(true);
                     }}
                   >
-                    Create a New Team
+                    Create a Team
                   </Button>
                 </Grid>
               </Grid>

--- a/src/views/RecIM/views/Activity/index.jsx
+++ b/src/views/RecIM/views/Activity/index.jsx
@@ -1,4 +1,14 @@
-import { Grid, Typography, Card, CardHeader, CardContent, Button, IconButton } from '@mui/material';
+import {
+  Grid,
+  Typography,
+  Card,
+  CardHeader,
+  CardContent,
+  Button,
+  IconButton,
+  Tabs,
+  Tab,
+} from '@mui/material';
 import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
@@ -19,6 +29,8 @@ import EditIcon from '@mui/icons-material/Edit';
 import ScheduleList from './components/ScheduleList';
 import { formatDateTimeRange } from '../../components/Helpers';
 import defaultLogo from 'views/RecIM/recim_logo.png';
+import { TabPanel } from 'views/RecIM/components';
+import { Box } from '@mui/system';
 
 const Activity = () => {
   const navigate = useNavigate();
@@ -195,40 +207,125 @@ const Activity = () => {
       </Card>
     );
 
-    let teamsCard = activity && (
-      <Card>
-        <CardHeader title="Teams" className={styles.cardHeader} />
-        <CardContent>
-          {canCreateTeam && (
-            <Grid container className={styles.buttonArea}>
-              <Grid item xs={12}>
-                <Grid container justifyContent="center">
-                  <Button
-                    variant="contained"
-                    color="warning"
-                    startIcon={<AddCircleRoundedIcon />}
-                    className={styles.actionButton}
-                    onClick={() => {
-                      setOpenTeamForm(true);
-                    }}
-                  >
-                    Create a Team
-                  </Button>
+    let teamsCard =
+      activity &&
+      (activity.Series.length > 0 ? (
+        <Card>
+          <CardHeader title="Teams" className={styles.cardHeader} />
+          <CardContent>
+            {canCreateTeam && (
+              <Grid container className={styles.buttonArea}>
+                <Grid item xs={12}>
+                  <Grid container justifyContent="center">
+                    <Button
+                      variant="contained"
+                      color="warning"
+                      startIcon={<AddCircleRoundedIcon />}
+                      className={styles.actionButton}
+                      onClick={() => {
+                        setOpenTeamForm(true);
+                      }}
+                    >
+                      Create a Team
+                    </Button>
+                  </Grid>
                 </Grid>
               </Grid>
-            </Grid>
-          )}
-          {activity.Team?.length ? (
-            <TeamList teams={activity.Team} />
-          ) : (
-            <Typography variant="body1" paragraph>
-              Be the first to create a team!
-            </Typography>
-          )}
-        </CardContent>
-      </Card>
-    );
-
+            )}
+            <Box display="flex" justifyContent="center" width="100%">
+              <Tabs
+                value={0}
+                //onChange={(event, newTab) => setTeamTab(newTab)}
+                variant="scrollable"
+                scrollButtons="auto"
+                aria-label="admin control center tabs"
+              >
+                <Tab label="placeholder1" />
+                <Tab label="placeholder2" />
+                {/* <Tab label="placeholder3" />
+                <Tab label="placeholder4" />
+                <Tab label="placeholder5" />
+                <Tab label="placeholder6" />
+                <Tab label="placeholder7" />
+                <Tab label="placeholder8" />
+                <Tab label="placeholder9" /> */}
+              </Tabs>
+            </Box>
+            <TabPanel value={0} index={0}>
+              {/*placeholder */}
+            </TabPanel>
+            <TabPanel value={0} index={1}>
+              {/*placeholder */}
+            </TabPanel>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader title="Teams" className={styles.cardHeader} />
+          <CardContent>
+            {canCreateTeam && (
+              <Grid container className={styles.buttonArea}>
+                <Grid item xs={12}>
+                  <Grid container justifyContent="center">
+                    <Button
+                      variant="contained"
+                      color="warning"
+                      startIcon={<AddCircleRoundedIcon />}
+                      className={styles.actionButton}
+                      onClick={() => {
+                        setOpenTeamForm(true);
+                      }}
+                    >
+                      Create a Team
+                    </Button>
+                  </Grid>
+                </Grid>
+              </Grid>
+            )}
+            {activity.Team?.length ? (
+              <TeamList teams={activity.Team} />
+            ) : (
+              <Typography variant="body1" paragraph>
+                Be the first to create a team!
+              </Typography>
+            )}
+          </CardContent>
+        </Card>
+      ));
+    // let teamsCard = activity && (
+    //   <Card>
+    //     <CardHeader title="Teams" className={styles.cardHeader} />
+    //     <CardContent>
+    //       {canCreateTeam && (
+    //         <Grid container className={styles.buttonArea}>
+    //           <Grid item xs={12}>
+    //             <Grid container justifyContent="center">
+    //               <Button
+    //                 variant="contained"
+    //                 color="warning"
+    //                 startIcon={<AddCircleRoundedIcon />}
+    //                 className={styles.actionButton}
+    //                 onClick={() => {
+    //                   setOpenTeamForm(true);
+    //                 }}
+    //               >
+    //                 Create a Team
+    //               </Button>
+    //             </Grid>
+    //           </Grid>
+    //         </Grid>
+    //       )}
+    //       {activity.Team?.length ? (
+    //         <TeamList teams={activity.Team} />
+    //       ) : (
+    //         <Typography variant="body1" paragraph>
+    //           Be the first to create a team!
+    //         </Typography>
+    //       )}
+    //     </CardContent>
+    //   </Card>
+    // );
+    console.log(activity);
     return (
       <>
         <Header activity={activity}>{headerContents}</Header>
@@ -237,10 +334,10 @@ const Activity = () => {
         ) : (
           <Grid container justifyContent="center" spacing={2}>
             <Grid item container justifyContent="center" spacing={2}>
-              <Grid item xs={12} md={6}>
+              <Grid item xs={12} md={7}>
                 {scheduleCard}
               </Grid>
-              <Grid item direction={'column'} xs={12} md={6}>
+              <Grid item direction={'column'} xs={12} md={5}>
                 <Grid item className={styles.gridItemStack}>
                   {teamsCard}
                 </Grid>

--- a/src/views/RecIM/views/Activity/index.jsx
+++ b/src/views/RecIM/views/Activity/index.jsx
@@ -27,7 +27,7 @@ import SeriesForm from 'views/RecIM/components/Forms/SeriesForm';
 import { getParticipantByUsername, getParticipantTeams } from 'services/recim/participant';
 import EditIcon from '@mui/icons-material/Edit';
 import ScheduleList from './components/ScheduleList';
-import { formatDateTimeRange, standardDate } from '../../components/Helpers';
+import { formatDateTimeRange } from '../../components/Helpers';
 import defaultLogo from 'views/RecIM/recim_logo.png';
 import { TabPanel } from 'views/RecIM/components';
 import { Box } from '@mui/system';

--- a/src/views/RecIM/views/Home/Home.module.scss
+++ b/src/views/RecIM/views/Home/Home.module.scss
@@ -53,3 +53,9 @@
   border-bottom-left-radius: 0.5em;
   border-bottom-right-radius: 0.5em;
 }
+
+.secondaryText {
+  margin-top: 1em;
+  color: $neutral-gray;
+  text-align: center;
+}

--- a/src/views/RecIM/views/Home/index.jsx
+++ b/src/views/RecIM/views/Home/index.jsx
@@ -168,9 +168,7 @@ const Home = () => {
       {participantTeams ? (
         <TeamList teams={participantTeams} />
       ) : (
-        <Typography className={styles.secondaryText}>
-          You're not yet apart of any teams; join one to get started!
-        </Typography>
+        <Typography className={styles.secondaryText}>You're not yet apart of any teams!</Typography>
       )}
     </CardContent>
   );

--- a/src/views/RecIM/views/Home/index.jsx
+++ b/src/views/RecIM/views/Home/index.jsx
@@ -25,14 +25,7 @@ import SeriesForm from 'views/RecIM/components/Forms/SeriesForm';
 import { getTeamInvites } from 'services/recim/team';
 import recimLogo from './../../recim_logo.png';
 import { isFuture } from 'date-fns';
-
-const TabPanel = ({ children, value, index }) => {
-  return (
-    <div hidden={value !== index} role="tabpanel">
-      {children}
-    </div>
-  );
-};
+import { TabPanel } from 'views/RecIM/components';
 
 export const HomeHeaderContents = () => {
   return (

--- a/src/views/RecIM/views/Home/index.jsx
+++ b/src/views/RecIM/views/Home/index.jsx
@@ -127,7 +127,7 @@ const Home = () => {
       {ongoingActivities.length > 0 ? (
         <ActivityList activities={ongoingActivities} showActivityOptions={hasPermissions} />
       ) : (
-        <Typography variant="body1" paragraph>
+        <Typography className={styles.secondaryText}>
           It looks like there aren't any Rec-IM activities currently ongoing
         </Typography>
       )}
@@ -139,7 +139,7 @@ const Home = () => {
       {registrableActivities.length > 0 ? (
         <ActivityList activities={registrableActivities} showActivityOptions={hasPermissions} />
       ) : (
-        <Typography variant="body1" paragraph>
+        <Typography className={styles.secondaryText}>
           It looks like there aren't any Rec-IM activities currently open for registration
         </Typography>
       )}
@@ -169,22 +169,24 @@ const Home = () => {
   let activitiesCard = (
     <Card>
       <CardHeader title="Rec-IM Activities" className={styles.cardHeader} />
-      {hasPermissions && createActivityButton}
-      <Tabs
-        value={activityTab}
-        onChange={(event, newTab) => setActivityTab(newTab)}
-        aria-label="admin control center tabs"
-        centered
-      >
-        <Tab label="Upcoming Activities" />
-        <Tab label="Ongoing Activities" />
-      </Tabs>
-      <TabPanel value={activityTab} index={0}>
-        {upcomingActivitiesContent}
-      </TabPanel>
-      <TabPanel value={activityTab} index={1}>
-        {ongoingActivitiesContent}
-      </TabPanel>
+      <CardContent>
+        {hasPermissions && createActivityButton}
+        <Tabs
+          value={activityTab}
+          onChange={(event, newTab) => setActivityTab(newTab)}
+          aria-label="admin control center tabs"
+          centered
+        >
+          <Tab label="Upcoming Activities" />
+          <Tab label="Ongoing Activities" />
+        </Tabs>
+        <TabPanel value={activityTab} index={0}>
+          {upcomingActivitiesContent}
+        </TabPanel>
+        <TabPanel value={activityTab} index={1}>
+          {ongoingActivitiesContent}
+        </TabPanel>
+      </CardContent>
     </Card>
   );
   let myTeamsCard = (
@@ -242,10 +244,10 @@ const Home = () => {
           <GordonLoader />
         ) : (
           <Grid container spacing={2}>
-            <Grid item xs={12} md={8}>
+            <Grid item xs={12} md={7}>
               {activitiesCard}
             </Grid>
-            <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={5}>
               {myTeamsCard}
             </Grid>
             {openActivityForm && (

--- a/src/views/RecIM/views/Home/index.jsx
+++ b/src/views/RecIM/views/Home/index.jsx
@@ -1,5 +1,15 @@
 import GordonUnauthorized from 'components/GordonUnauthorized';
-import { Grid, Typography, Card, CardHeader, CardContent, Button, Tabs, Tab } from '@mui/material';
+import {
+  Grid,
+  Typography,
+  Card,
+  CardHeader,
+  CardContent,
+  Button,
+  Tabs,
+  Tab,
+  Badge,
+} from '@mui/material';
 import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
 import ActivityForm from '../../components/Forms/ActivityForm';
 import { useUser } from 'hooks';
@@ -50,13 +60,14 @@ const Home = () => {
   const [activities, setActivities] = useState([]);
   const [ongoingActivities, setOngoingActivities] = useState([]);
   const [registrableActivities, setRegistrableActivities] = useState([]);
-  const [myTeams, setMyTeams] = useState([]);
+  const [participantTeams, setParticipantTeams] = useState([]);
   const [invites, setInvites] = useState([]);
   const [participant, setParticipant] = useState([]);
   const [openWaiver, setOpenWaiver] = useState(false);
   const [createdActivity, setCreatedActivity] = useState({ ID: null });
   const [hasPermissions, setHasPermissions] = useState(false);
-  const [tab, setTab] = useState(0);
+  const [activityTab, setActivityTab] = useState(0);
+  const [teamTab, setTeamTab] = useState(0);
 
   // profile hook used for future authentication
   // Administration privs will use AuthGroups -> example can be found in
@@ -70,7 +81,7 @@ const Home = () => {
       setInvites(await getTeamInvites());
       if (profile) {
         setParticipant(await getParticipantByUsername(profile.AD_Username));
-        setMyTeams(await getParticipantTeams(profile.AD_Username));
+        setParticipantTeams(await getParticipantTeams(profile.AD_Username));
       }
       setLoading(false);
     };
@@ -142,59 +153,73 @@ const Home = () => {
     </CardContent>
   );
 
+  let myInvites = (
+    <CardContent>
+      {invites.length > 0 ? (
+        <TeamList teams={invites} invite setInvites={setInvites} />
+      ) : (
+        <Typography className={styles.secondaryText}>No pending invites</Typography>
+      )}
+    </CardContent>
+  );
+
+  let myTeams = (
+    <CardContent>
+      {participantTeams ? (
+        <TeamList teams={participantTeams} />
+      ) : (
+        <Typography className={styles.secondaryText}>
+          You're not yet apart of any teams; join one to get started!
+        </Typography>
+      )}
+    </CardContent>
+  );
+
   let activitiesCard = (
     <Card>
       <CardHeader title="Rec-IM Activities" className={styles.cardHeader} />
       {hasPermissions && createActivityButton}
       <Tabs
-        value={tab}
-        onChange={(event, newTab) => setTab(newTab)}
+        value={activityTab}
+        onChange={(event, newTab) => setActivityTab(newTab)}
         aria-label="admin control center tabs"
         centered
       >
         <Tab label="Upcoming Activities" />
         <Tab label="Ongoing Activities" />
       </Tabs>
-      <TabPanel value={tab} index={0}>
+      <TabPanel value={activityTab} index={0}>
         {upcomingActivitiesContent}
       </TabPanel>
-      <TabPanel value={tab} index={1}>
+      <TabPanel value={activityTab} index={1}>
         {ongoingActivitiesContent}
       </TabPanel>
     </Card>
   );
-
   let myTeamsCard = (
     <Card>
       <CardHeader title="Teams" className={styles.cardHeader} />
-      <CardContent>
-        {invites.length > 0 && (
-          <>
-            <Grid container className={styles.teamHeader} alignItems="center" columnSpacing={2}>
-              <Grid item container direction="column">
-                <Typography variant="h6" className={styles.teamHeaderMainText}>
-                  My Team Invites
-                </Typography>
-              </Grid>
-            </Grid>
-            <TeamList teams={invites} invite setInvites={setInvites} />
-          </>
-        )}
-        <Grid container className={styles.teamHeader} alignItems="center" columnSpacing={2}>
-          <Grid item container direction="column">
-            <Typography variant="h6" className={styles.teamHeaderMainText}>
-              My Teams
-            </Typography>
-          </Grid>
-        </Grid>
-        {myTeams ? (
-          <TeamList teams={myTeams} />
-        ) : (
-          <Typography variant="body1" paragraph>
-            You're not yet apart of any teams; join one to get started!
-          </Typography>
-        )}
-      </CardContent>
+      <Tabs
+        value={teamTab}
+        onChange={(event, newTab) => setTeamTab(newTab)}
+        aria-label="admin control center tabs"
+        centered
+      >
+        <Tab label="My Teams" />
+        <Tab
+          label={
+            <Badge color="secondary" variant="dot" badgeContent={invites.length}>
+              Invites
+            </Badge>
+          }
+        />
+      </Tabs>
+      <TabPanel value={teamTab} index={0}>
+        {myTeams}
+      </TabPanel>
+      <TabPanel value={teamTab} index={1}>
+        {myInvites}
+      </TabPanel>
     </Card>
   );
 

--- a/src/views/RecIM/views/Home/index.jsx
+++ b/src/views/RecIM/views/Home/index.jsx
@@ -111,7 +111,7 @@ const Home = () => {
               setOpenActivityForm(true);
             }}
           >
-            Create a New Activity
+            Create a Activity
           </Button>
         </Grid>
       </Grid>

--- a/src/views/RecIM/views/Match/index.jsx
+++ b/src/views/RecIM/views/Match/index.jsx
@@ -95,7 +95,6 @@ const Match = () => {
     // The user is not logged in
     return <GordonUnauthorized feature={'the Rec-IM page'} />;
   } else {
-    console.log(match);
     let headerContents = (
       <>
         <Grid container spacing={4}>

--- a/src/views/RecIM/views/Match/index.jsx
+++ b/src/views/RecIM/views/Match/index.jsx
@@ -111,7 +111,7 @@ const Match = () => {
         <Grid container alignItems="center" justifyContent="space-around">
           <Grid item xs={2}>
             <img
-              src={match?.Team.find((t) => t.ID === match?.Team[0]?.ID).Logo ?? defaultLogo}
+              src={match?.Team.find((t) => t.ID === match?.Team[0]?.ID)?.Logo ?? defaultLogo}
               alt="Team Icon"
               width="85em"
             ></img>
@@ -173,7 +173,7 @@ const Match = () => {
           </Grid>
           <Grid item xs={2}>
             <img
-              src={match?.Team.find((t) => t.ID === match?.Team[1]?.ID).Logo ?? defaultLogo}
+              src={match?.Team.find((t) => t.ID === match?.Team[1]?.ID)?.Logo ?? defaultLogo}
               alt="Team Icon"
               width="85em"
             ></img>

--- a/src/views/RecIM/views/Match/index.jsx
+++ b/src/views/RecIM/views/Match/index.jsx
@@ -95,6 +95,7 @@ const Match = () => {
     // The user is not logged in
     return <GordonUnauthorized feature={'the Rec-IM page'} />;
   } else {
+    console.log(match);
     let headerContents = (
       <>
         <Grid container spacing={4}>
@@ -110,9 +111,7 @@ const Match = () => {
         <Grid container alignItems="center" justifyContent="space-around">
           <Grid item xs={2}>
             <img
-              src={
-                match?.Activity.Team.find((t) => t.ID === match?.Team[0]?.ID).Logo ?? defaultLogo
-              }
+              src={match?.Team.find((t) => t.ID === match?.Team[0]?.ID).Logo ?? defaultLogo}
               alt="Team Icon"
               width="85em"
             ></img>
@@ -174,9 +173,7 @@ const Match = () => {
           </Grid>
           <Grid item xs={2}>
             <img
-              src={
-                match?.Activity.Team.find((t) => t.ID === match?.Team[1]?.ID).Logo ?? defaultLogo
-              }
+              src={match?.Team.find((t) => t.ID === match?.Team[1]?.ID).Logo ?? defaultLogo}
               alt="Team Icon"
               width="85em"
             ></img>

--- a/src/views/RecIM/views/Team/Team.module.scss
+++ b/src/views/RecIM/views/Team/Team.module.scss
@@ -44,3 +44,9 @@
   border-bottom-left-radius: 0.5em;
   border-bottom-right-radius: 0.5em;
 }
+
+.secondaryText {
+  margin-top: 1em;
+  color: $neutral-gray;
+  text-align: center;
+}

--- a/src/views/RecIM/views/Team/index.jsx
+++ b/src/views/RecIM/views/Team/index.jsx
@@ -155,10 +155,10 @@ const Team = () => {
       <Card>
         <CardHeader title="Schedule" className={styles.cardHeader} />
         <CardContent>
-          {team.Match?.length ? (
+          {team.Match?.length > 0 ? (
             <MatchList matches={team.Match} activityID={team.Activity?.ID} />
           ) : (
-            <Typography variant="body1" paragraph>
+            <Typography className={styles.secondaryText}>
               No matches scheduled at this time!
             </Typography>
           )}


### PR DESCRIPTION
Team Records
--

Comparison (OLD)
![image](https://user-images.githubusercontent.com/78386128/226111316-0b9b462d-b6c5-40ce-a62a-55046a529eb6.png)

- Teams now have a Win/Loss count (Tie is unavailable currently as the calculation needs a rework)
- Activity font on the listing is smaller, and location has been moved below the team name (the benefit of this is that we can fit longer team/activity names and only need a smaller space for the listing/invite)

![image](https://user-images.githubusercontent.com/78386128/226111143-b4cecc16-c1ae-402c-9ca0-725b20cf76d4.png)
- `Home` shows an all encompassing Activity Record (a calculation done on summation of Series Records)
- `Activity` page shows Series Records individually and sorts them by Most Wins

![image](https://user-images.githubusercontent.com/78386128/226113441-b518028c-1987-429b-b9e2-3978877d1626.png)
- Activity see's teams by `Series` (thus individual series records)
- Tab is autofocused on first `ongoing` series (handled by time), defaulted to first tab

![image](https://user-images.githubusercontent.com/78386128/226113502-e844b339-1fb1-4011-aef2-243a7fbccbef.png)
- Series tabs are centered **UNTIL** they need to be scrollable
- MUI does not allow for scrollable and centered, had to do an interesting workaround using `Mui-Box`


Design Rework
--

### Invites
![image](https://user-images.githubusercontent.com/78386128/226111948-7936367e-ca32-4f9d-8122-63947b2eefcf.png)
![image](https://user-images.githubusercontent.com/78386128/226112068-5a11f520-bad2-4fac-9f23-bfba2a588b05.png)
- Accept/Reject colors use available Gordon Colors
- Accept/Reject reduced to `IconButton`
- Updated collapse size to ensure buttons dont get overlayed

Comparison (OLD)
![image](https://user-images.githubusercontent.com/78386128/226111987-ed1b36b7-2eca-4a47-b4b8-0da673f4fef5.png)

- Invites tab is **ALWAYS** available. 
- Badge disappears if there is no invite
![image](https://user-images.githubusercontent.com/78386128/226112147-d2044dc8-298e-4564-bbcc-9b45af801bf6.png)


### Match Listing
![image](https://user-images.githubusercontent.com/78386128/226112931-228a6119-0a6a-41c3-a49f-5960cad4764c.png)
- Displays **Final** over completed games and Score
- Displays **Forfeited** over forfeited games
- `vs.` if not a completed status
- Updated space available for Team names. This causes a small issue if the name is VERY VERY long, however, without the increased in dedicated size for the score, the name pushes up against the score. Also currently the Team names encroach on the space dedicated for Time and Surface (below) 

Comparison (Old)
![image](https://user-images.githubusercontent.com/78386128/226113586-ee86d509-5ceb-445e-9d56-7d9c2b20aa2b.png)

