### PR TITLE
Revert to login via redirect

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -25,7 +25,7 @@ const acquireAccessToken = async () => {
 
   const authResult = await msalInstance.acquireTokenSilent(request).catch((error) => {
     if (error instanceof InteractionRequiredAuthError) {
-      return msalInstance.acquireTokenPopup(apiRequest);
+      return msalInstance.acquireTokenRedirect(apiRequest);
     } else {
       throw error;
     }


### PR DESCRIPTION
I changed the fallback for acquiring a token to use the pop up method in #1792. However, that has caused some issues in Train that I didn't notice locally. Logging in via pop up does not work on browsers unless the Pop up privilege has been explicitly granted to the site. Redirect is therefore more reliable.