### PR TITLE
Use ReactGA properly

### DIFF
--- a/src/views/Home/components/GuestWelcome/index.jsx
+++ b/src/views/Home/components/GuestWelcome/index.jsx
@@ -14,7 +14,7 @@ import {
 import PWAInstructions from 'components/PWAInstructions/index';
 import useNetworkStatus from 'hooks/useNetworkStatus';
 import { useEffect, useState } from 'react';
-import { ga } from 'react-ga4';
+import ReactGA from 'react-ga4';
 import { authenticate } from 'services/auth';
 import styles from './GuestWelcome.module.css';
 import GordonLogoVerticalWhite from './images/gordon-logo-vertical-white.svg';
@@ -52,7 +52,7 @@ const GuestWelcome = () => {
       setShowPWALink(true);
     }
     // Google Analytics to track PWA usage
-    ga('set', 'dimension1', displayMode);
+    ReactGA.set({ dimension1: displayMode });
 
     // Removes all events listeners that were invoked in this component
     return function cleanupListener() {


### PR DESCRIPTION
When we updated to the `react-ga4` package, someone updated an import without actually checking that the import was still valid. It was not still valid, and it caused unauthenticated users to see an error page on the home screen, breaking the site.

I have updated the import to use the new syntax from the new package.