### PR TITLE
[RecIM] Sports!

### DIFF
--- a/src/services/recim/sport.ts
+++ b/src/services/recim/sport.ts
@@ -35,6 +35,6 @@ const getSportByID = async (ID: number): Promise<Sport> => http.get(`recim/sport
 const editSport = async (ID: number, updatedSport: PatchSport): Promise<Sport> =>
   http.patch(`recim/series/${ID}`, updatedSport);
 
-const deleteSport = async (ID: number) => console.log('temp');
+const deleteSport = async (ID: number) => http.del(`recim/sports/${ID}`);
 
 export { createSport, getSportByID, editSport, getAllSports, deleteSport };

--- a/src/services/recim/sport.ts
+++ b/src/services/recim/sport.ts
@@ -33,7 +33,7 @@ const getAllSports = async (): Promise<Sport[]> => http.get(`recim/sports`);
 const getSportByID = async (ID: number): Promise<Sport> => http.get(`recim/sports/${ID}`);
 
 const editSport = async (ID: number, updatedSport: PatchSport): Promise<Sport> =>
-  http.patch(`recim/series/${ID}`, updatedSport);
+  http.patch(`recim/sports/${ID}`, updatedSport);
 
 const deleteSport = async (ID: number) => http.del(`recim/sports/${ID}`);
 

--- a/src/services/recim/sport.ts
+++ b/src/services/recim/sport.ts
@@ -35,4 +35,6 @@ const getSportByID = async (ID: number): Promise<Sport> => http.get(`recim/sport
 const editSport = async (ID: number, updatedSport: PatchSport): Promise<Sport> =>
   http.patch(`recim/series/${ID}`, updatedSport);
 
-export { createSport, getSportByID, editSport, getAllSports };
+const deleteSport = async (ID: number) => console.log('temp');
+
+export { createSport, getSportByID, editSport, getAllSports, deleteSport };

--- a/src/views/RecIM/components/Forms/Form/components/InformationField/index.jsx
+++ b/src/views/RecIM/components/Forms/Form/components/InformationField/index.jsx
@@ -67,6 +67,7 @@ const InformationField = ({
       );
       break;
     case 'multiline':
+      gridSizes = { md: 12, lg: 6 };
       field = (
         <TextField
           variant="filled"

--- a/src/views/RecIM/components/Forms/Form/components/InformationField/index.jsx
+++ b/src/views/RecIM/components/Forms/Form/components/InformationField/index.jsx
@@ -66,6 +66,24 @@ const InformationField = ({
         />
       );
       break;
+    case 'multiline':
+      field = (
+        <TextField
+          variant="filled"
+          error={error}
+          className={`disable_select ${styles.field}`}
+          label={label}
+          name={name}
+          required={required}
+          helperText={error && helperText}
+          value={value}
+          onChange={(event) => onChange(event)}
+          type={type}
+          multiline
+          rows={4}
+        />
+      );
+      break;
     case 'number':
       field = (
         <TextField

--- a/src/views/RecIM/components/Forms/SportForm/index.jsx
+++ b/src/views/RecIM/components/Forms/SportForm/index.jsx
@@ -1,0 +1,92 @@
+import { useState, useMemo } from 'react';
+import Form from '../Form';
+import { createSport, editSport } from 'services/recim/sport';
+
+const createSportFields = [
+  {
+    label: 'Name',
+    name: 'Name',
+    type: 'text',
+    helperText: '*Required',
+    required: true,
+  },
+  {
+    label: 'Description',
+    name: 'Description',
+    type: 'text',
+    required: false,
+  },
+  {
+    label: 'Rules',
+    name: 'Rules',
+    type: 'multiline',
+    required: false,
+  },
+];
+
+const SportForm = ({ sport, createSnackbar, onClose, openSportForm, setOpenSportForm }) => {
+  const [isSaving, setSaving] = useState(false);
+
+  const currentInfo = useMemo(() => {
+    if (sport) {
+      return {
+        Name: sport.Name,
+        Description: sport.Description,
+        Rules: sport.Rules,
+        isLogoUpdate: false,
+      };
+    }
+    return {
+      Name: '',
+      Description: '',
+      Rules: '',
+      isLogoUpdate: false,
+    };
+  }, [sport]);
+
+  const handleConfirm = (newInfo, handleWindowClose) => {
+    setSaving(true);
+
+    let sportRequest = { ...currentInfo, ...newInfo };
+
+    if (sport) {
+      editSport(sport.ID, sportRequest)
+        .then(() => {
+          setSaving(false);
+          createSnackbar(`Sport ${sportRequest.Name} has been edited successfully`, 'success');
+          onClose();
+          handleWindowClose();
+        })
+        .catch((reason) => {
+          setSaving(false);
+          createSnackbar(`There was a problem editing your sport: ${reason.title}`, 'error');
+        });
+    } else {
+      createSport(sportRequest)
+        .then(() => {
+          setSaving(false);
+          createSnackbar(`Sport ${sportRequest.Name} has been created successfully`, 'success');
+          onClose();
+          handleWindowClose();
+        })
+        .catch((reason) => {
+          setSaving(false);
+          createSnackbar(`There was a problem creating your sport: ${reason.title}`, 'error');
+        });
+    }
+  };
+
+  return (
+    <Form
+      formTitles={{ name: 'Sport', formType: sport ? 'Edit' : 'Create' }}
+      fields={[createSportFields]}
+      currentInfo={currentInfo}
+      isSaving={isSaving}
+      setOpenForm={setOpenSportForm}
+      openForm={openSportForm}
+      handleConfirm={handleConfirm}
+    />
+  );
+};
+
+export default SportForm;

--- a/src/views/RecIM/components/Forms/SurfaceForm/index.jsx
+++ b/src/views/RecIM/components/Forms/SurfaceForm/index.jsx
@@ -48,6 +48,7 @@ const SurfaceForm = ({ surface, createSnackbar, onClose, openSurfaceForm, setOpe
           handleWindowClose();
         })
         .catch((reason) => {
+          setSaving(false);
           createSnackbar(`There was a problem editing your surface: ${reason.title}`, 'error');
         });
     } else {
@@ -59,6 +60,7 @@ const SurfaceForm = ({ surface, createSnackbar, onClose, openSurfaceForm, setOpe
           handleWindowClose();
         })
         .catch((reason) => {
+          setSaving(false);
           createSnackbar(`There was a problem creating your surface: ${reason.title}`, 'error');
         });
     }

--- a/src/views/RecIM/components/List/Listing/Listing.module.scss
+++ b/src/views/RecIM/components/List/Listing/Listing.module.scss
@@ -81,6 +81,12 @@
   font-size: 0.8em;
 }
 
+.listingAdditionalInfo {
+  color: $neutral-dark-gray2;
+  font-style: italic;
+  font-size: 0.8em;
+}
+
 .matchWinner {
   font-weight: bold;
   text-decoration: underline 0.2em $secondary-green;

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -553,9 +553,17 @@ const SportListing = ({ sport, confirmDelete, editDetails }) => {
           </IconButton>
         }
       >
-        <Grid container direction="column">
-          <ListItemText>{sport.Name}</ListItemText>
-          <Typography className={styles.listingSubtitle}>{sport.Description}</Typography>
+        <Grid container direction="row">
+          <Grid item container direction="column" xs={6}>
+            <ListItemText>{sport.Name}</ListItemText>
+            <Typography className={styles.listingSubtitle}>{sport.Description}</Typography>
+          </Grid>
+          <Grid item xs={6}>
+            <Typography className={styles.listingAdditionalInfo}>
+              <b>Rules: </b>
+              {sport.Rules}
+            </Typography>
+          </Grid>
         </Grid>
         <Menu
           open={optionsOpen}

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -23,8 +23,9 @@ import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import ClearIcon from '@mui/icons-material/Clear';
 import CheckIcon from '@mui/icons-material/Check';
 import { editTeamParticipant, respondToTeamInvite } from 'services/recim/team';
-import { getActivityTypes, isActivityRegisterable } from 'services/recim/activity';
+import { isActivityRegisterable } from 'services/recim/activity';
 import { deleteSurface, removeAttendance, updateAttendance } from 'services/recim/match';
+import { deleteSport } from 'services/recim/sport';
 import { getParticipantAttendanceCountForTeam } from 'services/recim/team';
 import SportsFootballIcon from '@mui/icons-material/SportsFootball';
 import SportsCricketIcon from '@mui/icons-material/SportsCricket';
@@ -32,25 +33,7 @@ import LocalActivityIcon from '@mui/icons-material/LocalActivity';
 import { standardDate, formatDateTimeRange } from '../../Helpers';
 import GordonDialogBox from 'components/GordonDialogBox';
 
-// Old activitylisting
 const ActivityListing = ({ activity }) => {
-  //const [activityType, setActivityType] = useState();
-  //const [currentCapacity, setCurrentCapacity] = useState(<GordonLoader size={15} inline />);
-  // useEffect(() => {
-  //   const loadActivityType = async () => {
-  //     let activityTypes = await getActivityTypes();
-  //     setActivityType(
-  //       activityTypes.find((activityType) => activityType.ID === activity.TypeID).Description,
-  //     );
-  //   };
-  //   const calculateCurrentCapacity = async () => {
-  //     let fullActivity = await getActivityByID(activity.ID);
-  //     setCurrentCapacity(fullActivity.Team?.length);
-  //   };
-  //   loadActivityType();
-  //   calculateCurrentCapacity();
-  // }, [activity]);
-
   let activeSeries = activity.Series.find((series) => isPast(Date.parse(series.StartDate)));
   let activeSeriesMessage =
     activeSeries && activeSeries.Name + ' until ' + standardDate(activeSeries.EndDate);
@@ -122,137 +105,11 @@ const ActivityListing = ({ activity }) => {
               </Grid>
             </Grid>
           </Grid>
-          {/* <Grid item sm={1}>
-            <Typography variant="subtitle">
-              {currentCapacity}
-              <Typography variant="span" sx={{ p: 0.2 }}>
-                /
-              </Typography>
-              {activity.MaxCapacity}
-            </Typography>
-          </Grid> */}
         </Grid>
       </ListItemButton>
     </ListItem>
   );
 };
-
-/*proposed new activitylisting
-const ActivityListing = ({ activity, showActivityOptions }) => {
-  const [anchorEl, setAnchorEl] = useState();
-  const moreOptionsOpen = Boolean(anchorEl);
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  let activeSeries = activity.Series.find((series) => isPast(Date.parse(series.StartDate)));
-  let activeSeriesMessage =
-    activeSeries && activeSeries.Name + ' until ' + standardDate(activeSeries.EndDate);
-
-  const activityTypeIconPair = [
-    {
-      type: 'League',
-      icon: <SportsFootballIcon />,
-    },
-    {
-      type: 'Tournament',
-      icon: <SportsCricketIcon />,
-    },
-    {
-      type: 'One Off',
-      icon: <LocalActivityIcon />,
-    },
-  ];
-
-  const handleActivityOptions = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  if (!activity) return null;
-  return (
-    <ListItem key={activity.ID} className={styles.listingWrapper}>
-      <ListItem
-        secondaryAction={
-          showActivityOptions && (
-            <IconButton edge="end" onClick={handleActivityOptions}>
-              <MoreHorizIcon />
-            </IconButton>
-          )
-        }
-        disablePadding
-      >
-        <ListItemButton
-          component={Link}
-          to={`/recim/activity/${activity.ID}`}
-          className={styles.listing}
-        >
-          <Grid container columnSpacing={2} alignItems="center">
-            <Grid item container direction="column" xs={12} sm={4} spacing={1}>
-              <Grid item>
-                <Typography className={styles.listingTitle}>{activity.Name}</Typography>
-              </Grid>
-              <Grid item>
-                <Chip
-                  icon={activityTypeIconPair.find((type) => type.type === activity.Type)?.icon}
-                  label={activity.Type}
-                  color={'success'}
-                  className={
-                    styles['activityType_' + activity?.Type?.toLowerCase().replace(/\s+/g, '')]
-                  }
-                  size="small"
-                ></Chip>
-              </Grid>
-            </Grid>
-            <Grid item container xs={12} sm={7} direction="column" spacing={1}>
-              {activity.StartDate && (
-                <Grid item>
-                  <Typography sx={{ color: 'gray', fontWeight: 'bold' }}>
-                    {activity.EndDate
-                      ? formatDateTimeRange(activity.StartDate, activity.EndDate)
-                      : standardDate(activity.StartDate) + ` - TBD`}
-                  </Typography>
-                </Grid>
-              )}
-              <Grid item container columnSpacing={2}>
-                <Grid item>
-                  <Chip
-                    icon={<EventAvailableIcon />}
-                    label={activity.RegistrationOpen ? 'Registration Open' : 'Registration Closed'}
-                    color={activity.RegistrationOpen ? 'success' : 'info'}
-                    size="small"
-                  ></Chip>
-                </Grid>
-                <Grid item>
-                  <Typography>
-                    {activity.RegistrationOpen
-                      ? 'Registration closes ' + standardDate(activity.RegistrationEnd)
-                      : activeSeriesMessage}
-                  </Typography>
-                </Grid>
-              </Grid>
-            </Grid>
-            <Grid item sm={1}></Grid>
-          </Grid>
-        </ListItemButton>
-        {showActivityOptions && (
-          <Menu open={moreOptionsOpen} onClose={handleClose} anchorEl={anchorEl}>
-            <MenuItem dense onClick={() => console.log('edit')} divider>
-              Edit
-            </MenuItem>
-            <MenuItem dense onClick={() => console.log('create series')} divider>
-              Create Series
-            </MenuItem>
-            <MenuItem dense onClick={() => console.log('delete')} className={styles.rejectButton}>
-              Delete
-            </MenuItem>
-          </Menu>
-        )}
-      </ListItem>
-    </ListItem>
-  );
-};
-*/
 
 const TeamListing = ({ team, invite, match, setTargetTeamID, callbackFunction }) => {
   if (!team && !match) return null;
@@ -678,6 +535,74 @@ const MatchListing = ({ match, activityID }) => {
   );
 };
 
+const SportListing = ({ sport, confirmDelete, editDetails }) => {
+  const [anchorEl, setAnchorEl] = useState();
+  const [openConfirmDelete, setOpenConfirmDelete] = useState();
+  const optionsOpen = Boolean(anchorEl);
+
+  if (!sport) return null;
+
+  const handleOptions = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  return (
+    <ListItem key={sport.ID} className={styles.listingWrapper}>
+      <ListItem
+        className={styles.listing}
+        secondaryAction={
+          <IconButton edge="end" onClick={handleOptions}>
+            <MoreHorizIcon />
+          </IconButton>
+        }
+      >
+        <Grid container direction="column">
+          <ListItemText>{sport.Name}</ListItemText>
+          <Typography className={styles.listingSubtitle}>{sport.Description}</Typography>
+        </Grid>
+        <Menu
+          open={optionsOpen}
+          onClose={() => setAnchorEl()}
+          anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+        >
+          <MenuItem dense onClick={() => editDetails(sport)} divider>
+            Edit details
+          </MenuItem>
+          <MenuItem dense onClick={() => confirmDelete(sport)} className={styles.redButton}>
+            Delete sport
+          </MenuItem>
+        </Menu>
+      </ListItem>
+      <GordonDialogBox
+        title="Confirm Delete"
+        open={openConfirmDelete}
+        cancelButtonClicked={() => setOpenConfirmDelete(false)}
+        buttonName="Yes, delete this surface"
+        buttonClicked={async () => {
+          await deleteSport(sport.ID);
+          setOpenConfirmDelete(false);
+        }}
+        severity="error"
+      >
+        <br />
+        <Typography variant="body1">
+          Are you sure you want to permanently delete this sport:
+          <i>'{sport.Name}'</i>?
+        </Typography>
+        <Typography variant="body1">This action cannot be undone.</Typography>
+      </GordonDialogBox>
+    </ListItem>
+  );
+};
+
 const SurfaceListing = ({ surface, confirmDelete, editDetails }) => {
   const [anchorEl, setAnchorEl] = useState();
   const [openConfirmDelete, setOpenConfirmDelete] = useState();
@@ -746,4 +671,11 @@ const SurfaceListing = ({ surface, confirmDelete, editDetails }) => {
   );
 };
 
-export { ActivityListing, TeamListing, ParticipantListing, MatchListing, SurfaceListing };
+export {
+  ActivityListing,
+  TeamListing,
+  ParticipantListing,
+  MatchListing,
+  SurfaceListing,
+  SportListing,
+};

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -24,14 +24,12 @@ import ClearIcon from '@mui/icons-material/Clear';
 import CheckIcon from '@mui/icons-material/Check';
 import { editTeamParticipant, respondToTeamInvite } from 'services/recim/team';
 import { isActivityRegisterable } from 'services/recim/activity';
-import { deleteSurface, removeAttendance, updateAttendance } from 'services/recim/match';
-import { deleteSport } from 'services/recim/sport';
+import { removeAttendance, updateAttendance } from 'services/recim/match';
 import { getParticipantAttendanceCountForTeam } from 'services/recim/team';
 import SportsFootballIcon from '@mui/icons-material/SportsFootball';
 import SportsCricketIcon from '@mui/icons-material/SportsCricket';
 import LocalActivityIcon from '@mui/icons-material/LocalActivity';
 import { standardDate, formatDateTimeRange } from '../../Helpers';
-import GordonDialogBox from 'components/GordonDialogBox';
 
 const ActivityListing = ({ activity }) => {
   let activeSeries = activity.Series.find((series) => isPast(Date.parse(series.StartDate)));
@@ -537,7 +535,6 @@ const MatchListing = ({ match, activityID }) => {
 
 const SportListing = ({ sport, confirmDelete, editDetails }) => {
   const [anchorEl, setAnchorEl] = useState();
-  const [openConfirmDelete, setOpenConfirmDelete] = useState();
   const optionsOpen = Boolean(anchorEl);
 
   if (!sport) return null;
@@ -573,39 +570,34 @@ const SportListing = ({ sport, confirmDelete, editDetails }) => {
             horizontal: 'right',
           }}
         >
-          <MenuItem dense onClick={() => editDetails(sport)} divider>
+          <MenuItem
+            dense
+            onClick={() => {
+              editDetails(sport);
+              setAnchorEl(null);
+            }}
+            divider
+          >
             Edit details
           </MenuItem>
-          <MenuItem dense onClick={() => confirmDelete(sport)} className={styles.redButton}>
+          <MenuItem
+            dense
+            onClick={() => {
+              confirmDelete(sport);
+              setAnchorEl(null);
+            }}
+            className={styles.redButton}
+          >
             Delete sport
           </MenuItem>
         </Menu>
       </ListItem>
-      <GordonDialogBox
-        title="Confirm Delete"
-        open={openConfirmDelete}
-        cancelButtonClicked={() => setOpenConfirmDelete(false)}
-        buttonName="Yes, delete this surface"
-        buttonClicked={async () => {
-          await deleteSport(sport.ID);
-          setOpenConfirmDelete(false);
-        }}
-        severity="error"
-      >
-        <br />
-        <Typography variant="body1">
-          Are you sure you want to permanently delete this sport:
-          <i>'{sport.Name}'</i>?
-        </Typography>
-        <Typography variant="body1">This action cannot be undone.</Typography>
-      </GordonDialogBox>
     </ListItem>
   );
 };
 
 const SurfaceListing = ({ surface, confirmDelete, editDetails }) => {
   const [anchorEl, setAnchorEl] = useState();
-  const [openConfirmDelete, setOpenConfirmDelete] = useState();
   const optionsOpen = Boolean(anchorEl);
 
   if (!surface) return null;
@@ -641,32 +633,28 @@ const SurfaceListing = ({ surface, confirmDelete, editDetails }) => {
             horizontal: 'right',
           }}
         >
-          <MenuItem dense onClick={() => editDetails(surface)} divider>
+          <MenuItem
+            dense
+            onClick={() => {
+              editDetails(surface);
+              setAnchorEl(null);
+            }}
+            divider
+          >
             Edit details
           </MenuItem>
-          <MenuItem dense onClick={() => confirmDelete(surface)} className={styles.redButton}>
+          <MenuItem
+            dense
+            onClick={() => {
+              confirmDelete(surface);
+              setAnchorEl(null);
+            }}
+            className={styles.redButton}
+          >
             Delete surface
           </MenuItem>
         </Menu>
       </ListItem>
-      <GordonDialogBox
-        title="Confirm Delete"
-        open={openConfirmDelete}
-        cancelButtonClicked={() => setOpenConfirmDelete(false)}
-        buttonName="Yes, delete this surface"
-        buttonClicked={async () => {
-          await deleteSurface(surface.ID);
-          setOpenConfirmDelete(false);
-        }}
-        severity="error"
-      >
-        <br />
-        <Typography variant="body1">
-          Are you sure you want to permanently delete this surface:
-          <i>'{surface.Name}'</i>?
-        </Typography>
-        <Typography variant="body1">This action cannot be undone.</Typography>
-      </GordonDialogBox>
     </ListItem>
   );
 };

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -5,6 +5,7 @@ import {
   ParticipantListing,
   SurfaceListing,
   TeamListing,
+  SportListing,
 } from './Listing';
 import { useNavigate } from 'react-router-dom';
 import styles from './List.module.css';
@@ -128,18 +129,22 @@ const TeamList = ({ teams, match, series, invite, setInvites, setTargetTeamID })
   return <List dense>{content}</List>;
 };
 
-const SurfacesList = ({ surfaces, confirmDelete, editDetails }) => {
-  if (!surfaces?.length)
-    return <Typography className={styles.secondaryText}>No surfaces to show.</Typography>;
-  let content = surfaces.map((surface) => (
-    <SurfaceListing
-      key={surface.ID}
-      surface={surface}
-      confirmDelete={confirmDelete}
-      editDetails={editDetails}
-    />
+const SportList = ({ sports, confirmDelete, editDetails }) => {
+  if (!sports?.length)
+    return <Typography className={styles.secondaryText}>No sports to show.</Typography>;
+  let content = sports.map((sport) => (
+    <SportListing sport={sport} confirmDelete={confirmDelete} editDetails={editDetails} />
   ));
   return <List dense>{content}</List>;
 };
 
-export { ActivityList, ParticipantList, MatchList, TeamList, SurfacesList };
+const SurfaceList = ({ surfaces, confirmDelete, editDetails }) => {
+  if (!surfaces?.length)
+    return <Typography className={styles.secondaryText}>No surfaces to show.</Typography>;
+  let content = surfaces.map((surface) => (
+    <SurfaceListing surface={surface} confirmDelete={confirmDelete} editDetails={editDetails} />
+  ));
+  return <List dense>{content}</List>;
+};
+
+export { ActivityList, ParticipantList, MatchList, TeamList, SurfaceList, SportList };

--- a/src/views/RecIM/views/Activity/index.jsx
+++ b/src/views/RecIM/views/Activity/index.jsx
@@ -251,11 +251,7 @@ const Activity = () => {
                   </>
                 }
               >
-                <IconButton
-                  disableRipple
-                  sx={{ mr: '1.3rem' }}
-                  onClick={() => setOpenTooltip((prev) => !prev)}
-                >
+                <IconButton sx={{ mr: '1.3rem' }} onClick={() => setOpenTooltip((prev) => !prev)}>
                   <ImportContactsIcon />
                 </IconButton>
               </RulesTooltip>

--- a/src/views/RecIM/views/Activity/index.jsx
+++ b/src/views/RecIM/views/Activity/index.jsx
@@ -10,7 +10,12 @@ import {
   Tab,
   Menu,
   MenuItem,
+  Tooltip,
+  tooltipClasses,
+  ClickAwayListener,
 } from '@mui/material';
+import { gordonColors } from 'theme';
+import { styled } from '@mui/material/styles';
 import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
 
 import { useEffect, useState, useCallback } from 'react';
@@ -30,6 +35,7 @@ import ImageOptions from 'views/RecIM/components/Forms/ImageOptions';
 import userService from 'services/user';
 import { getParticipantByUsername, getParticipantTeams } from 'services/recim/participant';
 import SettingsIcon from '@mui/icons-material/Settings';
+import ImportContactsIcon from '@mui/icons-material/ImportContacts';
 import ScheduleList from './components/ScheduleList';
 import { formatDateTimeRange } from '../../components/Helpers';
 import GordonDialogBox from 'components/GordonDialogBox';
@@ -46,6 +52,16 @@ const getNumMatches = (seriesArray) => {
   });
   return n;
 };
+
+const RulesTooltip = styled(({ className, ...props }) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))(({ theme }) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: gordonColors.neutral.lightGray,
+    color: gordonColors.neutral.contrastText,
+    maxWidth: 200,
+  },
+}));
 
 const Activity = () => {
   const navigate = useNavigate();
@@ -66,8 +82,9 @@ const Activity = () => {
   const [selectedSeriesTab, setSelectedSeriesTab] = useState(0);
   const [openConfirmDelete, setOpenConfirmDelete] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
-  const [anchorEl, setAnchorEl] = useState();
-  const openMenu = Boolean(anchorEl);
+  const [adminAnchorEl, setAdminAnchorEl] = useState();
+  const openAdminMenu = Boolean(adminAnchorEl);
+  const [openTooltip, setOpenTooltip] = useState(false);
 
   const createSnackbar = useCallback((message, severity) => {
     setSnackbar({ message, severity, open: true });
@@ -94,7 +111,6 @@ const Activity = () => {
     };
     loadData();
   }, [user, profile]);
-  // @TODO modify above dependency to only refresh upon form submit (not cancel)
 
   // disable create team if participant already is participating in this activity,
   // unless they're an admin
@@ -136,12 +152,12 @@ const Activity = () => {
 
   // default closure
   const handleMenuClose = () => {
-    setAnchorEl(null);
+    setAdminAnchorEl(null);
   };
 
   // menu button click
   const handleButtonClick = (e) => {
-    setAnchorEl(e.currentTarget);
+    setAdminAnchorEl(e.currentTarget);
   };
 
   const handleJoinActivity = async () => {
@@ -156,7 +172,6 @@ const Activity = () => {
     createSnackbar(`Activity ${activity.Name} has been joined successfully`, 'success');
     setLoading(false);
   };
-
   // profile hook used for future authentication
   // Administration privs will use AuthGroups -> example can be found in
   //           src/components/Header/components/NavButtonsRightCorner
@@ -199,13 +214,13 @@ const Activity = () => {
             </Typography>
           </Grid>
         </Grid>
-        {isAdmin && (
-          <Grid item xs={3} textAlign={'right'}>
+        <Grid item xs={3} textAlign={'right'}>
+          {isAdmin && (
             <IconButton onClick={handleButtonClick} sx={{ mr: '1rem' }}>
               <SettingsIcon
                 fontSize="large"
                 sx={
-                  openMenu && {
+                  openAdminMenu && {
                     animation: 'spin 0.2s linear ',
                     '@keyframes spin': {
                       '0%': {
@@ -219,8 +234,34 @@ const Activity = () => {
                 }
               />
             </IconButton>
-          </Grid>
-        )}
+          )}
+          <ClickAwayListener onClickAway={() => setOpenTooltip(false)}>
+            <Grid item>
+              <RulesTooltip
+                placement="bottom-start"
+                open={openTooltip}
+                title={
+                  <>
+                    <Typography fontWeight="bold" fontSize="1.5em">
+                      Rules for {activity?.Sport.Name}:
+                    </Typography>{' '}
+                    <Typography fontWeight="italic" fontSize="1.2em" fontStyle="italic">
+                      {activity?.Sport.Rules}
+                    </Typography>
+                  </>
+                }
+              >
+                <IconButton
+                  disableRipple
+                  sx={{ mr: '1.3rem' }}
+                  onClick={() => setOpenTooltip((prev) => !prev)}
+                >
+                  <ImportContactsIcon />
+                </IconButton>
+              </RulesTooltip>
+            </Grid>
+          </ClickAwayListener>
+        </Grid>
       </Grid>
     );
 
@@ -402,9 +443,9 @@ const Activity = () => {
               activityID={activityID}
             />
             <Menu
-              open={openMenu}
+              open={openAdminMenu}
               onClose={handleMenuClose}
-              anchorEl={anchorEl}
+              anchorEl={adminAnchorEl}
               className={styles.menu}
             >
               <Typography className={styles.menuTitle}>Admin Settings</Typography>

--- a/src/views/RecIM/views/Admin/Admin.module.scss
+++ b/src/views/RecIM/views/Admin/Admin.module.scss
@@ -1,11 +1,11 @@
 @import '../../../../vars';
 
-.addSurfaceButton {
+.addResourceButton {
   text-transform: none;
 }
 
 @media (min-width: $break-sm) {
-  .addSurfaceButton {
+  .addResourceButton {
     margin-left: 16px;
   }
 }

--- a/src/views/RecIM/views/Admin/index.jsx
+++ b/src/views/RecIM/views/Admin/index.jsx
@@ -20,6 +20,7 @@ import { getParticipants } from '../../../../services/recim/participant';
 import { deleteSurface, getSurfaces } from '../../../../services/recim/match';
 import AddIcon from '@mui/icons-material/Add';
 import SurfaceForm from 'views/RecIM/components/Forms/SurfaceForm';
+import SportForm from 'views/RecIM/components/Forms/SportForm';
 import GordonDialogBox from 'components/GordonDialogBox';
 import { Typography } from '@mui/material';
 import recimLogo from './../../recim_logo.png';
@@ -137,7 +138,6 @@ const Admin = () => {
         createSnackbar(`Sport ${sport.Name} deleted successfully`, 'success');
       })
       .catch((reason) => {
-        console.log(reason);
         createSnackbar(
           `There was a problem deleting sport ${sport.Name}: ${reason.title}`,
           'error',
@@ -241,6 +241,13 @@ const Admin = () => {
           </TabPanel>
         </CardContent>
       </Card>
+      <SportForm
+        sport={sport}
+        createSnackbar={createSnackbar}
+        onClose={async () => setSports(await getAllSports())}
+        openSportForm={openSportForm}
+        setOpenSportForm={setOpenSportForm}
+      />
       <SurfaceForm
         surface={surface}
         createSnackbar={createSnackbar}


### PR DESCRIPTION
This PR allows for the creation of sports on the admin page, with the following layout.
![image](https://user-images.githubusercontent.com/78440076/232379963-714e01f1-d76d-4d7c-a264-9b35615c6b9a.png)

Here is the corresponding form that appears when the "add a sport" button is clicked
![image](https://user-images.githubusercontent.com/78440076/232380040-3fb11472-6ddf-4565-917e-ad14366dadac.png)

A rule book now appears on the top right corner of the match page, with a clickable button to bring up a rule tooltip,
![image](https://user-images.githubusercontent.com/78440076/232380634-0d5edbb8-a222-4115-bccd-c214d30ec746.png)

Let me know if it looks good! The only thing I can mention, is that I could see the rules button opening a card with the rules if they were expected to be long. But I think that the tooltip will work for RecIM's purposes.

