### PR TITLE
Event page header

### DIFF
--- a/src/views/Events/index.jsx
+++ b/src/views/Events/index.jsx
@@ -23,7 +23,6 @@ import Media from 'react-media';
 import gordonEvent, { EVENT_FILTERS } from 'services/event';
 import { gordonColors } from 'theme';
 import { useLocation, useNavigate } from 'react-router';
-import { NoBackpackSharp } from '@mui/icons-material';
 
 const Events = () => {
   const [open, setOpen] = useState(false);

--- a/src/views/Events/index.jsx
+++ b/src/views/Events/index.jsx
@@ -110,31 +110,31 @@ const Events = () => {
     setURLParams(!includePast, filters);
   };
 
-  /*const searchWidth = () => {
+  function searchBarLength() {
     if (width >= 1800 && width <= 1920) {
-      return 5.87;
+      return 7.19;
     } else if (width >= 1700 && width < 1800) {
-      return 6.39;
+      return 6.89;
     } else if (width >= 1600 && width < 1700) {
-      return 6.91;
+      return 6.55;
     } else if (width >= 1500 && width < 1600) {
-      return 7.43;
+      return 6.31;
     } else if (width >= 1400 && width < 1500) {
-      return 7.95;
-    } else if (width >= 1300 && width < 1400) {     //I tried to make a function to check the window size and adjust the search bar's width accordingly-I can't get it to work. I may come back to it eventually
-      return 8.47;
+      return 7.15;
+    } else if (width >= 1300 && width < 1400) {
+      return 6.76;
     } else if (width >= 1200 && width < 1300) {
-      return 8.99;
+      return 6.3;
     } else if (width >= 1100 && width < 1200) {
-      return 9.51;
+      return 6.93;
     } else if (width >= 1000 && width < 1100) {
-      return 10.03;
+      return 6.39;
     } else if (width >= 920 && width < 1000) {
-      return 10.55;
+      return 5.87;
     } else {
       return 5.87;
     }
-  };*/
+  }
 
   const setURLParams = (includePast, filters) => {
     if (includePast || filters.length > 0) {
@@ -181,21 +181,7 @@ const Events = () => {
                 <Grid container direction="row" alignItems="center">
                   <Grid item xs={4} />
                   <Grid item xs={4} align="center"></Grid>
-                  <Grid item xs={4} align="right">
-                    {/*{isAuthenticated && (
-                    <Button
-                      color="primary"
-                      style={{
-                        backgroundColor: gordonColors.primary.cyan, //this was originally where the attended cl&w button code was
-                        color: gordonColors.neutral.grayShades[50],
-                      }}
-                      variant="contained"
-                      onClick={() => navigate('/attended')}
-                    >
-                      ATTENDED CL&amp;W
-                    </Button>
-                    )}*/}
-                  </Grid>
+                  <Grid item xs={4} align="right"></Grid>
                 </Grid>
 
                 {/* Search Bar and Filters */}
@@ -212,15 +198,7 @@ const Events = () => {
                           </Grid>
                         )}
                       />
-                      {/*I tried modifying the length of the search bar so all 3 
-                      buttons can fit beside it. I thought about putting the Attended
-                      CL&W in the header like some of the other buttons, but I think
-                      it'd look better this way. The smaller screen size has all of 
-                      the buttons next to each other, so I'm going to keep that here.
-                      The xs below says 5.87 because it's the smallest number that
-                      allows the 3 buttons to be on the same line-5.87 is the lowest
-                      on 920 width, the highest I could find is 7.5 on 1920 width*/}
-                      <Grid item xs={5.87}>
+                      <Grid item xs={searchBarLength()}>
                         <TextField
                           id="search"
                           label="Search"

--- a/src/views/Events/index.jsx
+++ b/src/views/Events/index.jsx
@@ -23,6 +23,7 @@ import Media from 'react-media';
 import gordonEvent, { EVENT_FILTERS } from 'services/event';
 import { gordonColors } from 'theme';
 import { useLocation, useNavigate } from 'react-router';
+import { NoBackpackSharp } from '@mui/icons-material';
 
 const Events = () => {
   const [open, setOpen] = useState(false);
@@ -109,6 +110,32 @@ const Events = () => {
     setURLParams(!includePast, filters);
   };
 
+  /*const searchWidth = () => {
+    if (width >= 1800 && width <= 1920) {
+      return 5.87;
+    } else if (width >= 1700 && width < 1800) {
+      return 6.39;
+    } else if (width >= 1600 && width < 1700) {
+      return 6.91;
+    } else if (width >= 1500 && width < 1600) {
+      return 7.43;
+    } else if (width >= 1400 && width < 1500) {
+      return 7.95;
+    } else if (width >= 1300 && width < 1400) {     //I tried to make a function to check the window size and adjust the search bar's width accordingly-I can't get it to work. I may come back to it eventually
+      return 8.47;
+    } else if (width >= 1200 && width < 1300) {
+      return 8.99;
+    } else if (width >= 1100 && width < 1200) {
+      return 9.51;
+    } else if (width >= 1000 && width < 1100) {
+      return 10.03;
+    } else if (width >= 920 && width < 1000) {
+      return 10.55;
+    } else {
+      return 5.87;
+    }
+  };*/
+
   const setURLParams = (includePast, filters) => {
     if (includePast || filters.length > 0) {
       let url = '?';
@@ -141,19 +168,25 @@ const Events = () => {
     return (
       <Grid container justifyContent="center" spacing={6}>
         <Grid item xs={12} lg={10} xl={8}>
-          <Card style={{ padding: '0 3vw' }}>
-            <CardContent>
-              <Grid container direction="row" alignItems="center">
-                <Grid item xs={4} />
-                <Grid item xs={4} align="center">
-                  <CardHeader title={searchPageTitle} />
-                </Grid>
-                <Grid item xs={4} align="right">
-                  {isAuthenticated && (
+          <Card style={{ padding: '0 0vw' }}>
+            <CardHeader
+              title={searchPageTitle}
+              style={{
+                backgroundColor: gordonColors.primary.blue,
+                color: gordonColors.neutral.grayShades[50],
+              }}
+            />
+            <Card style={{ padding: '0 3vw' }}>
+              <CardContent>
+                <Grid container direction="row" alignItems="center">
+                  <Grid item xs={4} />
+                  <Grid item xs={4} align="center"></Grid>
+                  <Grid item xs={4} align="right">
+                    {/*{isAuthenticated && (
                     <Button
                       color="primary"
                       style={{
-                        backgroundColor: gordonColors.primary.cyan,
+                        backgroundColor: gordonColors.primary.cyan, //this was originally where the attended cl&w button code was
                         color: gordonColors.neutral.grayShades[50],
                       }}
                       variant="contained"
@@ -161,14 +194,171 @@ const Events = () => {
                     >
                       ATTENDED CL&amp;W
                     </Button>
-                  )}
+                    )}*/}
+                  </Grid>
                 </Grid>
-              </Grid>
 
-              {/* Search Bar and Filters */}
-              <Grid container spacing={2} direction="row">
-                <Grid item xs={12}>
-                  <Grid container spacing={2} alignItems="center">
+                {/* Search Bar and Filters */}
+                <Grid container spacing={2} direction="row">
+                  <Grid item xs={12}>
+                    <Grid container spacing={1.5} alignItems="center">
+                      <Media
+                        query="(min-width: 600px)"
+                        render={() => (
+                          <Grid item>
+                            <EventIcon
+                              style={{ color: gordonColors.neutral.grayShades[900], fontSize: 20 }}
+                            />
+                          </Grid>
+                        )}
+                      />
+                      {/*I tried modifying the length of the search bar so all 3 
+                      buttons can fit beside it. I thought about putting the Attended
+                      CL&W in the header like some of the other buttons, but I think
+                      it'd look better this way. The smaller screen size has all of 
+                      the buttons next to each other, so I'm going to keep that here.
+                      The xs below says 5.87 because it's the smallest number that
+                      allows the 3 buttons to be on the same line-5.87 is the lowest
+                      on 920 width, the highest I could find is 7.5 on 1920 width*/}
+                      <Grid item xs={5.87}>
+                        <TextField
+                          id="search"
+                          label="Search"
+                          type="search"
+                          variant="filled"
+                          fullWidth
+                          value={search}
+                          onChange={(event) => setSearch(event.target.value)}
+                        />
+                      </Grid>
+
+                      <Grid item>
+                        <Button color="neutral" fullWidth variant="contained" onClick={clearAll}>
+                          CLEAR ALL
+                        </Button>
+                      </Grid>
+
+                      <Grid item>
+                        <Button
+                          color={filters.length === 0 ? 'primary' : 'secondary'}
+                          variant={open ? 'contained' : 'outlined'}
+                          onClick={handleExpandClick}
+                        >
+                          <AddIcon fontSize="inherit" />
+                          Filters
+                        </Button>
+                      </Grid>
+
+                      <Grid item>
+                        {isAuthenticated && (
+                          <Button
+                            color="primary"
+                            style={{
+                              backgroundColor: gordonColors.primary.cyan,
+                              color: gordonColors.neutral.grayShades[50],
+                            }}
+                            variant="contained"
+                            onClick={() => navigate('/attended')}
+                          >
+                            ATTENDED CL&amp;W
+                          </Button>
+                        )}
+                      </Grid>
+                    </Grid>
+                  </Grid>
+
+                  <Grid item xs={12}>
+                    <Collapse in={open} timeout="auto" unmountOnExit>
+                      <Grid container spacing={2} alignItems="center">
+                        <Media
+                          query="(min-width: 600px)"
+                          render={() => (
+                            <Grid item>
+                              <FilterListIcon
+                                style={{
+                                  color: gordonColors.neutral.grayShades[900],
+                                  fontSize: 20,
+                                }}
+                              />
+                            </Grid>
+                          )}
+                        />
+                        <Grid item xs={8}>
+                          <Autocomplete
+                            id="event-filters"
+                            multiple
+                            fullWidth
+                            options={EVENT_FILTERS}
+                            onChange={(event, value) => {
+                              handleChangeFilters(value);
+                            }}
+                            filterSelectedOptions
+                            renderTags={(value, getTagProps) =>
+                              value.map((option, index) => (
+                                <Chip
+                                  label={option}
+                                  style={{
+                                    backgroundColor: gordonColors.primary.cyan,
+                                    color: gordonColors.neutral.grayShades[50],
+                                  }}
+                                  {...getTagProps({ index })}
+                                />
+                              ))
+                            }
+                            value={filters}
+                            renderInput={(param) => (
+                              <TextField {...param} variant="filled" label="Filters" />
+                            )}
+                          />
+                        </Grid>
+                        <Grid container item xs={3}>
+                          <FormControlLabel
+                            control={
+                              <Checkbox checked={includePast} onChange={handleChangeIncludePast} />
+                            }
+                            label="Include Past"
+                          />
+                        </Grid>
+                      </Grid>
+                    </Collapse>
+                  </Grid>
+                </Grid>
+              </CardContent>
+            </Card>
+          </Card>
+
+          <br />
+
+          {/* List of Events */}
+          <Grid item xs={12}>
+            {content}
+          </Grid>
+        </Grid>
+      </Grid>
+    );
+  } else if (width < 920) {
+    return (
+      <Grid container justifyContent="center" spacing={6}>
+        <Grid item xs={12} lg={10} xl={8}>
+          <Card style={{ padding: '0 0vw' }}>
+            <CardHeader
+              title={searchPageTitle}
+              style={{
+                backgroundColor: gordonColors.primary.blue,
+                color: gordonColors.neutral.grayShades[50],
+              }}
+            />
+            <Card style={{ padding: '0 3vw' }}>
+              <CardContent>
+                <Grid container direction="row" alignItems="center">
+                  <Grid item xs={4} />
+                  <Grid item xs={4} align="center"></Grid>
+                  <Grid item xs={4} align="right"></Grid>
+                </Grid>
+
+                {/* Search Bar and Filters */}
+                <Grid container spacing={2} direction="row">
+                  <Grid item xs={12} container spacing={2} alignItems="center">
                     <Media
                       query="(min-width: 600px)"
                       render={() => (
@@ -179,7 +369,7 @@ const Events = () => {
                         </Grid>
                       )}
                     />
-                    <Grid item xs={8}>
+                    <Grid item xs={11}>
                       <TextField
                         id="search"
                         label="Search"
@@ -190,9 +380,17 @@ const Events = () => {
                         onChange={(event) => setSearch(event.target.value)}
                       />
                     </Grid>
-
+                  </Grid>
+                  <Grid
+                    item
+                    xs={12}
+                    container
+                    spacing={2}
+                    justifyContent="center"
+                    alignItems="center"
+                  >
                     <Grid item>
-                      <Button color="neutral" fullWidth variant="contained" onClick={clearAll}>
+                      <Button fullWidth color="neutral" variant="contained" onClick={clearAll}>
                         CLEAR ALL
                       </Button>
                     </Grid>
@@ -207,12 +405,34 @@ const Events = () => {
                         Filters
                       </Button>
                     </Grid>
-                  </Grid>
-                  <br />
-                </Grid>
 
+                    <Grid item>
+                      {isAuthenticated && (
+                        <Button
+                          color="primary"
+                          style={{
+                            backgroundColor: gordonColors.primary.cyan,
+                            color: gordonColors.neutral.grayShades[50],
+                          }}
+                          variant="contained"
+                          onClick={() => navigate('/attended')}
+                        >
+                          ATTENDED CL&amp;W
+                        </Button>
+                      )}
+                    </Grid>
+                  </Grid>
+                </Grid>
                 <Grid item xs={12}>
                   <Collapse in={open} timeout="auto" unmountOnExit>
+                    <Grid container item justifyContent="center">
+                      <FormControlLabel
+                        control={
+                          <Checkbox checked={includePast} onChange={handleChangeIncludePast} />
+                        }
+                        label="Include Past"
+                      />
+                    </Grid>
                     <Grid container spacing={2} alignItems="center">
                       <Media
                         query="(min-width: 600px)"
@@ -224,7 +444,7 @@ const Events = () => {
                           </Grid>
                         )}
                       />
-                      <Grid item xs={8}>
+                      <Grid item xs={11}>
                         <Autocomplete
                           id="event-filters"
                           multiple
@@ -246,168 +466,18 @@ const Events = () => {
                               />
                             ))
                           }
-                          value={filters}
                           renderInput={(param) => (
                             <TextField {...param} variant="filled" label="Filters" />
                           )}
                         />
                       </Grid>
-                      <Grid container item xs={3}>
-                        <FormControlLabel
-                          control={
-                            <Checkbox checked={includePast} onChange={handleChangeIncludePast} />
-                          }
-                          label="Include Past"
-                        />
-                      </Grid>
                     </Grid>
                   </Collapse>
                 </Grid>
-              </Grid>
-            </CardContent>
+              </CardContent>
+            </Card>
           </Card>
-
           <br />
-
-          {/* List of Events */}
-          <Grid item xs={12}>
-            {content}
-          </Grid>
-        </Grid>
-      </Grid>
-    );
-  } else if (width < 920) {
-    return (
-      <Grid container justifyContent="center" spacing={6}>
-        <Grid item xs={12} lg={10} xl={8}>
-          <Card style={{ padding: '0 3vw' }}>
-            <CardContent>
-              <Grid container item xs={12} justifyContent="center">
-                <CardHeader title={searchPageTitle} />
-              </Grid>
-
-              {/* Search Bar and Filters */}
-              <Grid container spacing={2} direction="row">
-                <Grid item xs={12} container spacing={2} alignItems="center">
-                  <Media
-                    query="(min-width: 600px)"
-                    render={() => (
-                      <Grid item>
-                        <EventIcon
-                          style={{ color: gordonColors.neutral.grayShades[900], fontSize: 20 }}
-                        />
-                      </Grid>
-                    )}
-                  />
-                  <Grid item xs={11}>
-                    <TextField
-                      id="search"
-                      label="Search"
-                      type="search"
-                      variant="filled"
-                      fullWidth
-                      value={search}
-                      onChange={(event) => setSearch(event.target.value)}
-                    />
-                  </Grid>
-                </Grid>
-                <Grid
-                  item
-                  xs={12}
-                  container
-                  spacing={2}
-                  justifyContent="center"
-                  alignItems="center"
-                >
-                  <Grid item>
-                    <Button fullWidth color="neutral" variant="contained" onClick={clearAll}>
-                      CLEAR ALL
-                    </Button>
-                  </Grid>
-
-                  <Grid item>
-                    <Button
-                      color={filters.length === 0 ? 'primary' : 'secondary'}
-                      variant={open ? 'contained' : 'outlined'}
-                      onClick={handleExpandClick}
-                    >
-                      <AddIcon fontSize="inherit" />
-                      Filters
-                    </Button>
-                  </Grid>
-
-                  <Grid item>
-                    {isAuthenticated && (
-                      <Button
-                        color="primary"
-                        style={{
-                          backgroundColor: gordonColors.primary.cyan,
-                          color: gordonColors.neutral.grayShades[50],
-                        }}
-                        variant="contained"
-                        onClick={() => navigate('/attended')}
-                      >
-                        ATTENDED CL&amp;W
-                      </Button>
-                    )}
-                  </Grid>
-                </Grid>
-              </Grid>
-
-              <Grid item xs={12}>
-                <Collapse in={open} timeout="auto" unmountOnExit>
-                  <Grid container item justifyContent="center">
-                    <FormControlLabel
-                      control={
-                        <Checkbox checked={includePast} onChange={handleChangeIncludePast} />
-                      }
-                      label="Include Past"
-                    />
-                  </Grid>
-                  <Grid container spacing={2} alignItems="center">
-                    <Media
-                      query="(min-width: 600px)"
-                      render={() => (
-                        <Grid item>
-                          <FilterListIcon
-                            style={{ color: gordonColors.neutral.grayShades[900], fontSize: 20 }}
-                          />
-                        </Grid>
-                      )}
-                    />
-                    <Grid item xs={11}>
-                      <Autocomplete
-                        id="event-filters"
-                        multiple
-                        fullWidth
-                        options={EVENT_FILTERS}
-                        onChange={(event, value) => {
-                          handleChangeFilters(value);
-                        }}
-                        filterSelectedOptions
-                        renderTags={(value, getTagProps) =>
-                          value.map((option, index) => (
-                            <Chip
-                              label={option}
-                              style={{
-                                backgroundColor: gordonColors.primary.cyan,
-                                color: gordonColors.neutral.grayShades[50],
-                              }}
-                              {...getTagProps({ index })}
-                            />
-                          ))
-                        }
-                        renderInput={(param) => (
-                          <TextField {...param} variant="filled" label="Filters" />
-                        )}
-                      />
-                    </Grid>
-                  </Grid>
-                </Collapse>
-              </Grid>
-            </CardContent>
-          </Card>
-
           {/* List of Events */}
           <Grid item xs={12}>
             {content}


### PR DESCRIPTION
Added a header to the event page tab. I moved the Attended CL&W button down by the buttons by the search bar. I also added a function that checks the screen's width and accordingly modifies how long the search bar is so all of the buttons can fit beside it without overflowing to an extra row. The color of "Gordon" in the title was dark blue, so I switched it to cyan to go along with similar titles on other pages.