### PR TITLE
Fix PeopleSearch params not updating on navigation

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -40,13 +40,12 @@ const TabUrlPatterns = [
  */
 const useTabHighlight = () => {
   const location = useLocation();
-  let currentPath = location.pathname;
   const [tabIndex, setTabIndex] = useState(0);
 
   useEffect(() => {
-    const matchedIndex = TabUrlPatterns.findIndex((pattern) => pattern.test(currentPath));
+    const matchedIndex = TabUrlPatterns.findIndex((pattern) => pattern.test(location.pathname));
     setTabIndex(matchedIndex); // This won't cause an update if the new value is the same as the old value
-  }, [currentPath]);
+  }, [location.pathname]);
 
   return tabIndex;
 };

--- a/src/views/PeopleSearch/components/SearchFieldList/index.tsx
+++ b/src/views/PeopleSearch/components/SearchFieldList/index.tsx
@@ -238,12 +238,14 @@ const SearchFieldList = ({ onSearch }: Props) => {
 
       shouldReadSearchParamsFromURL.current = false;
     }
+  }, [location, initialSearchParams]);
 
-    // Read search params from URL on 'popstate' (back/forward navigation) events
+  // Read search params from URL on 'popstate' (back/forward navigation) events
+  useEffect(() => {
     const onNavigate = () => (shouldReadSearchParamsFromURL.current = true);
     window.addEventListener('popstate', onNavigate);
     return () => window.removeEventListener('popstate', onNavigate);
-  }, [location.search, initialSearchParams]);
+  }, []);
 
   const handleUpdate = (event: ChangeEvent<HTMLInputElement>) =>
     setSearchParams((sp) => ({


### PR DESCRIPTION
For posterity - somehow, the `popstate` event listener was not being triggered within `SearchFieldList` when the user navigated in history. The fix was to add the event listener within a separate useEffect that only runs on mount, rather than inside the one that runs everytime `location` from React-Router updated.

Somehow, this bug in the event listener didn't appear until the Header component called `useLocation`. We have no idea why that is the case. :shrug: