### PR TITLE
[Rec-IM] Home Page hang

### DIFF
--- a/src/views/RecIM/views/Home/index.jsx
+++ b/src/views/RecIM/views/Home/index.jsx
@@ -71,10 +71,8 @@ const Home = () => {
       setLoading(true);
       // Get all active activities where registration has not closed
       setActivities(await getActivities());
-      setInvites(await getTeamInvites());
       if (profile) {
         setParticipant(await getParticipantByUsername(profile.AD_Username));
-        setParticipantTeams(await getParticipantTeams(profile.AD_Username));
       }
       setLoading(false);
     };
@@ -82,9 +80,17 @@ const Home = () => {
   }, [profile, openActivityForm, openWaiver, openCreateSeriesForm]);
 
   useEffect(() => {
+    const loadParticipantData = async () => {
+      setLoading(true);
+      setInvites(await getTeamInvites());
+      setParticipantTeams(await getParticipantTeams(profile.AD_Username));
+      setLoading(false);
+    };
+
     setOpenWaiver(participant == null);
     if (participant) {
       setHasPermissions(participant.IsAdmin);
+      loadParticipantData();
     }
   }, [participant]);
 


### PR DESCRIPTION
There was a bug that caused non-participants to load infinitely on the home page due to `Team Invites` and `Participant Teams` loading (since they weren't participants). Logic is moved after we check for a participant; if `null` we know that they haven't signed up for rec-im (which is fine). 

Next thing to do is to move the `Waiver` to `Accept Team Invite` and `Join an Activity`