### PR TITLE
removed duplicating button for timesheets (renewed)

### DIFF
--- a/src/components/Header/components/NavButtonsRightCorner/index.jsx
+++ b/src/components/Header/components/NavButtonsRightCorner/index.jsx
@@ -50,16 +50,6 @@ const GordonNavButtonsRightCorner = ({ onClose, openDialogBox, open, anchorEl })
     />
   );
 
-  const timesheetsButton = (
-    <GordonNavButton
-      unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : null}
-      onLinkClick={onClose}
-      openUnavailableDialog={openDialogBox}
-      linkName={'Timesheets'}
-      linkPath={'/timesheets'}
-    />
-  );
-
   const helpButton = <GordonNavButton onLinkClick={onClose} linkName={'Help'} linkPath={'/help'} />;
 
   const aboutButton = (
@@ -112,7 +102,6 @@ const GordonNavButtonsRightCorner = ({ onClose, openDialogBox, open, anchorEl })
             <div class={styles.right_menu_triangle} />
             {myProfileButton}
             {linksButton}
-            {timesheetsButton}
             {helpButton}
             {aboutButton}
             {feedbackButton}


### PR DESCRIPTION
There were two duplicating Timesheets icon in Gordon 360, one on the upper bar and one that pops up when you click the upper right Navigation button. I removed the second one and left the button that shows on the upper bar remaining.