### PR TITLE
Update visuals for involvements 'change image' use case

### DIFF
--- a/src/views/InvolvementProfile/InvolvementProfile.module.scss
+++ b/src/views/InvolvementProfile/InvolvementProfile.module.scss
@@ -7,3 +7,7 @@
     cursor: pointer;
   }
 }
+
+.update_image_components {
+  margin-top: 15px;
+}

--- a/src/views/InvolvementProfile/index.jsx
+++ b/src/views/InvolvementProfile/index.jsx
@@ -281,36 +281,41 @@ const InvolvementProfile = () => {
             isButtonDisabled={!preview}
             cancelButtonClicked={handleCloseCancel}
           >
-            <DialogContentText id="edit-involvement-image-dialog-description">
-              {window.innerWidth < 600
-                ? 'Tap Image to Browse Files'
-                : 'Drag & Drop Picture, or Click to Browse Files'}
-            </DialogContentText>
-            <Grid container justifyContent="center" spacing={2}>
+            <Grid container justifyContent="center" spacing={0}>
               {!preview && (
-                <Dropzone
-                  onDropAccepted={onDropAccepted.bind(this)}
-                  onDropRejected={onDropRejected.bind(this)}
-                  accept="image/jpeg, image/jpg, image/png"
-                >
-                  {({ getRootProps, getInputProps }) => (
-                    <section>
-                      <div className={styles.photoUploader} {...getRootProps()}>
-                        <input {...getInputProps()} />
-                        <img
-                          className="rounded_corners"
-                          src={ActivityImagePath}
-                          alt=""
-                          style={{ maxWidth: '320px', maxHeight: '320px' }}
-                        />
-                      </div>
-                    </section>
-                  )}
-                </Dropzone>
+                <>
+                  <DialogContentText
+                    id="edit-involvement-image-dialog-description"
+                    style={{ textAlign: 'center' }}
+                  >
+                    {window.innerWidth < 600
+                      ? 'Tap Image to Browse Files'
+                      : 'Drag & Drop Picture, or Click to Browse Files'}
+                  </DialogContentText>
+                  <Dropzone
+                    onDropAccepted={onDropAccepted.bind(this)}
+                    onDropRejected={onDropRejected.bind(this)}
+                    accept="image/jpeg, image/jpg, image/png"
+                  >
+                    {({ getRootProps, getInputProps }) => (
+                      <section>
+                        <div className={styles.photoUploader} {...getRootProps()}>
+                          <input {...getInputProps()} />
+                          <img
+                            className="rounded_corners"
+                            src={ActivityImagePath}
+                            alt=""
+                            style={{ maxWidth: '320px', maxHeight: '320px' }}
+                          />
+                        </div>
+                      </section>
+                    )}
+                  </Dropzone>
+                </>
               )}
               {preview && (
                 <>
-                  <Grid item>
+                  <Grid item style={{ marginTop: '20px' }}>
                     <Cropper
                       ref={cropperRef}
                       src={preview}
@@ -331,7 +336,7 @@ const InvolvementProfile = () => {
                     />
                   </Grid>
 
-                  <Grid item>
+                  <Grid item style={{ marginTop: '20px' }}>
                     <Button variant="contained" onClick={() => setPreview(null)}>
                       Choose Another Image
                     </Button>

--- a/src/views/InvolvementProfile/index.jsx
+++ b/src/views/InvolvementProfile/index.jsx
@@ -281,69 +281,67 @@ const InvolvementProfile = () => {
             isButtonDisabled={!preview}
             cancelButtonClicked={handleCloseCancel}
           >
-            <Grid container justifyContent="center" spacing={0}>
-              {!preview && (
-                <>
-                  <DialogContentText
-                    id="edit-involvement-image-dialog-description"
-                    style={{ textAlign: 'center' }}
-                  >
-                    {window.innerWidth < 600
-                      ? 'Tap Image to Browse Files'
-                      : 'Drag & Drop Picture, or Click to Browse Files'}
-                  </DialogContentText>
-                  <Dropzone
-                    onDropAccepted={onDropAccepted.bind(this)}
-                    onDropRejected={onDropRejected.bind(this)}
-                    accept="image/jpeg, image/jpg, image/png"
-                  >
-                    {({ getRootProps, getInputProps }) => (
-                      <section>
-                        <div className={styles.photoUploader} {...getRootProps()}>
-                          <input {...getInputProps()} />
-                          <img
-                            className="rounded_corners"
-                            src={ActivityImagePath}
-                            alt=""
-                            style={{ maxWidth: '320px', maxHeight: '320px' }}
-                          />
-                        </div>
-                      </section>
-                    )}
-                  </Dropzone>
-                </>
-              )}
-              {preview && (
-                <>
-                  <Grid item style={{ marginTop: '20px' }}>
-                    <Cropper
-                      ref={cropperRef}
-                      src={preview}
-                      style={{
-                        maxWidth: maxCropPreviewWidth(),
-                        maxHeight: maxCropPreviewWidth() / cropperData.aspectRatio,
-                      }}
-                      autoCropArea={1}
-                      viewMode={3}
-                      aspectRatio={1}
-                      highlight={false}
-                      background={false}
-                      zoom={onCropperZoom.bind(this)}
-                      zoomable={false}
-                      dragMode={'none'}
-                      minCropBoxWidth={cropperData.cropBoxDim}
-                      minCropBoxHeight={cropperData.cropBoxDim}
-                    />
-                  </Grid>
+            {!preview && (
+              <>
+                <DialogContentText
+                  id="edit-involvement-image-dialog-description"
+                  style={{ textAlign: 'center' }}
+                >
+                  {window.innerWidth < 600
+                    ? 'Tap Image to Browse Files'
+                    : 'Drag & Drop Picture, or Click to Browse Files'}
+                </DialogContentText>
+                <Dropzone
+                  onDropAccepted={onDropAccepted.bind(this)}
+                  onDropRejected={onDropRejected.bind(this)}
+                  accept="image/jpeg, image/jpg, image/png"
+                >
+                  {({ getRootProps, getInputProps }) => (
+                    <section>
+                      <div className={styles.photoUploader} {...getRootProps()}>
+                        <input {...getInputProps()} />
+                        <img
+                          className="rounded_corners"
+                          src={ActivityImagePath}
+                          alt=""
+                          style={{ maxWidth: '320px', maxHeight: '320px' }}
+                        />
+                      </div>
+                    </section>
+                  )}
+                </Dropzone>
+              </>
+            )}
+            {preview && (
+              <Grid container justifyContent="center" spacing={2}>
+                <Grid item style={{ marginTop: '20px' }}>
+                  <Cropper
+                    ref={cropperRef}
+                    src={preview}
+                    style={{
+                      maxWidth: maxCropPreviewWidth(),
+                      maxHeight: maxCropPreviewWidth() / cropperData.aspectRatio,
+                    }}
+                    autoCropArea={1}
+                    viewMode={3}
+                    aspectRatio={1}
+                    highlight={false}
+                    background={false}
+                    zoom={onCropperZoom.bind(this)}
+                    zoomable={false}
+                    dragMode={'none'}
+                    minCropBoxWidth={cropperData.cropBoxDim}
+                    minCropBoxHeight={cropperData.cropBoxDim}
+                  />
+                </Grid>
 
-                  <Grid item style={{ marginTop: '20px' }}>
-                    <Button variant="contained" onClick={() => setPreview(null)}>
-                      Choose Another Image
-                    </Button>
-                  </Grid>
-                </>
-              )}
-            </Grid>
+                <Grid item style={{ marginTop: '20px' }}>
+                  <Button variant="contained" onClick={() => setPreview(null)}>
+                    Choose Another Image
+                  </Button>
+                </Grid>
+              </Grid>
+            )}
           </GordonDialogBox>
 
           <GordonDialogBox

--- a/src/views/InvolvementProfile/index.jsx
+++ b/src/views/InvolvementProfile/index.jsx
@@ -313,8 +313,13 @@ const InvolvementProfile = () => {
               </>
             )}
             {preview && (
-              <Grid container justifyContent="center" spacing={2}>
-                <Grid item style={{ marginTop: '20px' }}>
+              <Grid
+                container
+                justifyContent="center"
+                spacing={2}
+                className={styles.update_image_components}
+              >
+                <Grid item>
                   <Cropper
                     ref={cropperRef}
                     src={preview}
@@ -335,7 +340,7 @@ const InvolvementProfile = () => {
                   />
                 </Grid>
 
-                <Grid item style={{ marginTop: '20px' }}>
+                <Grid item>
                   <Button variant="contained" onClick={() => setPreview(null)}>
                     Choose Another Image
                   </Button>


### PR DESCRIPTION
This PR just adds some styles and moves some code around so that 
1. Users can see the text to 'drag and drop or click image to choose image' which was previously covered up by the existing involvements photo (see #1747 example).
2. Users can no longer see the text asking to select an image when there is actually no functionality to do so (see example below).
Example:
Before:
![image](https://user-images.githubusercontent.com/24206170/232135827-fccfdcd6-9d6d-430d-ab06-71a524ca97c0.png)
After:
![image](https://user-images.githubusercontent.com/24206170/232137509-4d49ea04-2100-4f4b-98da-ff4965c652f7.png)

Fixes #1747 