### PR TITLE
Update `xlsx` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "react-to-print": "^2.14.1",
         "react-visibility-sensor": "^5.1.1",
         "url-regex-safe": "^2.1.0",
-        "xlsx": "^0.17.3"
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.2/xlsx-0.19.2.tgz"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.176",
@@ -2246,21 +2246,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
-      "integrity": "sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==",
-      "dependencies": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
-      },
-      "bin": {
-        "adler32": "bin/adler32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -2789,26 +2774,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/cfb/node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2939,14 +2904,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3065,17 +3022,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/cropperjs": {
@@ -4320,14 +4266,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/exit-on-epipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4466,14 +4404,6 @@
         "debug": {
           "optional": true
         }
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/fs-minipass": {
@@ -6926,17 +6856,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
-      "bin": {
-        "printj": "bin/printj.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -7906,17 +7825,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/ssri": {
       "version": "9.0.1",
@@ -9008,22 +8916,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -9113,18 +9005,10 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/xlsx": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.17.5.tgz",
-      "integrity": "sha512-lXNU0TuYsvElzvtI6O7WIVb9Zar1XYw7Xb3VAx2wn8N/n0whBYrCnHMxtFyIiUU1Wjf09WzmLALDfBO5PqTb1g==",
-      "dependencies": {
-        "adler-32": "~1.2.0",
-        "cfb": "^1.1.4",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.0",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
+      "version": "0.19.2",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.19.2/xlsx-0.19.2.tgz",
+      "integrity": "sha512-UwxQlR0S/ozz4xezXrmPI7ZqxhZ1bg7I7CtFw/WW9Hi/fKtwE8IVZ903r4uxS7W8I9mxYyHrGB85pRc4jq3jMw==",
+      "license": "Apache-2.0",
       "bin": {
         "xlsx": "bin/xlsx.njs"
       },
@@ -10613,15 +10497,6 @@
       "peer": true,
       "requires": {}
     },
-    "adler-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
-      "integrity": "sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==",
-      "requires": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
-      }
-    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -11007,22 +10882,6 @@
         "lodash": "^4.17.15"
       }
     },
-    "cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "requires": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "dependencies": {
-        "adler-32": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-          "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="
-        }
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -11117,11 +10976,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
-    },
-    "codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -11224,11 +11078,6 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
-    },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "cropperjs": {
       "version": "1.5.12",
@@ -12146,11 +11995,6 @@
         "clone-regexp": "^2.1.0"
       }
     },
-    "exit-on-epipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -12258,11 +12102,6 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
       "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
-    },
-    "frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="
     },
     "fs-minipass": {
       "version": "2.1.0",
@@ -14060,11 +13899,6 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
-    "printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
-    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -14781,14 +14615,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "peer": true
-    },
-    "ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "requires": {
-        "frac": "~1.1.2"
-      }
     },
     "ssri": {
       "version": "9.0.1",
@@ -15587,16 +15413,6 @@
         }
       }
     },
-    "wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="
-    },
-    "word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -15664,18 +15480,8 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "xlsx": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.17.5.tgz",
-      "integrity": "sha512-lXNU0TuYsvElzvtI6O7WIVb9Zar1XYw7Xb3VAx2wn8N/n0whBYrCnHMxtFyIiUU1Wjf09WzmLALDfBO5PqTb1g==",
-      "requires": {
-        "adler-32": "~1.2.0",
-        "cfb": "^1.1.4",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.0",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      }
+      "version": "https://cdn.sheetjs.com/xlsx-0.19.2/xlsx-0.19.2.tgz",
+      "integrity": "sha512-UwxQlR0S/ozz4xezXrmPI7ZqxhZ1bg7I7CtFw/WW9Hi/fKtwE8IVZ903r4uxS7W8I9mxYyHrGB85pRc4jq3jMw=="
     },
     "xmlcreate": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-to-print": "^2.14.1",
     "react-visibility-sensor": "^5.1.1",
     "url-regex-safe": "^2.1.0",
-    "xlsx": "^0.17.3"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.2/xlsx-0.19.2.tgz"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.176",

--- a/src/components/SpreadsheetUploader/index.jsx
+++ b/src/components/SpreadsheetUploader/index.jsx
@@ -1,17 +1,16 @@
-import { Button, Card, Typography } from '@mui/material';
+import { Paper, Stack, Typography } from '@mui/material';
 import { Description as SpreadsheetIcon } from '@mui/icons-material';
 import GordonDialogBox from 'components/GordonDialogBox';
 import GordonSnackbar from 'components/Snackbar';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Dropzone from 'react-dropzone';
-import { Link } from 'react-router-dom';
 import { read, utils } from 'xlsx';
 import styles from './SpreadsheetUploader.module.css';
 
 const acceptedTypes = [
   'application/vnd.ms-excel',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'text/csv'
+  'text/csv',
 ];
 
 const SpreadsheetUploader = ({
@@ -28,137 +27,113 @@ const SpreadsheetUploader = ({
   const [data, setData] = useState();
   const [error, setError] = useState();
 
-  useEffect(() => {
-    if (error) {
-      setData(null);
-    }
-  }, [error]);
+  const handleFileUpload = async ([file]) => {
+    try {
+      if (!acceptedTypes.includes(file.type)) {
+        throw new Error('The file is not one of the supported file types.');
+      }
 
-  const onDropAccepted = (fileList) => {
-    const file = fileList[0];
-    if (!acceptedTypes.includes(file.type)) {
-      setError('The file is not one of the supported file types.');
-      return;
-    }
-    const reader = new FileReader();
-    reader.onload = function(event) {
-      const data = event.target.result;
-      const workbook = read(data, {
-        type: 'binary',
-      });
+      const data = await file.arrayBuffer();
+
+      const workbook = read(data);
       const sheet = workbook.Sheets[workbook.SheetNames[0]];
 
-      const uploadedData = utils.sheet_to_row_object_array(sheet);
+      const uploadedData = utils.sheet_to_json(sheet);
 
       uploadedData.forEach((row) => {
         let columnNames = Object.keys(row);
 
-        if (error) return;
+        if (columnNames.length > maxColumns) throw new Error('File has too many columns');
 
-        if (columnNames.length > maxColumns) setError('File has too many columns');
-        if (columnNames.length < requiredColumns.length) setError('File has too few columns');
-        if (requiredColumns.some((column) => !columnNames.includes(column)))
-          setError('File is missing required columns');
+        if (columnNames.length < requiredColumns.length)
+          throw new Error('File has too few columns');
+
+        if (!requiredColumns.every((column) => columnNames.includes(column)))
+          throw new Error('File is missing required columns');
+
         if (
           columnNames.some(
             (columnName) =>
               !requiredColumns.includes(columnName) && !otherColumns.includes(columnName),
           )
         )
-          setError('File contains extra columns');
+          throw new Error('File contains extra columns');
       });
 
-      if (error) return;
-
       setData(uploadedData);
-    };
-
-    reader.onerror = function(event) {
-      console.error('File could not be read! Code ' + event.target.error.code);
-    };
-
-    reader.readAsBinaryString(file);
+    } catch (e) {
+      setError(e.message);
+    }
   };
 
   const dropZone = (
     <>
-      <Dropzone onDropAccepted={(files) => onDropAccepted(files)} multiple={false}>
-        {({ getRootProps, getInputProps }) => {
-          return (
-            <section className={styles.dropzone} {...getRootProps()}>
-              <input {...getInputProps()} />
-              <SpreadsheetIcon fontSize="large" className={styles.spreadsheeticon} />
-              &nbsp; Upload a Spreadsheet
-            </section>
-          );
-        }}
+      <Dropzone onDropAccepted={handleFileUpload} multiple={false}>
+        {({ getRootProps, getInputProps }) => (
+          <section className={styles.dropzone} {...getRootProps()}>
+            <input {...getInputProps()} />
+            <SpreadsheetIcon fontSize="large" className={styles.spreadsheeticon} />
+            &nbsp; Upload a Spreadsheet
+          </section>
+        )}
       </Dropzone>
       <Typography className={styles.dropzone_text} variant="body2">
         Accepted file types: CSV, XLSX
       </Typography>
-      {template ? (
-        <a href={template} rel="noopener noreferrer" target="_blank" download className={styles.dropzone_templatelink}>
+      {template && (
+        <a
+          href={template}
+          rel="noopener noreferrer"
+          target="_blank"
+          download
+          className={styles.dropzone_templatelink}
+        >
           Download Template
         </a>
-      ) : null}
+      )}
     </>
   );
+
+  const handleClose = () => {
+    setOpen(false);
+    setData(null);
+  };
 
   return (
     <GordonDialogBox
       open={open}
       title={title}
-      cancelButtonClicked={() => {
-        setOpen(false);
+      buttonName={buttonName}
+      buttonClicked={() => {
+        onSubmitData(data);
+        handleClose();
       }}
-      onClose={() => {
-        setOpen(false);
-      }}
+      isButtonDisabled={!data}
+      cancelButtonClicked={handleClose}
+      onClose={handleClose}
     >
       {data ? (
         <>
-          <Button
-            variant="contained"
-            onClick={() => {
-              onSubmitData(data);
-              setOpen(false);
-              setData(null);
-            }}
-            color="primary"
-            disabled={!data}
-            style={{ marginTop: '5px' }}
-          >
-            {buttonName}
-          </Button>
-          <Button
-            variant="contained"
-            onClick={() => {
-              setOpen(false);
-              setData(null);
-            }}
-          >
-            Cancel
-          </Button>
           <Typography variant="body2" width="60%" className={styles.dataconfirmationmessage}>
             Check over the data below to confirm that it is accurate.
           </Typography>
+          <Stack spacing={1} sx={{ maxHeight: '40vb' }}>
+            {data.map((row, index) => (
+              <Paper key={index} className={styles.dataconfirmationcard}>
+                {requiredColumns.map((columnName) =>
+                  row[columnName] ? (
+                    <Typography variant="body2">
+                      <b>{columnName}:</b> {row[columnName]}
+                    </Typography>
+                  ) : null,
+                )}
+              </Paper>
+            ))}
+          </Stack>
         </>
-      ) : null}
-      {data
-        ? data.map((row, index) => {
-          return (
-            <Card key={index} className={styles.dataconfirmationcard}>
-              {requiredColumns.map((columnName) =>
-                row[columnName] ? (
-                  <Typography variant="body2">
-                    <b>{columnName}:</b> {row[columnName]}
-                  </Typography>
-                ) : null,
-              )}
-            </Card>
-          );
-        })
-        : dropZone}
+      ) : (
+        dropZone
+      )}
       <GordonSnackbar
         open={error}
         text={error}

--- a/src/components/SpreadsheetUploader/index.jsx
+++ b/src/components/SpreadsheetUploader/index.jsx
@@ -13,6 +13,14 @@ const acceptedTypes = [
   'text/csv',
 ];
 
+const displayCell = (cellData) => {
+  if (cellData instanceof Date) {
+    return cellData.toLocaleString();
+  } else {
+    return cellData;
+  }
+};
+
 const SpreadsheetUploader = ({
   open,
   setOpen,
@@ -35,7 +43,7 @@ const SpreadsheetUploader = ({
 
       const data = await file.arrayBuffer();
 
-      const workbook = read(data);
+      const workbook = read(data, { cellDates: true });
       const sheet = workbook.Sheets[workbook.SheetNames[0]];
 
       const uploadedData = utils.sheet_to_json(sheet);
@@ -123,7 +131,7 @@ const SpreadsheetUploader = ({
                 {requiredColumns.map((columnName) =>
                   row[columnName] ? (
                     <Typography variant="body2">
-                      <b>{columnName}:</b> {row[columnName]}
+                      <b>{columnName}:</b> {displayCell(row[columnName])}
                     </Typography>
                   ) : null,
                 )}

--- a/src/views/Admin/components/CliftonStrengthsUpload/index.jsx
+++ b/src/views/Admin/components/CliftonStrengthsUpload/index.jsx
@@ -119,14 +119,15 @@ const CliftonStrengthsUpload = () => {
         title="Clifton Strengths Upload"
         requiredColumns={[
           'Email',
-          'DateCompleted',
-          'Theme1',
-          'Theme2',
-          'Theme3',
-          'Theme4',
-          'Theme5',
-          'AccessCode',
+          'Date Completed',
+          'Theme_1',
+          'Theme_2',
+          'Theme_3',
+          'Theme_4',
+          'Theme_5',
+          'Access Code',
         ]}
+        otherColumns={['Last Name', 'First Name', 'Status']}
         buttonName="Upload Strengths"
         template={templateUrl}
       />

--- a/src/views/Admin/components/CliftonStrengthsUpload/index.jsx
+++ b/src/views/Admin/components/CliftonStrengthsUpload/index.jsx
@@ -12,15 +12,12 @@ import {
 } from '@mui/material';
 import GordonLoader from 'components/Loader';
 import SpreadsheetUploader from 'components/SpreadsheetUploader';
-import { addDays, parseISO } from 'date-fns';
 import { useState } from 'react';
 import CliftonStrengthsService from 'services/cliftonStrengths';
 import styles from './CliftonStrengthsUpload.module.scss';
 import templateUrl from './cliftonStrengthsUploadTemplate.csv?url';
 
 const successResults = ['Success', 'Added', 'Modified'];
-
-const initDate = parseISO('1900-01-01T00:00:00');
 
 const CliftonStrengthsUpload = () => {
   const [isSpreadsheetUploaderOpen, setIsSpreadsheetUploaderOpen] = useState(false);
@@ -30,53 +27,18 @@ const CliftonStrengthsUpload = () => {
   const handleSubmitStrengths = (uploadedData) => {
     setLoading(true);
 
-    let formattedData = uploadedData.map((cs) => {
-      // The date completed value comes out of the
-      // spreadsheet uploader as a number of days since 1/1/1900.
-      let days = cs['Date Completed'];
-      cs['Date Completed'] = addDays(initDate, days).toISOString();
-
-      return {
-        AccessCode: cs['Access Code'],
-        Email: cs.Email,
-        DateCompleted: cs['Date Completed'],
-        Themes: [cs.Theme_1, cs.Theme_2, cs.Theme_3, cs.Theme_4, cs.Theme_5],
-        Private: false,
-      };
-    });
+    const formattedData = uploadedData.map((cs) => ({
+      AccessCode: cs['Access Code'],
+      Email: cs.Email,
+      DateCompleted: cs['Date Completed'].toISOString(),
+      Themes: [cs.Theme_1, cs.Theme_2, cs.Theme_3, cs.Theme_4, cs.Theme_5],
+      Private: false,
+    }));
 
     CliftonStrengthsService.postCliftonStrengths(formattedData)
-      .then((data) => {
-        setUploadResults(
-          data.map((uploadResult, index) => {
-            const uploadResultSuccess = successResults.some((s) => s === uploadResult.UploadResult);
-            return (
-              <TableRow key={index}>
-                <TableCell className={styles.cell}>{uploadResult.Email}</TableCell>
-                <TableCell className={styles.cell}>{uploadResult.AccessCode}</TableCell>
-                <TableCell
-                  className={
-                    uploadResultSuccess ? styles.resultmessage_green : styles.resultmessage_red
-                  }
-                >
-                  {uploadResultSuccess ? (
-                    <CheckCircle style={{ color: '#009900' }} />
-                  ) : (
-                    <XCircle style={{ color: '#B53228' }} />
-                  )}
-                  &nbsp;
-                  {uploadResult.UploadResult}
-                </TableCell>
-              </TableRow>
-            );
-          }),
-        );
-        setLoading(false);
-      })
-      .catch((error) => {
-        setUploadResults(<h1>An Error has occurred while uploading.</h1>);
-        setLoading(false);
-      });
+      .then(setUploadResults)
+      .catch(() => setUploadResults(<h1>An Error has occurred while uploading.</h1>))
+      .finally(() => setLoading(false));
   };
 
   return (
@@ -107,7 +69,34 @@ const CliftonStrengthsUpload = () => {
                   <TableCell className={styles.headercell}>Upload Result</TableCell>
                 </TableRow>
               </TableHead>
-              <TableBody>{uploadResults}</TableBody>
+              <TableBody>
+                {uploadResults.map((uploadResult, index) => {
+                  const uploadResultSuccess = successResults.some(
+                    (s) => s === uploadResult.UploadResult,
+                  );
+                  return (
+                    <TableRow key={index}>
+                      <TableCell className={styles.cell}>{uploadResult.Email}</TableCell>
+                      <TableCell className={styles.cell}>{uploadResult.AccessCode}</TableCell>
+                      <TableCell
+                        className={
+                          uploadResultSuccess
+                            ? styles.resultmessage_green
+                            : styles.resultmessage_red
+                        }
+                      >
+                        {uploadResultSuccess ? (
+                          <CheckCircle style={{ color: '#009900' }} />
+                        ) : (
+                          <XCircle style={{ color: '#B53228' }} />
+                        )}
+                        &nbsp;
+                        {uploadResult.UploadResult}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
             </Table>
           )
         )}


### PR DESCRIPTION
I have updated our `xlsx` package to the latest version. Note that the `xlsx` [package on the public npm registry](https://www.npmjs.com/package/xlsx) is no longer the authoritative version and is not being updated. The official source for the package is now their own [cdn](https://cdn.sheetjs.com/) (and also the official source code is in their own Gitea instance, with the GitHub repo being deprecated).

I have tested that the updated package works as expected.

I fixed a regression in the Clifton Strengths uploader caused by a bad merge during the switch to Vite (my bad!).

I have also refactored the `SpreadsheetUploader` component. The only behavioral difference is that the preview of uploaded data now has a `max-height` of `40vb` (aka 40% of the height/block-direction of the viewport). This means that the data preview is scrollable when it is longer than that size, while the dialog buttons remain visible at all times. This also allowed me to use the dialog's buttons only, whereas previously there were other buttons at the top of the dialog content so that the user didn't have to scroll to the bottom of the preview in order to submit.

Here are some picture to demonstrate:
<img width="338" alt="image" src="https://user-images.githubusercontent.com/35319956/230913230-407865b0-ed67-4183-ab89-e292f8e53af1.png">
<img width="430" alt="image" src="https://user-images.githubusercontent.com/35319956/230913253-faf49758-0a48-4738-b410-84913f4c465b.png">
<img width="431" alt="image" src="https://user-images.githubusercontent.com/35319956/230913265-6fdb2d59-3c92-4ef0-9852-45964277d8e3.png">
<img width="436" alt="image" src="https://user-images.githubusercontent.com/35319956/230913285-b5b7ca21-27c8-403f-aa1e-68a03fee4a1c.png">



The other refactoring was purely code quality: simplifying syntax in a few places and re-working the file upload callback slightly.