### PR TITLE
Fix Involvement Member Links on small screens

### DIFF
--- a/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.jsx
+++ b/src/views/InvolvementProfile/components/Membership/components/MemberList/components/MemberListItem/index.jsx
@@ -327,7 +327,7 @@ const MemberListItem = ({
                         {member.FirstName} {member.LastName}
                       </Typography>
                     ) : (
-                      <Link href={`/profile/${member.AD_Username}`} underline="hover">
+                      <Link href={`/profile/${member.Username}`} underline="hover">
                         <Typography>
                           {member.FirstName} {member.LastName}
                         </Typography>
@@ -379,7 +379,7 @@ const MemberListItem = ({
                 {member.FirstName} {member.LastName}
               </Typography>
             ) : (
-              <Link href={`/profile/${member.AD_Username}`} underline="hover">
+              <Link href={`/profile/${member.Username}`} underline="hover">
                 <Typography>
                   {member.FirstName} {member.LastName}
                 </Typography>


### PR DESCRIPTION
This PR fixes the member profile links in an involvement on small screens by fixing a variable name.

Fixes #1638 