### PR TITLE
Add a Mailto link in the search results page

### DIFF
--- a/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
@@ -38,4 +38,6 @@
 
 .mailingIconContainer {
   flex: 1;
+  height: 100px;
+  justify-content: center;
 }

--- a/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
@@ -1,6 +1,6 @@
 @import '../../../../vars';
 
-.resultContainer {
+.result_container {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -36,17 +36,17 @@
   font-size: clamp(0.75rem, 0.6429rem + 0.5357vw, 1.5rem);
 }
 
-.profileLinkContainer {
+.profile_link_container {
   flex: 6;
 }
 
-.mailingIconContainer {
+.mailing_icon_container {
   display: flex;
   justify-content: center;
   flex: 0.5;
 }
 
-.mailCardAction {
+.mail_card_action {
   width: fit-content;
   background-color: $primary-blue;
   border-radius: 6px;

--- a/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  flex-direction: row;
   gap: min(1rem, 1vw);
 
   & :global(.MuiCardContent-root) {

--- a/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
@@ -37,12 +37,11 @@
 }
 
 .mailingIconContainer {
-  flex: 0.3;
-  height: 30px;
-  background-color: blue;
-}
-
-.mailAction {
   display: flex;
   justify-content: center;
+  flex: 0.5;
+}
+
+.mailCardAction {
+  width: fit-content;
 }

--- a/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
@@ -36,6 +36,10 @@
   font-size: clamp(0.75rem, 0.6429rem + 0.5357vw, 1.5rem);
 }
 
+.profileLinkContainer {
+  flex: 6;
+}
+
 .mailingIconContainer {
   display: flex;
   justify-content: center;

--- a/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
@@ -37,7 +37,12 @@
 }
 
 .mailingIconContainer {
-  flex: 1;
-  height: 100px;
+  flex: 0.3;
+  height: 30px;
+  background-color: blue;
+}
+
+.mailAction {
+  display: flex;
   justify-content: center;
 }

--- a/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
@@ -1,10 +1,15 @@
 @import '../../../../vars';
 
+.resultContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
 .result {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  flex-direction: row;
   gap: min(1rem, 1vw);
 
   & :global(.MuiCardContent-root) {
@@ -29,4 +34,8 @@
 
 .secondary_text {
   font-size: clamp(0.75rem, 0.6429rem + 0.5357vw, 1.5rem);
+}
+
+.mailingIconContainer {
+  flex: 1;
 }

--- a/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/PeopleSearchResult.module.scss
@@ -44,4 +44,7 @@
 
 .mailCardAction {
   width: fit-content;
+  background-color: $primary-blue;
+  border-radius: 6px;
+  padding: 0 0.2rem;
 }

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -91,19 +91,23 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   const emailIcon = isMobileView ? (
     <></>
   ) : (
-    <a href={`mailto:${person.Email}`}>
-      <div style={{ justifyContent: 'center' }}>
-        <MailOutlineIcon
-          sx={{
-            fontSize: 30,
-            color: 'white',
-            height: '100%',
-            backgroundColor: 'blue',
-            borderRadius: 4,
-          }}
-        />
-      </div>
-    </a>
+    <Card className={styles.mailingIconContainer}>
+      <CardActionArea className={styles.mailAction}>
+        <a href={`mailto:${person.Email}`}>
+          <div>
+            <MailOutlineIcon
+              sx={{
+                fontSize: 30,
+                color: 'white',
+                height: '100%',
+                backgroundColor: 'blue',
+                // borderRadius: 4,
+              }}
+            />
+          </div>
+        </a>
+      </CardActionArea>
+    </Card>
   );
 
   return (
@@ -111,7 +115,7 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
       <VisibilitySensor onChange={handleVisibilityChange}>
         <Card className={styles.resultContainer} elevation={0}>
           <CardActionArea
-            style={{ flex: 9 }}
+            style={{ flex: 7 }}
             className="gc360_link"
             onClick={() => {
               navigate(`/profile/${person.AD_Username}`);
@@ -156,7 +160,7 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
             </Card>
             {/* </Link> */}
           </CardActionArea>
-          <CardActionArea className={styles.mailingIconContainer}>{emailIcon}</CardActionArea>
+          {emailIcon}
         </Card>
       </VisibilitySensor>
       <Divider />

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -1,4 +1,5 @@
-import { Card, CardContent, CardMedia, Divider, Typography } from '@mui/material';
+import { Card, CardContent, CardMedia, Divider, Typography, Button } from '@mui/material';
+import EmailIcon from '@mui/icons-material/Email';
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import VisibilitySensor from 'react-visibility-sensor';
@@ -114,6 +115,11 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
               </SecondaryText>
               <SecondaryText className={styles.secondary_text}>{person.Email}</SecondaryText>
               <SecondaryText className={styles.secondary_text}>{mailLocation}</SecondaryText>
+              <a href={`mailto:${person.Email}`}>
+                <div>
+                  <EmailIcon />
+                </div>
+              </a>
             </CardContent>
           </Card>
         </Link>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import VisibilitySensor from 'react-visibility-sensor';
 import { Class, SearchResult } from 'services/peopleSearch';
+import { useWindowSize } from 'hooks';
 import userService from 'services/user';
 import styles from './PeopleSearchResult.module.css';
 
@@ -13,6 +14,7 @@ import styles from './PeopleSearchResult.module.css';
 const GORDONCOLORS_NEUTRAL_LIGHTGRAY_1X1 =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8/erVfwAJRwPA/3pinwAAAABJRU5ErkJggg==';
 const JPG_BASE64_HEADER = 'data:image/jpg;base64,';
+const breakpointWidth = 810;
 
 const SecondaryText = ({
   children,
@@ -36,6 +38,8 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
     person.AD_Username ? GORDONCOLORS_NEUTRAL_LIGHTGRAY_1X1 : null,
   );
   const [hasBeenRun, setHasBeenRun] = useState(false);
+  const [width] = useWindowSize();
+  const isMobileView = width < breakpointWidth;
 
   const loadAvatar = useCallback(async () => {
     if (person.AD_Username) {
@@ -82,6 +86,16 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
       break;
   }
 
+  const emailIcon = isMobileView ? (
+    <></>
+  ) : (
+    <a href={`mailto:${person.Email}`} className={styles.mailingIconContainer}>
+      <div>
+        <EmailIcon />
+      </div>
+    </a>
+  );
+
   return (
     <>
       <VisibilitySensor onChange={handleVisibilityChange}>
@@ -124,11 +138,7 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
               </CardContent>
             </Card>
           </Link>
-          <a href={`mailto:${person.Email}`} className={styles.mailingIconContainer}>
-            <div>
-              <EmailIcon />
-            </div>
-          </a>
+          {emailIcon}
         </Card>
       </VisibilitySensor>
       <Divider />

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -7,7 +7,6 @@ import { Class, SearchResult } from 'services/peopleSearch';
 import { useWindowSize } from 'hooks';
 import userService from 'services/user';
 import styles from './PeopleSearchResult.module.css';
-import { BorderAll } from '@mui/icons-material';
 
 /*Const string was created with https://png-pixel.com/ .
  *It is a 1 x 1 pixel with the same color as gordonColors.neutral.lightGray (7/9/21)
@@ -91,23 +90,22 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   const emailIcon = isMobileView ? (
     <></>
   ) : (
-    <Card className={styles.mailingIconContainer}>
-      <CardActionArea className={styles.mailAction}>
+    <div className={styles.mailingIconContainer}>
+      <CardActionArea className={styles.mailCardAction}>
         <a href={`mailto:${person.Email}`}>
-          <div>
-            <MailOutlineIcon
-              sx={{
-                fontSize: 30,
-                color: 'white',
-                height: '100%',
-                backgroundColor: 'blue',
-                // borderRadius: 4,
-              }}
-            />
-          </div>
+          <MailOutlineIcon
+            sx={{
+              fontSize: 35,
+              color: 'white',
+              height: '100%',
+              width: 40,
+              backgroundColor: '#23c3ff',
+              borderRadius: 4,
+            }}
+          />
         </a>
       </CardActionArea>
-    </Card>
+    </div>
   );
 
   return (
@@ -115,7 +113,7 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
       <VisibilitySensor onChange={handleVisibilityChange}>
         <Card className={styles.resultContainer} elevation={0}>
           <CardActionArea
-            style={{ flex: 7 }}
+            style={{ flex: 6 }}
             className="gc360_link"
             onClick={() => {
               navigate(`/profile/${person.AD_Username}`);

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -1,12 +1,13 @@
-import { Card, CardContent, CardMedia, Divider, Typography } from '@mui/material';
-import EmailIcon from '@mui/icons-material/Email';
+import { Card, CardActionArea, CardContent, CardMedia, Divider, Typography } from '@mui/material';
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import { ReactNode, useCallback, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import VisibilitySensor from 'react-visibility-sensor';
 import { Class, SearchResult } from 'services/peopleSearch';
 import { useWindowSize } from 'hooks';
 import userService from 'services/user';
 import styles from './PeopleSearchResult.module.css';
+import { BorderAll } from '@mui/icons-material';
 
 /*Const string was created with https://png-pixel.com/ .
  *It is a 1 x 1 pixel with the same color as gordonColors.neutral.lightGray (7/9/21)
@@ -39,6 +40,7 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   );
   const [hasBeenRun, setHasBeenRun] = useState(false);
   const [width] = useWindowSize();
+  const navigate = useNavigate();
   const isMobileView = width < breakpointWidth;
 
   const loadAvatar = useCallback(async () => {
@@ -89,9 +91,17 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   const emailIcon = isMobileView ? (
     <></>
   ) : (
-    <a href={`mailto:${person.Email}`} className={styles.mailingIconContainer}>
-      <div>
-        <EmailIcon />
+    <a href={`mailto:${person.Email}`}>
+      <div style={{ justifyContent: 'center' }}>
+        <MailOutlineIcon
+          sx={{
+            fontSize: 30,
+            color: 'white',
+            height: '100%',
+            backgroundColor: 'blue',
+            borderRadius: 4,
+          }}
+        />
       </div>
     </a>
   );
@@ -100,7 +110,14 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
     <>
       <VisibilitySensor onChange={handleVisibilityChange}>
         <Card className={styles.resultContainer} elevation={0}>
-          <Link style={{ flex: 7 }} className="gc360_link" to={`/profile/${person.AD_Username}`}>
+          <CardActionArea
+            style={{ flex: 9 }}
+            className="gc360_link"
+            onClick={() => {
+              navigate(`/profile/${person.AD_Username}`);
+            }}
+          >
+            {/* <Link style={{ flex: 7 }} className="gc360_link" to={`/profile/${person.AD_Username}`}> */}
             <Card className={styles.result} elevation={0}>
               {avatar && (
                 <CardMedia
@@ -137,8 +154,9 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
                 <SecondaryText className={styles.secondary_text}>{mailLocation}</SecondaryText>
               </CardContent>
             </Card>
-          </Link>
-          {emailIcon}
+            {/* </Link> */}
+          </CardActionArea>
+          <CardActionArea className={styles.mailingIconContainer}>{emailIcon}</CardActionArea>
         </Card>
       </VisibilitySensor>
       <Divider />

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -91,8 +91,8 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   const emailIcon = isMobileView ? (
     <></>
   ) : (
-    <div className={styles.mailingIconContainer}>
-      <CardActionArea className={styles.mailCardAction}>
+    <div className={styles.mailing_icon_container}>
+      <CardActionArea className={styles.mail_card_action}>
         <a href={`mailto:${person.Email}`}>
           <MailOutlineIcon
             sx={{
@@ -110,9 +110,9 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   return (
     <>
       <VisibilitySensor onChange={handleVisibilityChange}>
-        <Card className={styles.resultContainer} elevation={0}>
+        <Card className={styles.result_container} elevation={0}>
           <Link
-            className={`gc360_link ${styles.profileLinkContainer}`}
+            className={`gc360_link ${styles.profile_link_container}`}
             to={`/profile/${person.AD_Username}`}
           >
             <Card className={styles.result} elevation={0}>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardMedia, Divider, Typography, Button } from '@mui/material';
+import { Card, CardContent, CardMedia, Divider, Typography } from '@mui/material';
 import EmailIcon from '@mui/icons-material/Email';
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -85,41 +85,46 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   return (
     <>
       <VisibilitySensor onChange={handleVisibilityChange}>
-        <Card className={styles.result} elevation={0}>
-          <Link className="gc360_link" to={`/profile/${person.AD_Username}`}>
-            {avatar && (
-              <CardMedia src={avatar} title={fullName} component="img" className={styles.avatar} />
-            )}
+        <Card className={styles.resultContainer} elevation={0}>
+          <Link style={{ flex: 7 }} className="gc360_link" to={`/profile/${person.AD_Username}`}>
+            <Card className={styles.result} elevation={0}>
+              {avatar && (
+                <CardMedia
+                  src={avatar}
+                  title={fullName}
+                  component="img"
+                  className={styles.avatar}
+                />
+              )}
+              <CardContent>
+                <Typography variant="h5" className={styles.name}>
+                  {person.FirstName} {nickname} {person.LastName} {maidenName}
+                </Typography>
+                <Typography className={styles.subtitle}>
+                  {classOrJobTitle ?? person.Type}
+                  {person.Type === 'Alumni' && person.PreferredClassYear
+                    ? ' ' + person.PreferredClassYear
+                    : null}
+                </Typography>
+                <SecondaryText className={styles.secondary_text}>
+                  {(person.Type === 'Student' || person.Type === 'Alumni') && (
+                    <>
+                      {person.Major1Description}
+                      {person.Major2Description
+                        ? (person.Major1Description ? ', ' : '') + `${person.Major2Description}`
+                        : null}
+                      {person.Type === 'Student' && person.Major3Description
+                        ? `, ${person.Major3Description}`
+                        : null}
+                    </>
+                  )}
+                </SecondaryText>
+                <SecondaryText className={styles.secondary_text}>{person.Email}</SecondaryText>
+                <SecondaryText className={styles.secondary_text}>{mailLocation}</SecondaryText>
+              </CardContent>
+            </Card>
           </Link>
-          <Link className="gc360_link" to={`/profile/${person.AD_Username}`} style={{ flex: 5 }}>
-            <CardContent>
-              <Typography variant="h5" className={styles.name}>
-                {person.FirstName} {nickname} {person.LastName} {maidenName}
-              </Typography>
-              <Typography className={styles.subtitle}>
-                {classOrJobTitle ?? person.Type}
-                {person.Type === 'Alumni' && person.PreferredClassYear
-                  ? ' ' + person.PreferredClassYear
-                  : null}
-              </Typography>
-              <SecondaryText className={styles.secondary_text}>
-                {(person.Type === 'Student' || person.Type === 'Alumni') && (
-                  <>
-                    {person.Major1Description}
-                    {person.Major2Description
-                      ? (person.Major1Description ? ', ' : '') + `${person.Major2Description}`
-                      : null}
-                    {person.Type === 'Student' && person.Major3Description
-                      ? `, ${person.Major3Description}`
-                      : null}
-                  </>
-                )}
-              </SecondaryText>
-              <SecondaryText className={styles.secondary_text}>{person.Email}</SecondaryText>
-              <SecondaryText className={styles.secondary_text}>{mailLocation}</SecondaryText>
-            </CardContent>
-          </Link>
-          <a href={`mailto:${person.Email}`} style={{ flex: 1, marginLeft: 15 }}>
+          <a href={`mailto:${person.Email}`} className={styles.mailingIconContainer}>
             <div>
               <EmailIcon />
             </div>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -7,6 +7,7 @@ import { Class, SearchResult } from 'services/peopleSearch';
 import { useWindowSize } from 'hooks';
 import userService from 'services/user';
 import styles from './PeopleSearchResult.module.css';
+import { gordonColors } from 'theme';
 
 /*Const string was created with https://png-pixel.com/ .
  *It is a 1 x 1 pixel with the same color as gordonColors.neutral.lightGray (7/9/21)
@@ -95,12 +96,10 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
         <a href={`mailto:${person.Email}`}>
           <MailOutlineIcon
             sx={{
-              fontSize: 35,
-              color: 'white',
+              color: gordonColors.neutral.grayShades[50],
               height: '100%',
               width: 40,
-              backgroundColor: '#23c3ff',
-              borderRadius: 4,
+              borderRadius: 2,
             }}
           />
         </a>
@@ -112,14 +111,7 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
     <>
       <VisibilitySensor onChange={handleVisibilityChange}>
         <Card className={styles.resultContainer} elevation={0}>
-          <CardActionArea
-            style={{ flex: 6 }}
-            className="gc360_link"
-            onClick={() => {
-              navigate(`/profile/${person.AD_Username}`);
-            }}
-          >
-            {/* <Link style={{ flex: 7 }} className="gc360_link" to={`/profile/${person.AD_Username}`}> */}
+          <Link style={{ flex: 6 }} className="gc360_link" to={`/profile/${person.AD_Username}`}>
             <Card className={styles.result} elevation={0}>
               {avatar && (
                 <CardMedia
@@ -156,8 +148,7 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
                 <SecondaryText className={styles.secondary_text}>{mailLocation}</SecondaryText>
               </CardContent>
             </Card>
-            {/* </Link> */}
-          </CardActionArea>
+          </Link>
           {emailIcon}
         </Card>
       </VisibilitySensor>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -111,7 +111,10 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
     <>
       <VisibilitySensor onChange={handleVisibilityChange}>
         <Card className={styles.resultContainer} elevation={0}>
-          <Link style={{ flex: 6 }} className="gc360_link" to={`/profile/${person.AD_Username}`}>
+          <Link
+            className={`gc360_link ${styles.profileLinkContainer}`}
+            to={`/profile/${person.AD_Username}`}
+          >
             <Card className={styles.result} elevation={0}>
               {avatar && (
                 <CardMedia

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -89,8 +89,8 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   }
 
   const emailIcon = !isMobileView && (
-    <div className={styles.mailingIconContainer}>
-      <CardActionArea className={styles.mailCardAction}>
+    <div className={styles.mailing_icon_container}>
+      <CardActionArea className={styles.mail_card_action}>
         <a href={`mailto:${person.Email}`}>
           <MailOutlineIcon
             sx={{

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -85,11 +85,13 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
   return (
     <>
       <VisibilitySensor onChange={handleVisibilityChange}>
-        <Link className="gc360_link" to={`/profile/${person.AD_Username}`}>
-          <Card className={styles.result} elevation={0}>
+        <Card className={styles.result} elevation={0}>
+          <Link className="gc360_link" to={`/profile/${person.AD_Username}`}>
             {avatar && (
               <CardMedia src={avatar} title={fullName} component="img" className={styles.avatar} />
             )}
+          </Link>
+          <Link className="gc360_link" to={`/profile/${person.AD_Username}`} style={{ flex: 5 }}>
             <CardContent>
               <Typography variant="h5" className={styles.name}>
                 {person.FirstName} {nickname} {person.LastName} {maidenName}
@@ -115,14 +117,14 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
               </SecondaryText>
               <SecondaryText className={styles.secondary_text}>{person.Email}</SecondaryText>
               <SecondaryText className={styles.secondary_text}>{mailLocation}</SecondaryText>
-              <a href={`mailto:${person.Email}`}>
-                <div>
-                  <EmailIcon />
-                </div>
-              </a>
             </CardContent>
-          </Card>
-        </Link>
+          </Link>
+          <a href={`mailto:${person.Email}`} style={{ flex: 1, marginLeft: 15 }}>
+            <div>
+              <EmailIcon />
+            </div>
+          </a>
+        </Card>
       </VisibilitySensor>
       <Divider />
     </>


### PR DESCRIPTION
Implements a use case where you can easily start emailing someone from the people search results list by adding a mailing icon/button for each result listed. 
This is only implemented in Desktop view for now because of the limited space for such a use case on a mobile view.

Fixes #1194 