### PR TITLE
Add patch route to http.ts

### DIFF
--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -45,7 +45,8 @@ const post = <TResponse>(
   headers = new Headers(),
 ): Promise<TResponse> =>
   makeRequest(endpoint, 'post', JSON.stringify(body), setContentTypeJSON(headers));
-// PATCH is required to be in all caps, http services automatically capitalizes headers for post,put,get,del... but not patch
+
+// PATCH is required to be in all caps.  http services automatically capitalizes headers for post,put,get,del... but not patch.
 const patch = <TResponse>(
   endpoint: string,
   body: Object = '',

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -46,6 +46,14 @@ const post = <TResponse>(
 ): Promise<TResponse> =>
   makeRequest(endpoint, 'post', JSON.stringify(body), setContentTypeJSON(headers));
 
+const patch = <TResponse>(
+  endpoint: string,
+  body: Object = '',
+  headers = new Headers(),
+): Promise<TResponse> =>
+  makeRequest(endpoint, 'PATCH', JSON.stringify(body), setContentTypeJSON(headers));
+
+
 const del = <TResponse>(endpoint: string): Promise<TResponse> => makeRequest(endpoint, 'delete');
 
 const apiBaseURL = import.meta.env.DEV ? '/' : (import.meta.env.VITE_API_URL as string);
@@ -174,6 +182,7 @@ const httpUtils = {
   del,
   get,
   post,
+  patch,
   postImage,
   put,
   toQueryString,

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -45,7 +45,7 @@ const post = <TResponse>(
   headers = new Headers(),
 ): Promise<TResponse> =>
   makeRequest(endpoint, 'post', JSON.stringify(body), setContentTypeJSON(headers));
-
+// PATCH is required to be in all caps, http services automatically capitalizes headers for post,put,get,del... but not patch
 const patch = <TResponse>(
   endpoint: string,
   body: Object = '',
@@ -181,8 +181,8 @@ const toQueryString = (
 const httpUtils = {
   del,
   get,
-  post,
   patch,
+  post,
   postImage,
   put,
   toQueryString,


### PR DESCRIPTION
Currently all our updates use `http put` which is not correct terminology when updating elements of a resource and not the entire resource. 

This update has already been in the `recim` branch, but as the branch is not ready to be merged, it would be beneficial for the practicum students to have access to the patch route.