### PR TITLE
Fac/Staff Personal Info Toggle Visual Fix

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -79,9 +79,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
   const isCampusLocationPrivate = isStudent && keepPrivate && profile.OnOffCampus !== PRIVATE_INFO;
 
   // Students' home phone is always private. FacStaffs' home phone is private for private users
-  const [isHomePhonePrivate, setIsHomePhonePrivate] = useState(
-    (isStudent || keepPrivate) && Boolean(profile.HomePhone),
-  );
+  const [isHomePhonePrivate, setIsHomePhonePrivate] = useState(isStudent || keepPrivate);
 
   // Street address info is always private, and City/State/Country info is private for private users
   const isAddressPrivate =
@@ -116,6 +114,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
 
   const handleChangeHomePhonePrivacy = async () => {
     try {
+      // this user service currently sets mobile_privacy to true or false - same as setMobilePhonePrivacy, which is NOT optimal or sensical. See user.ts
       await userService.setHomePhonePrivacy(!isHomePhonePrivate);
       setIsHomePhonePrivate(!isHomePhonePrivate);
 
@@ -501,6 +500,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
           </Grid>
           <Grid item xs={4} align="right">
             {/* visible only for fac/staff on their profile */}
+            {/* isHomePhonePrivate is a misleading name for determining if personal information should be shown */}
             {isFacStaff && myProf ? (
               <FormControlLabel
                 control={


### PR DESCRIPTION
Continuation from #1709.

This PR fixes state logic for showing which selection (from private or public) personal information currently is. Previously, the logic for setting the state of the toggle always returned false when there was no Home phone no. added (it seems), which automatically set the toggle to 'true' (which is shown as public by the toggler). So whether or not you set your profile as private or public with the toggle, it would show that it was set to public (see https://github.com/gordon-cs/gordon-360-ui/issues/1653).