### PR TITLE
Improve error logging for ID Uploader

### DIFF
--- a/src/services/errorLog.ts
+++ b/src/services/errorLog.ts
@@ -1,67 +1,35 @@
 import http from './http';
 
-const postErrorLog = (message: string) =>
-  http.post('log/add', { LOG_MESSAGE: message, LOG_TIME: Date.now() });
+interface UserAgentDataBrand {
+  readonly brand: string;
+  readonly version: string;
+}
+interface UserAgentData {
+  readonly platform: string;
+  readonly brands: UserAgentDataBrand[];
+  readonly mobile: boolean;
+}
+
+declare global {
+  interface Navigator {
+    readonly userAgentData?: UserAgentData;
+  }
+}
 
 const postErrorMessage = (message: string) => http.post('log', message);
 
-//Code modified from https://medium.com/creative-technology-concepts-code/detect-device-browser-and-version-using-javascript-8b511906745
-const matchItem = (string: string, data: { name: string; value: string }[]): string => {
-  data.forEach((element) => {
-    const match = new RegExp(element.value, 'i').test(string);
-    if (match) {
-      return element.name;
-    }
-  });
-  return 'unknown';
-};
-
-const oses = [
-  { name: 'Windows Phone', value: 'Windows Phone' },
-  { name: 'Windows', value: 'Win' },
-  { name: 'iPhone', value: 'iPhone' },
-  { name: 'iPad', value: 'iPad' },
-  { name: 'Kindle', value: 'Silk' },
-  { name: 'Android', value: 'Android' },
-  { name: 'PlayBook', value: 'PlayBook' },
-  { name: 'BlackBerry', value: 'BlackBerry' },
-  { name: 'Macintosh', value: 'Mac' },
-  { name: 'Linux', value: 'Linux' },
-  { name: 'Palm', value: 'Palm' },
-];
-
-const browsers = [
-  { name: 'Chrome', value: 'Chrome' },
-  { name: 'Firefox', value: 'Firefox' },
-  { name: 'Safari', value: 'Safari' },
-  { name: 'Internet Explorer', value: 'MSIE' },
-  { name: 'Opera', value: 'Opera' },
-  { name: 'BlackBerry', value: 'CLDC' },
-  { name: 'Mozilla', value: 'Mozilla' },
-];
-
-const parseNavigator = (navigator: Navigator) => {
-  //Code modified from https://medium.com/creative-technology-concepts-code/detect-device-browser-and-version-using-javascript-8b511906745
-
-  const header = [
-    navigator.platform,
-    navigator.userAgent,
-    navigator.appVersion,
-    navigator.vendor,
-    //@ts-ignore
-    window.opera,
-  ];
-
-  const agent = header.join(' ');
-  const os = matchItem(agent, oses);
-  const browser = matchItem(agent, browsers);
-  return 'OS: ' + os + ', Browser: ' + browser;
+const parseUserAgentData = () => {
+  if (navigator.userAgentData) {
+    const { brands, platform, mobile } = navigator.userAgentData;
+    const { brand, version } = brands[0];
+    return `${platform} running ${brand} version ${version} on ${mobile ? 'mobile' : 'non-mobile'}`;
+  }
+  return navigator.userAgent;
 };
 
 const errorLogService = {
-  postErrorLog,
   postErrorMessage,
-  parseNavigator,
+  parseUserAgentData,
 };
 
 export default errorLogService;

--- a/src/services/logging.ts
+++ b/src/services/logging.ts
@@ -16,7 +16,7 @@ declare global {
   }
 }
 
-const postLogMessage = (message: string) => http.post('log', message);
+const post = (message: string) => http.post('log', message);
 
 // @TODO: Make this a strcutured component of all logs, e.g. with new columns for OS, Version, etc.
 const parseUserAgentData = () => {
@@ -29,7 +29,7 @@ const parseUserAgentData = () => {
 };
 
 const errorLogService = {
-  postLogMessage,
+  post,
   parseUserAgentData,
 };
 

--- a/src/services/logging.ts
+++ b/src/services/logging.ts
@@ -16,7 +16,10 @@ declare global {
   }
 }
 
-const post = (message: string) => http.post('log', message);
+const post = (message: string) => {
+  const userAgentData = parseUserAgentData();
+  http.post('log', `${userAgentData}: ${message}`);
+};
 
 // @TODO: Make this a strcutured component of all logs, e.g. with new columns for OS, Version, etc.
 const parseUserAgentData = () => {

--- a/src/services/logging.ts
+++ b/src/services/logging.ts
@@ -16,8 +16,9 @@ declare global {
   }
 }
 
-const postErrorMessage = (message: string) => http.post('log', message);
+const postLogMessage = (message: string) => http.post('log', message);
 
+// @TODO: Make this a strcutured component of all logs, e.g. with new columns for OS, Version, etc.
 const parseUserAgentData = () => {
   if (navigator.userAgentData) {
     const { brands, platform, mobile } = navigator.userAgentData;
@@ -28,7 +29,7 @@ const parseUserAgentData = () => {
 };
 
 const errorLogService = {
-  postErrorMessage,
+  postLogMessage,
   parseUserAgentData,
 };
 

--- a/src/views/IDUploader/index.jsx
+++ b/src/views/IDUploader/index.jsx
@@ -18,7 +18,7 @@ import { Component, createRef } from 'react';
 import Cropper from 'react-cropper';
 import Dropzone from 'react-dropzone';
 import { authenticate } from 'services/auth';
-import errorLog from 'services/errorLog';
+import logging from 'services/logging';
 import user from 'services/user';
 import { gordonColors } from 'theme';
 import styles from './IDUploader.module.css';
@@ -85,10 +85,10 @@ class IDUploader extends Component {
         this.setState({ submitDialogOpen: true });
         postedSuccessfully = true;
       } catch (error) {
-        const userAgentData = errorLog.parseUserAgentData();
+        const userAgentData = logging.parseUserAgentData();
         const errorDetails = JSON.stringify(error);
         const logMessage = `ID photo submission #${attemptNumber} for ${profile.AD_Username} from ${userAgentData} failed: ${errorDetails}`;
-        errorLog.postErrorMessage(logMessage);
+        logging.postLogMessage(logMessage);
         attemptNumber++;
       }
     }

--- a/src/views/IDUploader/index.jsx
+++ b/src/views/IDUploader/index.jsx
@@ -75,20 +75,21 @@ class IDUploader extends Component {
   };
 
   async postCroppedImage(croppedImage) {
-    let profile = await user.getProfileInfo();
-    let postedSuccessfully = false;
+    const profile = await user.getProfileInfo();
+    const userAgentData = logging.parseUserAgentData();
     let attemptNumber = 0;
+    let logIntro = `ID photo submission for ${profile.AD_Username} from ${userAgentData}`;
+    let postedSuccessfully = false;
 
     while (!postedSuccessfully && attemptNumber < 5) {
       try {
         await user.postIDImage(croppedImage);
         this.setState({ submitDialogOpen: true });
+        logging.post(logIntro + ` succeeded on #${attemptNumber}`);
         postedSuccessfully = true;
       } catch (error) {
-        const userAgentData = logging.parseUserAgentData();
         const errorDetails = JSON.stringify(error);
-        const logMessage = `ID photo submission #${attemptNumber} for ${profile.AD_Username} from ${userAgentData} failed: ${errorDetails}`;
-        logging.postLogMessage(logMessage);
+        logging.post(logIntro + ` failed #${attemptNumber} with error: ${errorDetails}`);
         attemptNumber++;
       }
     }

--- a/src/views/IDUploader/index.jsx
+++ b/src/views/IDUploader/index.jsx
@@ -89,7 +89,7 @@ class IDUploader extends Component {
         postedSuccessfully = true;
       } catch (error) {
         const errorDetails = JSON.stringify(error);
-        logging.post(logIntro + ` failed #${attemptNumber} with error: ${errorDetails}`);
+        logging.post(logIntro + ` failed on #${attemptNumber} with error: ${errorDetails}`);
         attemptNumber++;
       }
     }

--- a/src/views/IDUploader/index.jsx
+++ b/src/views/IDUploader/index.jsx
@@ -76,9 +76,8 @@ class IDUploader extends Component {
 
   async postCroppedImage(croppedImage) {
     const profile = await user.getProfileInfo();
-    const userAgentData = logging.parseUserAgentData();
     let attemptNumber = 0;
-    let logIntro = `ID photo submission for ${profile.AD_Username} from ${userAgentData}`;
+    let logIntro = `ID photo submission for ${profile.AD_Username}`;
     let postedSuccessfully = false;
 
     while (!postedSuccessfully && attemptNumber < 5) {


### PR DESCRIPTION
The error logging within the ID Uploader service depends on deprecated navigator APIs (platform, appVersion, vendor) - as well as the `navigator.userAgent` that is gradually being deprecated and quickly becoming less than informative - for useful error logging. This is causing problems because the data extracted from these old APIs is now appearing in logs as repeated "unknown"s, which is not very helpful.

Chromium-based browsers (which hold >70% market share of browsers) already support the (currently experimental) User Agent Data interface that is planned to take the place of these old interfaces<sup>1</sup>. As such, I have updated the logging logic to take from the User Agent Data API if it exists in the browser, and to fallback to the old user agent otherwise.

I also updated the `postCroppedImage` method of the ID Uploader to use the new `logging.parseUserAgentData` method. In the process, I refactored it slightly to be more readable and performant.

<sup>1</sup> - https://caniuse.com/mdn-api_navigator_useragentdata