### PR TITLE
Revert "Fix PeopleSearch params not updating on navigation"

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -40,12 +40,13 @@ const TabUrlPatterns = [
  */
 const useTabHighlight = () => {
   const location = useLocation();
+  let currentPath = location.pathname;
   const [tabIndex, setTabIndex] = useState(0);
 
   useEffect(() => {
-    const matchedIndex = TabUrlPatterns.findIndex((pattern) => pattern.test(location.pathname));
+    const matchedIndex = TabUrlPatterns.findIndex((pattern) => pattern.test(currentPath));
     setTabIndex(matchedIndex); // This won't cause an update if the new value is the same as the old value
-  }, [location.pathname]);
+  }, [currentPath]);
 
   return tabIndex;
 };

--- a/src/views/PeopleSearch/components/SearchFieldList/index.tsx
+++ b/src/views/PeopleSearch/components/SearchFieldList/index.tsx
@@ -238,14 +238,12 @@ const SearchFieldList = ({ onSearch }: Props) => {
 
       shouldReadSearchParamsFromURL.current = false;
     }
-  }, [location, initialSearchParams]);
 
-  // Read search params from URL on 'popstate' (back/forward navigation) events
-  useEffect(() => {
+    // Read search params from URL on 'popstate' (back/forward navigation) events
     const onNavigate = () => (shouldReadSearchParamsFromURL.current = true);
     window.addEventListener('popstate', onNavigate);
     return () => window.removeEventListener('popstate', onNavigate);
-  }, []);
+  }, [location.search, initialSearchParams]);
 
   const handleUpdate = (event: ChangeEvent<HTMLInputElement>) =>
     setSearchParams((sp) => ({


### PR DESCRIPTION
Reverts gordon-cs/gordon-360-ui#1906

While this improves the code, it doesn't fix the "back" button going strictly between people searches.  Let's revert this, and PR 1837 (via 1905), so we can release the rest of the improvements.  Then we can work on a new fix that incorporates both of these PRs.