### PR TITLE
Fix erroneous redirects

### DIFF
--- a/src/components/AppRedirect/index.jsx
+++ b/src/components/AppRedirect/index.jsx
@@ -10,7 +10,13 @@ const AppRedirect = () => {
 
   useEffect(() => {
     if (isAuthenticated) {
-      checkInService.getStatus().then((status) => setEnrollmentCheckinComplete(status ?? true));
+      checkInService
+        .getStatus()
+        .then(setEnrollmentCheckinComplete)
+        .catch((error) => {
+          console.error(error);
+          setEnrollmentCheckinComplete(true);
+        });
     }
   }, [isAuthenticated, location]);
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -6,9 +6,7 @@ const apiRequest = {
   scopes: ['api://b19c300a-00dc-4adc-bcd1-b678b25d7ad1/access_as_user'],
 };
 
-const authenticate = async () => {
-  await msalInstance.loginRedirect(apiRequest);
-};
+const authenticate = () => msalInstance.loginRedirect(apiRequest);
 
 const acquireAccessToken = async () => {
   const activeAccount = msalInstance.getActiveAccount();
@@ -25,9 +23,11 @@ const acquireAccessToken = async () => {
     account: activeAccount || accounts[0],
   };
 
-  const authResult = await msalInstance.acquireTokenSilent(request).catch(async (error) => {
+  const authResult = await msalInstance.acquireTokenSilent(request).catch((error) => {
     if (error instanceof InteractionRequiredAuthError) {
-      return await msalInstance.acquireTokenRedirect(apiRequest);
+      return msalInstance.acquireTokenPopup(apiRequest);
+    } else {
+      throw error;
     }
   });
 

--- a/src/services/checkIn.ts
+++ b/src/services/checkIn.ts
@@ -1,5 +1,5 @@
-import { AuthError, NotFoundError } from './error';
-import http from './http';
+import { AuthError, NotFoundError } from "./error";
+import http from "./http";
 
 /**
  * these holds prevent a student from checking in
@@ -47,11 +47,11 @@ type Demographic = {
 };
 
 export enum Race {
-  NativeAmerican = 'Native American or Alaskan Native',
-  Asian = 'Asian',
-  Black = 'Black or African American',
-  Hawaiian = 'Native Hawaiian or Other Pacific Islander',
-  White = 'White',
+  NativeAmerican = "Native American or Alaskan Native",
+  Asian = "Asian",
+  Black = "Black or African American",
+  Hawaiian = "Native Hawaiian or Other Pacific Islander",
+  White = "White",
 }
 
 type EnrollmentCheckin = {
@@ -62,16 +62,15 @@ type EnrollmentCheckin = {
   MinorHolds &
   Demographic;
 
-const getStatus = (): Promise<boolean> =>
-  http
-    .get<boolean>(`checkIn/status`)
-    .catch((err) => err instanceof NotFoundError || err instanceof AuthError);
+const getStatus = (): Promise<boolean> => http.get<boolean>(`checkIn/status`);
 
 const markCompleted = (): Promise<void> => http.put(`checkIn/status`);
 
 const getHolds = (): Promise<EnrollmentCheckin> => http.get(`checkIn/holds`);
 
-const getEmergencyContacts = (username: string): Promise<EmergencyContact[] | void> =>
+const getEmergencyContacts = (
+  username: string
+): Promise<EmergencyContact[] | void> =>
   http.get(`profiles/emergency-contact/${username}/`);
 
 const submitPhone = (data: EnrollmentCheckin): Promise<EnrollmentCheckin> =>
@@ -80,8 +79,9 @@ const submitPhone = (data: EnrollmentCheckin): Promise<EnrollmentCheckin> =>
 const submitContact = (data: EmergencyContact): Promise<EmergencyContact> =>
   http.post(`checkIn/emergencycontact`, data);
 
-const submitDemographic = (data: EnrollmentCheckin): Promise<EnrollmentCheckin> =>
-  http.put(`checkIn/demographic`, data);
+const submitDemographic = (
+  data: EnrollmentCheckin
+): Promise<EnrollmentCheckin> => http.put(`checkIn/demographic`, data);
 
 const checkInService = {
   getStatus,


### PR DESCRIPTION
The user was getting erroneously redirected to the Enrollment Check In page. This error seemed to occur when first opening the app after a multi-hour period of inactivity.

This bug has proven almost impossible to reproduce consistently in the development environment. However, based off of my observations in our deployed environments and a deep dive into the execution order of the redirect process, I believe I have narrowed down the cause of the issue. It seems to be a blip in authentication logic when an authenticated user has an expired token.

The way that our authentication library works is that the user authenticates against Microsoft using their Gordon (Microsoft Exchange) account. If the user authenticates to Microsoft successfully, Microsoft returns them to our site along with an ID Token proving their identity and an API Token to access the 360 API.

When we send a request to the 360 API, the frontend asks our authentication library for the API Token mentioned above. Typically, that token will be stored in local storage from when the user authenticated. That token is refreshed periodically and automatically while the application is active. However, if the user remains authenticated but the application is inactive for a prolonged, the token will truly expire. In that case, the silent request for the API Token fails, and the frontend has to send the user back to Microsoft for a new API Token. Assuming the user is still authenticated to Microsoft (which they almost always are), this redirect to Microsoft and back happens almost instantaneously, and appears as just some white flashes interspersed by Gordon loading bars.

However, my suspicion is that, somewhere in the process of redirecting the user to Microsoft for a new access token, the API request to retrieve the user's Enrollment Check In status fails with an unanticipated error message. Up until now, the Enrollment Check In redirect only anticipated the Not Found and Unauthorized errors, because those were seemingly the only possible error responses from the API. However, if the error is being thrown not by the API but by the authentication library when we request a new token, that might cause the Enrollment Check In status to be set incorrectly, which would redirect the user to the Enrollment Check In page. Immediately (from the user's perspective) after they are redirected, the authentication library has now successfully acquired a new token so any future requests for the user's enrollment check in status will function as expected. The end result will appear, to the user, as a screen that flashes several times quickly between white and 360 with only the header and spinning loader, followed finally by the Enrollment Check In page.

I have not been able to recreate the above bug exactly in my own testing, so I may be incorrect. Regardless, the new error checking I am adding to handle the above behavior should improve the logic for any edge case, and at the very least should not cause any regressions.