### PR TITLE
[Rec-IM] Image feature Hotfix 3

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,7 +7,7 @@
 # VITE_API_URL=https://360ApiTrain.gordon.edu/
 
 # @RECIM
-VITE_API_URL=https://360ApiRecIM.gordon.edu/
+# VITE_API_URL=https://360ApiRecIM.gordon.edu/
 
 # @LOCALHOST
-# VITE_API_URL=http://localhost:51626/
+ VITE_API_URL=http://localhost:52000/

--- a/src/services/recim/activity.ts
+++ b/src/services/recim/activity.ts
@@ -44,6 +44,7 @@ type PatchActivity = BaseActivity & {
   TypeID: number;
   StatusID: number;
   Logo: string;
+  IsLogoUpdate: boolean;
   Completed: boolean;
 };
 

--- a/src/services/recim/sport.ts
+++ b/src/services/recim/sport.ts
@@ -21,6 +21,7 @@ type PatchSport = {
   Description: string;
   Rules: string;
   Logo: string;
+  IsLogoUpdate: boolean;
 };
 
 //Sport Routes

--- a/src/services/recim/team.ts
+++ b/src/services/recim/team.ts
@@ -68,6 +68,7 @@ type PatchTeam = {
   Name: string;
   StatusID: number;
   Logo: string;
+  IsLogoUpdate: boolean;
 };
 
 //Team Routes

--- a/src/views/RecIM/components/Forms/ActivityForm/index.jsx
+++ b/src/views/RecIM/components/Forms/ActivityForm/index.jsx
@@ -284,7 +284,7 @@ const ActivityForm = ({ activity, closeWithSnackbar, openActivityForm, setOpenAc
     newActivityRequest.typeID = activityTypes.find(
       (type) => type.Description === newActivityRequest.typeID,
     ).ID;
-    
+
     setActivityRequest(newActivityRequest);
   };
 
@@ -295,6 +295,7 @@ const ActivityForm = ({ activity, closeWithSnackbar, openActivityForm, setOpenAc
       activityRequest.statusID = activityStatusTypes.find(
         (type) => type.Description === activityRequest.statusID,
       ).ID;
+      activity.isLogoUpdate = false;
       editActivity(activity.ID, activityRequest).then((res) => {
         setSaving(false);
         closeWithSnackbar({

--- a/src/views/RecIM/components/Forms/ImageOptions/index.jsx
+++ b/src/views/RecIM/components/Forms/ImageOptions/index.jsx
@@ -119,6 +119,7 @@ const ImageOptions = ({
       case 'Activity': {
         let activityRequest = {
           Logo: cropperRef.current.cropper.getCroppedCanvas({ width: CROPPER_WIDTH }).toDataURL(),
+          IsLogoUpdate: true,
         };
 
         editActivity(component.ID, activityRequest).then(() => {
@@ -134,6 +135,7 @@ const ImageOptions = ({
       case 'Team': {
         let teamRequest = {
           Logo: cropperRef.current.cropper.getCroppedCanvas({ width: CROPPER_WIDTH }).toDataURL(),
+          IsLogoUpdate: true,
         };
 
         editTeam(component.ID, teamRequest).then(() => {

--- a/src/views/RecIM/components/Forms/TeamForm/index.jsx
+++ b/src/views/RecIM/components/Forms/TeamForm/index.jsx
@@ -173,6 +173,7 @@ const TeamForm = ({
       teamRequest.StatusID = teamStatus.find(
         (type) => type.Description === teamRequest.StatusID,
       ).ID;
+      teamRequest.IsLogoUpdate = false;
 
       editTeam(team.ID, teamRequest).then(() => {
         setSaving(false);


### PR DESCRIPTION
This pr fixes one issue on image feature:
 - The image is reset to default (to null in database) whenever you make an update from `ActivityForm` or `TeamForm`.

Since now we have separate UIs for regular activity and team info updates and image update, I added a boolean `IsLogoUpdate` in relative Patch viewmodels to specify the procedure for image.

API pr:.