### PR TITLE
[Rec-IM] Create & Edit custom participant in Admin page

### DIFF
--- a/src/services/recim/participant.ts
+++ b/src/services/recim/participant.ts
@@ -2,26 +2,30 @@ import http from '../http';
 import { Team } from './team';
 import { Lookup } from './recim';
 
-export type Participant = {
+export type Participant = CustomParticipant & {
   Username: string;
-  Email: string;
   Role: string;
-  AllowEmails: boolean;
-  SpecifiedGender: string;
   GamesAttended: number;
   Status: string;
   Notification: ParticipantNotification[];
   IsAdmin: boolean;
   IsCustom: boolean;
-  FirstName: string;
-  LastName: string;
 };
 
 type CustomParticipant = {
   AllowEmails: boolean;
+  Email: string;
   SpecifiedGender: string;
   FirstName: string;
   LastName: string;
+};
+
+type BasicInfo = {
+  FirstName: string;
+  LastName: string;
+  UserName: string;
+  Nickname: string;
+  MaidenName: string;
 };
 
 type PatchParticipantActivity = {
@@ -103,6 +107,16 @@ const getParticipantStatusTypes = (): Promise<Lookup[]> =>
 const getParticipantActivityPrivTypes = (): Promise<Lookup[]> =>
   http.get(`recim/participants/lookup?type=activitypriv`);
 
+const getAccountsBasicInfo = async (
+  query: string,
+): Promise<[searchTime: number, searchResults: BasicInfo[]]> => {
+  const searchStartTime = Date.now();
+  // Replace period or space with a slash: 'first.last' or 'first last' become 'first/last'
+  const searchQuery = query.toLowerCase().trim().replace(/\.|\s/g, '/');
+  const searchResults: BasicInfo[] = await http.get(`recim/participants/search/${searchQuery}`);
+  return [searchStartTime, searchResults];
+};
+
 const sendNotification = (
   username: string,
   notification: UploadParticipantNotification,
@@ -141,6 +155,7 @@ export {
   getParticipantStatusHistory,
   getParticipantStatusTypes,
   getParticipantActivityPrivTypes,
+  getAccountsBasicInfo,
   sendNotification,
   editCustomParticipant,
   editParticipantAdmin,

--- a/src/services/recim/participant.ts
+++ b/src/services/recim/participant.ts
@@ -6,10 +6,22 @@ export type Participant = {
   Username: string;
   Email: string;
   Role: string;
+  AllowEmails: boolean;
+  SpecifiedGender: string;
   GamesAttended: number;
   Status: string;
   Notification: ParticipantNotification[];
   IsAdmin: boolean;
+  IsCustom: boolean;
+  FirstName: string;
+  LastName: string;
+};
+
+type CustomParticipant = {
+  AllowEmails: boolean;
+  SpecifiedGender: string;
+  FirstName: string;
+  LastName: string;
 };
 
 type PatchParticipantActivity = {
@@ -69,6 +81,11 @@ type CreatedParticipantActivity = {
 const createParticipant = (username: string): Promise<Participant> =>
   http.put(`recim/participants/${username}`);
 
+const createCustomParticipant = (
+  username: string,
+  newcustomParticipant: CustomParticipant,
+): Promise<Participant> => http.put(`recim/participants/${username}/custom`, newcustomParticipant);
+
 const getParticipants = (): Promise<Participant[]> => http.get(`recim/participants`);
 
 const getParticipantByUsername = (username: string): Promise<Participant> =>
@@ -92,6 +109,12 @@ const sendNotification = (
 ): Promise<CreatedParticipantNotification> =>
   http.post(`participants/${username}/notifications`, notification);
 
+const editCustomParticipant = (
+  username: string,
+  updatedCustomParticipant: CustomParticipant,
+): Promise<Participant> =>
+  http.patch(`recim/participants/${username}/custom/update`, updatedCustomParticipant);
+
 const editParticipantAdmin = (username: string, isAdmin: boolean): Promise<Participant> =>
   http.patch(`recim/participants/${username}/admin`, isAdmin);
 
@@ -111,6 +134,7 @@ const editParticipantStatus = (
 
 export {
   createParticipant,
+  createCustomParticipant,
   getParticipants,
   getParticipantByUsername,
   getParticipantTeams,
@@ -118,6 +142,7 @@ export {
   getParticipantStatusTypes,
   getParticipantActivityPrivTypes,
   sendNotification,
+  editCustomParticipant,
   editParticipantAdmin,
   editParticipantAllowEmails,
   editParticipantActivity,

--- a/src/services/recim/participant.ts
+++ b/src/services/recim/participant.ts
@@ -86,7 +86,7 @@ const createCustomParticipant = (
   newcustomParticipant: CustomParticipant,
 ): Promise<Participant> => http.put(`recim/participants/${username}/custom`, newcustomParticipant);
 
-const getParticipants = (): Promise<Participant[]> => http.get(`recim/participants`);
+const getParticipants = async (): Promise<Participant[]> => http.get(`recim/participants`);
 
 const getParticipantByUsername = (username: string): Promise<Participant> =>
   http.get(`recim/participants/${username}`);

--- a/src/views/RecIM/components/Forms/InviteParticipantForm/index.jsx
+++ b/src/views/RecIM/components/Forms/InviteParticipantForm/index.jsx
@@ -2,7 +2,7 @@ import { Grid } from '@mui/material';
 import { useState, useEffect } from 'react';
 import GordonDialogBox from 'components/GordonDialogBox';
 import { ParticipantList } from './../../List';
-import GordonQuickSearch from 'components/Header/components/QuickSearch';
+import RecIMQuickSearch from 'views/RecIM/components/QuickSearch';
 import { addParticipantToTeam, createTeam, deleteTeamParticipant } from 'services/recim/team';
 import GordonLoader from 'components/Loader';
 import styles from './InviteParticipantForm.module.css';
@@ -27,7 +27,7 @@ const InviteParticipantForm = ({
     setDisableUpdateButton(!inviteList || !inviteList.length);
   }, [inviteList]);
 
-  const onSearchSubmit = (username) => {
+  const onSearchSubmit = (username, firstName, lastName) => {
     // Check if participant exists in invite list
     for (let index = 0; index < inviteList.length; index++) {
       if (inviteList[index].Username === username) {
@@ -36,7 +36,15 @@ const InviteParticipantForm = ({
       }
     }
 
-    setInviteList([...inviteList, { Username: username }]);
+    setInviteList([
+      ...inviteList,
+      {
+        Username: username,
+        FirstName: firstName,
+        LastName: lastName,
+        IsCustom: username.split('.').at(-1) === 'custom',
+      },
+    ]);
   };
 
   const removeInvite = (username) => {
@@ -128,10 +136,12 @@ const InviteParticipantForm = ({
           </Grid>
           {!saving && (
             <Grid item>
-              <GordonQuickSearch
+              <RecIMQuickSearch
                 customPlaceholderText={'Search for people'}
                 disableLink
-                onSearchSubmit={(selectedUsername) => onSearchSubmit(selectedUsername)}
+                onSearchSubmit={(selectedUsername, firstName, lastName) =>
+                  onSearchSubmit(selectedUsername, firstName, lastName)
+                }
               />
             </Grid>
           )}

--- a/src/views/RecIM/components/Forms/ParticipantForm/index.jsx
+++ b/src/views/RecIM/components/Forms/ParticipantForm/index.jsx
@@ -72,7 +72,7 @@ const ParticipantForm = ({
         .then(() => {
           setSaving(false);
           createSnackbar(
-            `Participant ${participantRequest.FullName} has been edited successfully`,
+            `Participant ${participantRequest.FirstName} ${participantRequest.LastName} has been updated successfully`,
             'success',
           );
           onClose();
@@ -90,7 +90,7 @@ const ParticipantForm = ({
         .then(() => {
           setSaving(false);
           createSnackbar(
-            `Participant ${participantRequest.FullName} has been created successfully`,
+            `Participant ${participantRequest.FirstName} ${participantRequest.LastName} has been created successfully`,
             'success',
           );
           onClose();

--- a/src/views/RecIM/components/Forms/ParticipantForm/index.jsx
+++ b/src/views/RecIM/components/Forms/ParticipantForm/index.jsx
@@ -1,0 +1,122 @@
+import { useState, useMemo } from 'react';
+import Form from '../Form';
+import { createCustomParticipant, editCustomParticipant } from 'services/recim/participant';
+
+const genderTypes = ['U', 'M', 'F'];
+
+const createParticipantFields = [
+  {
+    label: 'First Name',
+    name: 'FirstName',
+    type: 'text',
+    helperText: '*Required',
+    required: true,
+  },
+  {
+    label: 'Last Name',
+    name: 'LastName',
+    type: 'text',
+    helperText: '*Required',
+    required: true,
+  },
+  {
+    label: 'Specified Gender',
+    name: 'SpecifiedGender',
+    type: 'select',
+    menuItems: genderTypes.map((type) => type),
+  },
+  {
+    label: 'Turn On Email Notifications',
+    name: 'AllowEmails',
+    type: 'checkbox',
+    helperText: '*Required', // checkbox: either 0 or 1 => default 1
+    required: false,
+  },
+];
+
+const ParticipantForm = ({
+  participant,
+  createSnackbar,
+  onClose,
+  openParticipantForm,
+  setOpenParticipantForm,
+}) => {
+  const [isSaving, setSaving] = useState(false);
+
+  const currentInfo = useMemo(() => {
+    if (participant) {
+      return {
+        FirstName: participant.FirstName,
+        LastName: participant.LastName,
+        SpecifiedGender: participant.SpecifiedGender,
+        AllowEmails: participant.AllowEmails,
+      };
+    }
+    return {
+      FirstName: '',
+      LastName: '',
+      SpecifiedGender: 'U',
+      AllowEmails: true,
+    };
+  }, [participant]);
+
+  const handleConfirm = (newInfo, handleWindowClose) => {
+    setSaving(true);
+
+    let participantUsername =
+      participant?.Username ?? (newInfo.FirstName + '.' + newInfo.LastName).replaceAll(' ', '');
+    let participantRequest = { ...currentInfo, ...newInfo };
+
+    if (participant) {
+      editCustomParticipant(participantUsername, participantRequest)
+        .then(() => {
+          setSaving(false);
+          createSnackbar(
+            `Participant ${participantRequest.FullName} has been edited successfully`,
+            'success',
+          );
+          onClose();
+          handleWindowClose();
+        })
+        .catch((reason) => {
+          setSaving(false);
+          createSnackbar(
+            `There was a problem editing custom participant: ${reason.title}`,
+            'error',
+          );
+        });
+    } else {
+      createCustomParticipant(participantUsername, participantRequest)
+        .then(() => {
+          setSaving(false);
+          createSnackbar(
+            `Participant ${participantRequest.FullName} has been created successfully`,
+            'success',
+          );
+          onClose();
+          handleWindowClose();
+        })
+        .catch((reason) => {
+          setSaving(false);
+          createSnackbar(
+            `There was a problem creating custom participant: ${reason.title}`,
+            'error',
+          );
+        });
+    }
+  };
+
+  return (
+    <Form
+      formTitles={{ name: 'Participant', formType: participant ? 'Edit' : 'Create' }}
+      fields={[createParticipantFields]}
+      currentInfo={currentInfo}
+      isSaving={isSaving}
+      setOpenForm={setOpenParticipantForm}
+      openForm={openParticipantForm}
+      handleConfirm={handleConfirm}
+    />
+  );
+};
+
+export default ParticipantForm;

--- a/src/views/RecIM/components/Forms/ParticipantForm/index.jsx
+++ b/src/views/RecIM/components/Forms/ParticipantForm/index.jsx
@@ -32,6 +32,13 @@ const createParticipantFields = [
     helperText: '*Required', // checkbox: either 0 or 1 => default 1
     required: false,
   },
+  {
+    label: 'Email Address',
+    name: 'Email',
+    type: 'text',
+    helperText: '*Required',
+    required: true,
+  },
 ];
 
 const ParticipantForm = ({
@@ -50,6 +57,7 @@ const ParticipantForm = ({
         LastName: participant.LastName,
         SpecifiedGender: participant.SpecifiedGender,
         AllowEmails: participant.AllowEmails,
+        Email: participant.Email,
       };
     }
     return {
@@ -57,6 +65,7 @@ const ParticipantForm = ({
       LastName: '',
       SpecifiedGender: 'U',
       AllowEmails: true,
+      Email: '',
     };
   }, [participant]);
 
@@ -108,7 +117,7 @@ const ParticipantForm = ({
 
   return (
     <Form
-      formTitles={{ name: 'Participant', formType: participant ? 'Edit' : 'Create' }}
+      formTitles={{ name: 'Non-Gordon Participant', formType: participant ? 'Edit' : 'Create' }}
       fields={[createParticipantFields]}
       currentInfo={currentInfo}
       isSaving={isSaving}

--- a/src/views/RecIM/components/Forms/ParticipantForm/index.jsx
+++ b/src/views/RecIM/components/Forms/ParticipantForm/index.jsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 import Form from '../Form';
 import { createCustomParticipant, editCustomParticipant } from 'services/recim/participant';
 
-const genderTypes = ['U', 'M', 'F'];
+const genderTypes = ['Undefined', 'Male', 'Female'];
 
 const createParticipantFields = [
   {
@@ -50,12 +50,34 @@ const ParticipantForm = ({
 }) => {
   const [isSaving, setSaving] = useState(false);
 
+  const getGenderChar = (gender) => {
+    switch (gender) {
+      case 'Male':
+        return 'M';
+      case 'Female':
+        return 'F';
+      default:
+        return 'U';
+    }
+  };
+
+  const getGender = (genderChar) => {
+    switch (genderChar) {
+      case 'M':
+        return 'Male';
+      case 'F':
+        return 'Female';
+      default:
+        return 'Undefined';
+    }
+  };
+
   const currentInfo = useMemo(() => {
     if (participant) {
       return {
         FirstName: participant.FirstName,
         LastName: participant.LastName,
-        SpecifiedGender: participant.SpecifiedGender,
+        SpecifiedGender: getGender(participant.SpecifiedGender),
         AllowEmails: participant.AllowEmails,
         Email: participant.Email,
       };
@@ -63,7 +85,7 @@ const ParticipantForm = ({
     return {
       FirstName: '',
       LastName: '',
-      SpecifiedGender: 'U',
+      SpecifiedGender: 'Undefined',
       AllowEmails: true,
       Email: '',
     };
@@ -75,6 +97,7 @@ const ParticipantForm = ({
     let participantUsername =
       participant?.Username ?? (newInfo.FirstName + '.' + newInfo.LastName).replaceAll(' ', '');
     let participantRequest = { ...currentInfo, ...newInfo };
+    participantRequest.SpecifiedGender = getGenderChar(participantRequest.SpecifiedGender);
 
     if (participant) {
       editCustomParticipant(participantUsername, participantRequest)

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -232,7 +232,7 @@ const ParticipantListing = ({
   callbackFunction,
   showParticipantOptions,
   isAdminPage,
-  editCustomParticipant,
+  editDetails,
   withAttendance,
   isAdmin,
   initialAttendance,
@@ -448,7 +448,7 @@ const ParticipantListing = ({
             <MenuItem
               dense
               onClick={() => {
-                editCustomParticipant(participant);
+                editDetails(participant);
                 setAnchorCustomEl(null);
               }}
               divider

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -232,7 +232,7 @@ const ParticipantListing = ({
   callbackFunction,
   showParticipantOptions,
   isAdminPage,
-  editDetails,
+  editParticipantInfo,
   withAttendance,
   isAdmin,
   initialAttendance,
@@ -241,22 +241,21 @@ const ParticipantListing = ({
 }) => {
   const { teamID: teamIDParam, activityID } = useParams(); // for use by team page roster
   const [avatar, setAvatar] = useState();
-  const [name, setName] = useState();
   const [anchorEl, setAnchorEl] = useState();
-  const [anchorCustomEl, setAnchorCustomEl] = useState();
+  const [anchorCustomParticipantEl, setAnchorCustomParticipantEl] = useState();
   const moreOptionsOpen = Boolean(anchorEl);
-  const moreOptionsCustomOpen = Boolean(anchorCustomEl);
+  const moreOptionsCustomParticipantOpen = Boolean(anchorCustomParticipantEl);
   const [didAttend, setDidAttend] = useState(initialAttendance != null);
   const [attendanceCount, setAttendanceCount] = useState();
 
   const handleClickOff = () => {
     setAnchorEl(null);
-    setAnchorCustomEl(null);
+    setAnchorCustomParticipantEl(null);
   };
 
   const handleClose = () => {
     setAnchorEl(null);
-    setAnchorCustomEl(null);
+    setAnchorCustomParticipantEl(null);
     callbackFunction((val) => !val);
   };
 
@@ -273,16 +272,10 @@ const ParticipantListing = ({
         // TODO - Depdens on how we want to store custom participants' Pics
       }
     };
-    const loadUserInfo = async () => {
-      if (participant.Username) {
-        setName(`${participant.FirstName} ${participant.LastName}`);
-      }
-    };
 
     const loadAttendanceCount = async () => {
       setAttendanceCount(await getParticipantAttendanceCountForTeam(teamID, participant.Username));
     };
-    loadUserInfo();
     loadAvatar();
     if (teamID && withAttendance) loadAttendanceCount();
   }, [
@@ -295,7 +288,7 @@ const ParticipantListing = ({
   ]);
 
   const handleCustomParticipantOptions = (event) => {
-    setAnchorCustomEl(event.currentTarget);
+    setAnchorCustomParticipantEl(event.currentTarget);
   };
 
   const handleParticipantOptions = (event) => {
@@ -354,6 +347,24 @@ const ParticipantListing = ({
     attended ? await updateAttendance(matchID, att) : await removeAttendance(matchID, att);
   };
 
+  const participantItem = (participant) => {
+    return (
+      <>
+        <ListItemAvatar>
+          <Avatar
+            src={`data:image/jpg;base64,${avatar}`}
+            className={minimal ? styles.avatarSmall : styles.avatar}
+            variant="rounded"
+          ></Avatar>
+        </ListItemAvatar>
+        <ListItemText
+          primary={`${participant.FirstName} ${participant.LastName}`}
+          secondary={participant.Role}
+        />
+      </>
+    );
+  };
+
   if (!participant) return null;
   return (
     // first ListItem is used only for paddings/margins
@@ -410,14 +421,7 @@ const ParticipantListing = ({
               withAttendance && (didAttend ? styles.attendedListing : styles.absentListing)
             }`}
           >
-            <ListItemAvatar>
-              <Avatar
-                src={`data:image/jpg;base64,${avatar}`}
-                className={minimal ? styles.avatarSmall : styles.avatar}
-                variant="rounded"
-              ></Avatar>
-            </ListItemAvatar>
-            <ListItemText primary={name} secondary={participant.Role} />
+            {participantItem(participant)}
           </ListItem>
         ) : (
           <ListItemButton
@@ -426,14 +430,7 @@ const ParticipantListing = ({
               withAttendance && (didAttend ? styles.attendedListing : styles.absentListing)
             }`}
           >
-            <ListItemAvatar>
-              <Avatar
-                src={`data:image/jpg;base64,${avatar}`}
-                className={minimal ? styles.avatarSmall : styles.avatar}
-                variant="rounded"
-              ></Avatar>
-            </ListItemAvatar>
-            <ListItemText primary={name} secondary={participant.Role} />
+            {participantItem(participant)}
           </ListItemButton>
         )}
         {showParticipantOptions && (
@@ -457,9 +454,9 @@ const ParticipantListing = ({
         )}
         {isAdminPage && participant.IsCustom && (
           <Menu
-            open={moreOptionsCustomOpen}
+            open={moreOptionsCustomParticipantOpen}
             onClose={handleClickOff}
-            anchorEl={anchorCustomEl}
+            anchorEl={anchorCustomParticipantEl}
             anchorOrigin={{
               vertical: 'bottom',
               horizontal: 'right',
@@ -472,8 +469,8 @@ const ParticipantListing = ({
             <MenuItem
               dense
               onClick={() => {
-                editDetails(participant);
-                setAnchorCustomEl(null);
+                editParticipantInfo(participant);
+                setAnchorCustomParticipantEl(null);
               }}
               divider
             >

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -270,7 +270,7 @@ const ParticipantListing = ({
           setAvatar(preferredImage || defaultImage);
         }
       } else {
-        // TODO - Depdent on how we want to store their Pics
+        // TODO - Depdens on how we want to store custom participants' Pics
       }
     };
     const loadUserInfo = async () => {
@@ -285,7 +285,14 @@ const ParticipantListing = ({
     loadUserInfo();
     loadAvatar();
     if (teamID && withAttendance) loadAttendanceCount();
-  }, [participant.Username, teamID, withAttendance]);
+  }, [
+    participant.Username,
+    participant.LastName,
+    participant.FirstName,
+    participant.IsCustom,
+    teamID,
+    withAttendance,
+  ]);
 
   const handleCustomParticipantOptions = (event) => {
     setAnchorCustomEl(event.currentTarget);
@@ -397,21 +404,38 @@ const ParticipantListing = ({
         }
         disablePadding
       >
-        <ListItemButton
-          to={`/profile/${participant.Username}`}
-          className={`${styles.listing} ${
-            withAttendance && (didAttend ? styles.attendedListing : styles.absentListing)
-          }`}
-        >
-          <ListItemAvatar>
-            <Avatar
-              src={`data:image/jpg;base64,${avatar}`}
-              className={minimal ? styles.avatarSmall : styles.avatar}
-              variant="rounded"
-            ></Avatar>
-          </ListItemAvatar>
-          <ListItemText primary={name} secondary={participant.Role} />
-        </ListItemButton>
+        {participant.IsCustom ? (
+          <ListItem
+            className={`${styles.listing} ${
+              withAttendance && (didAttend ? styles.attendedListing : styles.absentListing)
+            }`}
+          >
+            <ListItemAvatar>
+              <Avatar
+                src={`data:image/jpg;base64,${avatar}`}
+                className={minimal ? styles.avatarSmall : styles.avatar}
+                variant="rounded"
+              ></Avatar>
+            </ListItemAvatar>
+            <ListItemText primary={name} secondary={participant.Role} />
+          </ListItem>
+        ) : (
+          <ListItemButton
+            to={`/profile/${participant.Username}`}
+            className={`${styles.listing} ${
+              withAttendance && (didAttend ? styles.attendedListing : styles.absentListing)
+            }`}
+          >
+            <ListItemAvatar>
+              <Avatar
+                src={`data:image/jpg;base64,${avatar}`}
+                className={minimal ? styles.avatarSmall : styles.avatar}
+                variant="rounded"
+              ></Avatar>
+            </ListItemAvatar>
+            <ListItemText primary={name} secondary={participant.Role} />
+          </ListItemButton>
+        )}
         {showParticipantOptions && (
           <Menu open={moreOptionsOpen} onClose={handleClickOff} anchorEl={anchorEl}>
             {participant.Role !== 'Inactive' && participant.Role !== 'Co-Captain' && (

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -49,7 +49,7 @@ const ParticipantList = ({
         participant={participant}
         minimal={minimal}
         isAdminPage={isAdminPage}
-        editDetails={editDetails}
+        editParticipantInfo={editDetails}
         withAttendance={withAttendance}
         initialAttendance={
           withAttendance && attendance?.find((att) => att.Username === participant.Username)

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -26,6 +26,8 @@ const ActivityList = ({ activities, showActivityOptions }) => {
 const ParticipantList = ({
   participants,
   minimal,
+  isAdminPage,
+  editCustomParticipant,
   showParticipantOptions,
   withAttendance,
   attendance,
@@ -46,6 +48,8 @@ const ParticipantList = ({
         key={participant.username}
         participant={participant}
         minimal={minimal}
+        isAdminPage={isAdminPage}
+        editCustomParticipant={editCustomParticipant}
         withAttendance={withAttendance}
         initialAttendance={
           withAttendance && attendance?.find((att) => att.Username === participant.Username)

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -27,7 +27,7 @@ const ParticipantList = ({
   participants,
   minimal,
   isAdminPage,
-  editCustomParticipant,
+  editDetails,
   showParticipantOptions,
   withAttendance,
   attendance,
@@ -49,7 +49,7 @@ const ParticipantList = ({
         participant={participant}
         minimal={minimal}
         isAdminPage={isAdminPage}
-        editCustomParticipant={editCustomParticipant}
+        editDetails={editDetails}
         withAttendance={withAttendance}
         initialAttendance={
           withAttendance && attendance?.find((att) => att.Username === participant.Username)

--- a/src/views/RecIM/components/QuickSearch/QuickSearch.module.scss
+++ b/src/views/RecIM/components/QuickSearch/QuickSearch.module.scss
@@ -1,0 +1,122 @@
+@use 'sass:color';
+@import '../../../../vars';
+
+.quick_search {
+  width: inherit;
+}
+
+.root {
+  align-self: flex-end;
+  color: inherit;
+  transition: box-shadow 0.3s, width 0.3s;
+  border-radius: 4px;
+  border: 1px solid $neutral-white;
+  border-color: inherit;
+  padding: 2px 10px;
+  max-width: 15rem;
+  &:focus-within {
+    box-shadow: 0 3px 10px 0 $neutral-black-opacity20;
+    max-width: 15rem;
+  }
+  &:hover:not(:focus-within) {
+    box-shadow: 0 3px 5px 0 $neutral-black-opacity20;
+  }
+
+  & :global(.MuiInputBase-input) {
+    padding: 7px 0px;
+  }
+}
+
+.dropdown {
+  position: absolute;
+  max-height: 60vh;
+  width: inherit;
+  // max-width: 15rem;
+  overflow-y: auto; // make this to scroll
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+  border-radius: 4px;
+  z-index: 10;
+}
+
+.matched_text {
+  text-decoration: none;
+  padding-bottom: 1px;
+  border-bottom: 2px solid $primary-cyan;
+  background-color: color.adjust($color: $primary-cyan, $alpha: -0.9);
+}
+
+.suggestion_selected {
+  background-color: $neutral-light-gray;
+}
+
+.suggestion,
+.suggestion_selected {
+  display: block;
+  text-align: start;
+  white-space: normal; // wrap long names
+}
+
+.suggestion_selected:hover {
+  background-color: $neutral-light-gray !important;
+}
+
+.dropdown:hover .suggestion_selected {
+  background-color: $neutral-white;
+}
+
+// .loading is shown first. After 350ms, .loading opacity and font-size go to 0. This is done
+// to give space for .no-results to increase in font size and change to normal opacity.
+.no_results {
+  font-style: italic;
+  color: gray;
+  animation: show-no-results 1500ms;
+}
+
+@keyframes show-no-results {
+  0% {
+    font-size: 0;
+    opacity: 0;
+  }
+  99% {
+    font-size: 0;
+    opacity: 0;
+  }
+  100% {
+    font-size: 90%;
+    opacity: 1;
+  }
+}
+
+.loading {
+  font-size: 0;
+  opacity: 0;
+  font-style: italic;
+  color: gray;
+  animation: show-loading 1500ms;
+}
+
+@keyframes show-loading {
+  0% {
+    font-size: 90%;
+    opacity: 1;
+  }
+  99% {
+    font-size: 90%;
+    opacity: 1;
+  }
+  100% {
+    font-size: 0;
+    opacity: 0;
+  }
+}
+
+@media (min-width: $break-sm) {
+  .root {
+    align-self: flex-end;
+  }
+}
+
+:global(hr.MuiDivider-root).suggestion_divider {
+  margin: 0px;
+}

--- a/src/views/RecIM/components/QuickSearch/index.jsx
+++ b/src/views/RecIM/components/QuickSearch/index.jsx
@@ -1,0 +1,294 @@
+import { InputAdornment, MenuItem, Paper, TextField, Typography, Divider } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import Downshift from 'downshift';
+import { useDebounce, useNetworkStatus, useWindowSize } from 'hooks';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { getAccountsBasicInfo } from 'services/recim/participant';
+import styles from './QuickSearch.module.css';
+
+const MIN_QUERY_LENGTH = 2;
+const BREAKPOINT_WIDTH = 450;
+const NO_SEARCH_RESULTS = [0, []];
+
+const renderInput = ({ autoFocus, value, ref, ...other }) => (
+  <TextField
+    type="search"
+    autoFocus={autoFocus}
+    value={value}
+    inputRef={ref}
+    InputProps={{
+      disableUnderline: true,
+      classes: {
+        // Use static class as target of global styles
+        root: `${styles.root} gc360_quick_search_root`,
+      },
+      startAdornment: (
+        <InputAdornment position="start" sx={{ color: 'inherit' }}>
+          <SearchIcon />
+        </InputAdornment>
+      ),
+      ...other,
+    }}
+  />
+);
+
+const GordonQuickSearch = ({ customPlaceholderText, disableLink, onSearchSubmit }) => {
+  // Search time is never used via variable name, but it is used via index
+  // to ensure that earlier searches which took longer to run don't overwrite later searches
+  // eslint-disable-next-line no-unused-vars
+  const [[searchTime, suggestions], setSearchResults] = useState(NO_SEARCH_RESULTS);
+  const [suggestionIndex, setSuggestionIndex] = useState(-1);
+  const [query, setQuery] = useDebounce('', 200);
+  const [highlightQuery, setHighlightQuery] = useState(String);
+  const [downshift, setDownshift] = useState();
+  const [width] = useWindowSize();
+  const isOnline = useNetworkStatus();
+  const placeholder = !isOnline
+    ? 'Offline'
+    : customPlaceholderText ?? (width < BREAKPOINT_WIDTH ? 'People' : 'People Search');
+
+  async function updateQuery(query) {
+    query = query.replace(/[^a-zA-Z0-9'\-.\s]/gm, '');
+
+    // Trim beginning or trailing spaces or periods from query text
+    var highlightQuery = query.replace(/^[\s.]+|[\s.]+$/gm, '');
+    setQuery(query);
+    setHighlightQuery(highlightQuery);
+  }
+
+  useEffect(() => {
+    // Only load suggestions if query is of minimum length
+    if (query?.length >= MIN_QUERY_LENGTH) {
+      getAccountsBasicInfo(query).then((newResults) =>
+        // Only update the search results if the new search time is greater than the previous search time
+        setSearchResults((prevResults) =>
+          newResults[0] > prevResults[0] ? newResults : prevResults,
+        ),
+      );
+    } else {
+      setSearchResults(NO_SEARCH_RESULTS);
+    }
+  }, [query]);
+
+  function handleClick(theChosenOne, firstName, lastName) {
+    if (theChosenOne && disableLink) {
+      onSearchSubmit(theChosenOne, firstName, lastName);
+    }
+    reset();
+  }
+
+  function handleKeys(key) {
+    let sIndex = suggestionIndex;
+    let suggestionList = suggestions;
+    let theChosenOne, firstName, lastName;
+
+    if (key === 'Enter' && suggestionList && suggestionList.length > 0) {
+      if (sIndex === -1) {
+        theChosenOne = suggestionList[0].UserName;
+        firstName = suggestionList[0].firstName;
+        lastName = suggestionList[0].lastName;
+      } else {
+        theChosenOne = suggestionList[sIndex].UserName;
+        firstName = suggestionList[sIndex].firstName;
+        lastName = suggestionList[sIndex].lastName;
+      }
+      // If prop set to disable link, then trigger the onSearchSubmit callback function
+      // Else, redirect the user to the selected profile page
+      disableLink
+        ? onSearchSubmit(theChosenOne, firstName, lastName)
+        : (window.location.pathname = '/profile/' + theChosenOne);
+      reset();
+    }
+    if (key === 'ArrowDown') {
+      sIndex++;
+      sIndex = sIndex % suggestionList.length;
+      setSuggestionIndex(sIndex);
+    }
+    if (key === 'ArrowUp') {
+      if (sIndex !== -1) sIndex--;
+      if (sIndex === -1) sIndex = suggestionList.length - 1;
+      setSuggestionIndex(sIndex);
+    }
+  }
+
+  function reset() {
+    // Remove chosen username from the input
+    downshift.clearSelection();
+
+    // Remove loaded suggestions
+    downshift.clearItems();
+
+    setSuggestionIndex(-1);
+  }
+
+  function highlightParse(text) {
+    return text.replace(/ |\./, '|');
+  }
+
+  // Highlight first occurrence of 'highlight' in 'text'
+  function getHighlightedText(text, highlight) {
+    // Split text on highlight term, include term itself into parts, ignore case
+    var highlights = highlightParse(highlight);
+    var parts = text.split(new RegExp(`(${highlights})`, 'gi'));
+    var hasMatched = false;
+    return (
+      <span>
+        {parts.map((part, key) =>
+          !hasMatched && part.match(new RegExp(`(${highlights})`, 'i'))
+            ? (hasMatched = true && (
+                <span className={styles.matched_text} key={key}>
+                  {part}
+                </span>
+              ))
+            : part,
+        )}
+      </span>
+    );
+  }
+
+  function renderSuggestion({ suggestion, itemProps }) {
+    // Bail if any required properties are missing
+    if (!suggestion.UserName || !suggestion.FirstName || !suggestion.LastName) {
+      return null;
+    }
+
+    const highlightQuerySplit = highlightQuery.match(/ |\./);
+
+    return (
+      <>
+        <MenuItem
+          {...itemProps}
+          key={suggestion.UserName}
+          onClick={() =>
+            handleClick(suggestion.UserName, suggestion.FirstName, suggestion.LastName)
+          }
+          className={
+            suggestionIndex !== -1 &&
+            suggestion.UserName === suggestions?.[suggestionIndex]?.UserName
+              ? styles.suggestion_selected
+              : styles.suggestion
+          }
+        >
+          <Typography variant="body2">
+            {/* If the query contains a space or a period, only highlight occurrences of the first
+              name part of the query in the first name, and only highlight occurrences of the last
+              name part of the query in the last name. Otherwise, highlight occurrences of the
+              query in the first and last name. */}
+            {highlightQuerySplit?.length > 1 ? (
+              <>
+                <span key={1}>
+                  {getHighlightedText(suggestion.FirstName + ' ', highlightQuerySplit[0])}
+                </span>
+                <span key={2}>
+                  {getHighlightedText(suggestion.LastName, highlightQuerySplit[1])}
+                </span>
+              </>
+            ) : (
+              getHighlightedText(
+                suggestion.FirstName +
+                  // If having nickname that is unique, display that nickname
+                  (suggestion.Nickname &&
+                  suggestion.Nickname !== suggestion.FirstName &&
+                  suggestion.Nickname !== suggestion.UserName.split(/ |\./)[0]
+                    ? ' (' + suggestion.Nickname + ') '
+                    : ' ') +
+                  suggestion.LastName +
+                  // If having maiden name that is unique, display that maiden name
+                  (suggestion.MaidenName &&
+                  suggestion.MaidenName !== suggestion.LastName &&
+                  suggestion.MaidenName !== suggestion.UserName.split(/ |\./)[1]
+                    ? ' (' + suggestion.MaidenName + ')'
+                    : ''),
+                highlightQuery,
+              )
+            )}
+          </Typography>
+          <Typography variant="caption" component="p">
+            {/* If the first name matches either part (first or last name) of the query, don't
+              highlight occurrences of the query in the first name part of the username.
+              If the username contains a period, add it back in.
+              If the last name matches either part (first of last name) of the query, don't
+              highlight occurrences of the query in the last name part of the username. */}
+            {!suggestion.FirstName.match(new RegExp(`(${highlightParse(highlightQuery)})`, 'i'))
+              ? getHighlightedText(suggestion.UserName.split('.')[0], highlightQuery)
+              : suggestion.UserName.split('.')[0]}
+            {suggestion.UserName.includes('.') && '.'}
+            {suggestion.UserName.includes('.') &&
+              (!suggestion.LastName.match(new RegExp(`(${highlightParse(highlightQuery)})`, 'i'))
+                ? getHighlightedText(suggestion.UserName.split('.')[1], highlightQuery)
+                : suggestion.UserName.split('.')[1])}
+          </Typography>
+        </MenuItem>
+        <Divider className={styles.suggestion_divider} />
+      </>
+    );
+  }
+
+  return (
+    <Downshift
+      // Assign reference to Downshift to state property for usage elsewhere in the component
+      ref={(downshift) => {
+        setDownshift(downshift);
+      }}
+    >
+      {({ getInputProps, getItemProps, isOpen }) => (
+        <span className={styles.quick_search} key="suggestion-list-span">
+          {renderInput(
+            getInputProps({
+              placeholder: placeholder,
+              ...(isOnline
+                ? {
+                    onChange: (event) => updateQuery(event.target.value),
+                    onKeyDown: (event) => handleKeys(event.key),
+                    onBlur: () => setQuery(''),
+                  }
+                : {
+                    style: { color: 'white' },
+                    disabled: { isOnline },
+                  }),
+            }),
+          )}
+          {isOpen && query.length >= MIN_QUERY_LENGTH && (
+            <Paper square className={`${styles.dropdown} gc360_quick_search_dropdown`}>
+              {suggestions.length > 0 ? (
+                suggestions.map((suggestion) =>
+                  renderSuggestion({
+                    suggestion,
+                    itemProps: getItemProps({
+                      item: suggestion.UserName,
+                      ...(!disableLink
+                        ? {
+                            component: Link,
+                            to: `/profile/${suggestion.UserName}`,
+                          }
+                        : {}),
+                    }),
+                  }),
+                )
+              ) : (
+                <MenuItem className={styles.suggestion} style={{ paddingBottom: '5px' }}>
+                  <Typography className={styles.no_results} variant="body2">
+                    No results
+                  </Typography>
+                  <Typography className={styles.loading} variant="body2">
+                    Loading...
+                  </Typography>
+                </MenuItem>
+              )}
+            </Paper>
+          )}
+        </span>
+      )}
+    </Downshift>
+  );
+};
+
+GordonQuickSearch.propTypes = {
+  customPlaceholderText: PropTypes.string,
+  disableLink: PropTypes.any,
+  onSearchSubmit: PropTypes.func,
+};
+
+export default GordonQuickSearch;

--- a/src/views/RecIM/views/Admin/index.jsx
+++ b/src/views/RecIM/views/Admin/index.jsx
@@ -19,6 +19,7 @@ import { getTeams } from '../../../../services/recim/team';
 import { getParticipants } from '../../../../services/recim/participant';
 import { deleteSurface, getSurfaces } from '../../../../services/recim/match';
 import AddIcon from '@mui/icons-material/Add';
+import ParticipantForm from 'views/RecIM/components/Forms/ParticipantForm';
 import SurfaceForm from 'views/RecIM/components/Forms/SurfaceForm';
 import SportForm from 'views/RecIM/components/Forms/SportForm';
 import GordonDialogBox from 'components/GordonDialogBox';
@@ -44,11 +45,13 @@ const Admin = () => {
   const [activities, setActivities] = useState();
   const [teams, setTeams] = useState();
   const [participants, setParticipants] = useState();
+  const [participant, setParticipant] = useState();
   const [surfaces, setSurfaces] = useState();
   const [surface, setSurface] = useState();
   const [sports, setSports] = useState();
   const [sport, setSport] = useState();
   const [tab, setTab] = useState(0);
+  const [openParticipantForm, setOpenParticipantForm] = useState();
   const [openSurfaceForm, setOpenSurfaceForm] = useState();
   const [openSportForm, setOpenSportForm] = useState(false);
   const [openConfirmDeleteSurface, setOpenConfirmDeleteSurface] = useState();
@@ -87,6 +90,11 @@ const Admin = () => {
     setSnackbar({ message, severity, open: true });
   }, []);
 
+  const handleOpenCreateParticipant = () => {
+    setParticipant();
+    setOpenParticipantForm(true);
+  };
+
   const handleOpenCreateSurface = () => {
     setSurface();
     setOpenSurfaceForm(true);
@@ -95,6 +103,11 @@ const Admin = () => {
   const handleOpenCreateSport = () => {
     setSport();
     setOpenSportForm(true);
+  };
+
+  const handleOpenEditParticipant = (participant) => {
+    setParticipant(participant);
+    setOpenParticipantForm(true);
   };
 
   const handleOpenEditSurface = (surface) => {
@@ -195,7 +208,25 @@ const Admin = () => {
             {teams ? <TeamList teams={teams} /> : <GordonLoader />}
           </TabPanel>
           <TabPanel value={tab} index={2}>
-            {participants ? <ParticipantList participants={participants} /> : <GordonLoader />}
+            {participants ? (
+              <>
+                <Button
+                  color="secondary"
+                  startIcon={<AddIcon />}
+                  className={styles.addResourceButton}
+                  onClick={handleOpenCreateParticipant}
+                >
+                  add a participant
+                </Button>
+                <ParticipantList
+                  participants={participants}
+                  isAdminPage={true}
+                  editCustomParticipant={handleOpenEditParticipant}
+                />
+              </>
+            ) : (
+              <GordonLoader />
+            )}
           </TabPanel>
           <TabPanel value={tab} index={3}>
             {surfaces ? (
@@ -241,6 +272,13 @@ const Admin = () => {
           </TabPanel>
         </CardContent>
       </Card>
+      <ParticipantForm
+        participant={participant}
+        createSnackbar={createSnackbar}
+        onClose={async () => setParticipants(await getParticipants())}
+        openParticipantForm={openParticipantForm}
+        setOpenParticipantForm={setOpenParticipantForm}
+      />
       <SportForm
         sport={sport}
         createSnackbar={createSnackbar}

--- a/src/views/RecIM/views/Admin/index.jsx
+++ b/src/views/RecIM/views/Admin/index.jsx
@@ -221,7 +221,7 @@ const Admin = () => {
                 <ParticipantList
                   participants={participants}
                   isAdminPage={true}
-                  editCustomParticipant={handleOpenEditParticipant}
+                  editDetails={handleOpenEditParticipant}
                 />
               </>
             ) : (

--- a/src/views/RecIM/views/Admin/index.jsx
+++ b/src/views/RecIM/views/Admin/index.jsx
@@ -216,7 +216,7 @@ const Admin = () => {
                   className={styles.addResourceButton}
                   onClick={handleOpenCreateParticipant}
                 >
-                  add a participant
+                  add a non-Gordon participant
                 </Button>
                 <ParticipantList
                   participants={participants}


### PR DESCRIPTION
This pr adds a new form that allows creating custom participants, and updating their info in the Admin page.
Also improves the loading speed of Admin page by replacing `GetProfileInfo()` with a lighter method.

API pr: https://github.com/gordon-cs/gordon-360-api/pull/891.

New `Create Participant` Button
![image](https://user-images.githubusercontent.com/78691207/232872522-d92ebfef-c82c-465e-9bf3-bf77b116e35a.png)

`Create Participant` View
![image](https://user-images.githubusercontent.com/78691207/233866530-2f0111b6-838c-44ba-b131-d9bab8995e7d.png)

Only `Custom Participant` has the `MoreOption` Button at the righthand side
And they don't have a pic for now
![image](https://user-images.githubusercontent.com/78691207/232872939-e4af3a1b-5b3f-4cab-9c32-167233a9c1f9.png)

Menu displayed when clicked the `MoreOption` Button
![image](https://user-images.githubusercontent.com/78691207/232873131-e8a26cb3-b260-490e-948e-4f51400cebf3.png)

`Edit Participant` View
![image](https://user-images.githubusercontent.com/78691207/232873325-93c6c5f0-4d62-423b-b08d-033f3e4cca6b.png)

Quick Search in RecIM team page
* Admins can search both Gordon participants and non-Gordon participants
![image](https://user-images.githubusercontent.com/78691207/233850886-cba28fa4-abae-41de-9f91-d1eb1570608e.png)
![image](https://user-images.githubusercontent.com/78691207/233850898-42ec5a78-f5c7-4338-aa9d-57c44e3af99d.png)

**Participant List Checklist**
* let me know if I missed any
- [x] Admin page - participant list
- [x] Team page - roster
- [x] Team page - invite list
- [x] Match page - attendance list