### PR TITLE
Update Google Analytics to V4

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -2,7 +2,7 @@
 
 # @PROD
 # VITE_API_URL=https://360Api1.gordon.edu/
-# VITE_ANALYTICS_ID=UA-3559968-3
+# VITE_ANALYTICS_ID=G-2FE78G0CBN
 
 # @TRAIN
 VITE_API_URL=https://360ApiTrain.gordon.edu/

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react-dom": "^17.0.2",
         "react-dom-confetti": "^0.2.0",
         "react-dropzone": "^11.4.2",
-        "react-ga": "^3.3.0",
+        "react-ga4": "^2.1.0",
         "react-icons": "^4.3.1",
         "react-image-gallery": "^1.2.7",
         "react-imask": "^6.4.2",
@@ -7062,14 +7062,10 @@
         "react": ">= 16.8"
       }
     },
-    "node_modules/react-ga": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
-      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
-      "peerDependencies": {
-        "prop-types": "^15.6.0",
-        "react": "^15.6.2 || ^16.0 || ^17 || ^18"
-      }
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "node_modules/react-icons": {
       "version": "4.4.0",
@@ -14041,11 +14037,10 @@
         "prop-types": "^15.8.1"
       }
     },
-    "react-ga": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
-      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
-      "requires": {}
+    "react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "react-icons": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^17.0.2",
     "react-dom-confetti": "^0.2.0",
     "react-dropzone": "^11.4.2",
-    "react-ga": "^3.3.0",
+    "react-ga4": "^2.1.0",
     "react-icons": "^4.3.1",
     "react-image-gallery": "^1.2.7",
     "react-imask": "^6.4.2",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2,7 +2,7 @@ import AppRedirect from 'components/AppRedirect';
 import BirthdayMessage from 'components/BirthdayMessage';
 import { createBrowserHistory } from 'history';
 import { useEffect, useRef, useState } from 'react';
-import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import './app.global.css';
 import styles from './app.module.css';
 import ErrorBoundary from './components/ErrorBoundary';

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,7 +1,10 @@
-import ReactGA from 'react-ga';
+import ReactGA from 'react-ga4';
 
 const onError = (description: string) => {
-  ReactGA.exception({ description });
+  ReactGA.send({
+    hitType: 'exception',
+    exDescription: description,
+  });
 };
 
 /**
@@ -21,10 +24,15 @@ const onEvent = (category: string, action: string, label?: string, value?: numbe
     value,
   });
 
-const onPageView = () => ReactGA.pageview(window.location.pathname + window.location.search);
+const onPageView = (title?: string) =>
+  ReactGA.send({
+    hitType: 'pageview',
+    page: window.location.pathname + window.location.search,
+    title: title ?? null,
+  });
 
 const initialize = () => {
-  ReactGA.initialize(import.meta.env.VITE_ANALYTICS_ID ?? 'UA-101865570-1');
+  ReactGA.initialize(import.meta.env.VITE_ANALYTICS_ID ?? 'G-2FE78G0CBN');
   // Set user role
   // TODO get user role from JWT
   ReactGA.set({ dimension1: 'god' });

--- a/src/views/Home/components/GuestWelcome/index.jsx
+++ b/src/views/Home/components/GuestWelcome/index.jsx
@@ -1,3 +1,4 @@
+import GetAppIcon from '@mui/icons-material/GetApp';
 import {
   Button,
   Card,
@@ -10,11 +11,10 @@ import {
   Grid,
   Typography,
 } from '@mui/material';
-import GetAppIcon from '@mui/icons-material/GetApp';
 import PWAInstructions from 'components/PWAInstructions/index';
 import useNetworkStatus from 'hooks/useNetworkStatus';
 import { useEffect, useState } from 'react';
-import { ga } from 'react-ga';
+import { ga } from 'react-ga4';
 import { authenticate } from 'services/auth';
 import styles from './GuestWelcome.module.css';
 import GordonLogoVerticalWhite from './images/gordon-logo-vertical-white.svg';


### PR DESCRIPTION
This PR updates the version of our Google Analytics package to work with their new version 4 which will replace Universal Analytics on July 1st.

The changes are pretty minimal and simple but we needed a new tag code to use on the site as well. Most of the new features are in the analytics dashboard itself.