### PR TITLE
People Search: Read params from URL directly in event listener

### DIFF
--- a/src/views/PeopleSearch/components/SearchFieldList/index.tsx
+++ b/src/views/PeopleSearch/components/SearchFieldList/index.tsx
@@ -38,7 +38,7 @@ import {
   FaMapMarkerAlt as LocationCity,
   FaUser as Person,
 } from 'react-icons/fa';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import addressService from 'services/address';
 import { AuthGroup } from 'services/auth';
 import peopleSearchService, { Class, PeopleSearchQuery, SearchResult } from 'services/peopleSearch';
@@ -123,7 +123,6 @@ const AdvancedOptionsColumn = ({ children, ...otherProps }: { children: ReactNod
 const SearchFieldList = ({ onSearch }: Props) => {
   const { profile } = useUser();
   const navigate = useNavigate();
-  const location = useLocation();
 
   const [isStudent, isFacStaff, isAlumni] = useAuthGroups(
     AuthGroup.Student,
@@ -180,14 +179,14 @@ const SearchFieldList = ({ onSearch }: Props) => {
       await peopleSearchService.search(searchParams).then(onSearch);
 
       const newQueryString = serializeSearchParams(searchParams);
-      // If search params are new since last search, add search to navigate
-      if (location.search !== newQueryString) {
+      // If search params are new since last search, add search to history
+      if (window.location.search !== newQueryString) {
         navigate(newQueryString);
       }
 
       setLoadingSearch(false);
     }
-  }, [canSearch, searchParams, onSearch, location.search, navigate]);
+  }, [canSearch, searchParams, onSearch, navigate]);
 
   useEffect(() => {
     const loadPage = async () => {

--- a/src/views/PeopleSearch/components/SearchFieldList/index.tsx
+++ b/src/views/PeopleSearch/components/SearchFieldList/index.tsx
@@ -212,7 +212,7 @@ const SearchFieldList = ({ onSearch }: Props) => {
     };
 
     loadPage();
-  }, [isAlumni]);
+  }, []);
 
   useEffect(() => {
     const readSearchParamsFromURL = () => {

--- a/src/views/PeopleSearch/components/SearchFieldList/index.tsx
+++ b/src/views/PeopleSearch/components/SearchFieldList/index.tsx
@@ -25,7 +25,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 import {
@@ -237,8 +236,8 @@ const SearchFieldList = ({ onSearch }: Props) => {
     readSearchParamsFromURL();
 
     // Read search params from URL on 'popstate' (back/forward navigation) events
-    window.addEventListener('popstate', readSearchParamsFromURL );
-    return () => window.removeEventListener('popstate', readSearchParamsFromURL );
+    window.addEventListener('popstate', readSearchParamsFromURL);
+    return () => window.removeEventListener('popstate', readSearchParamsFromURL);
   }, [initialSearchParams]);
 
   const handleUpdate = (event: ChangeEvent<HTMLInputElement>) =>


### PR DESCRIPTION
Previously, we listened for the `popstate` event and updated a `ref` when the event happened. Simultaneously, we had a useEffect that would run whenever `location` changed, which would update the search params from the URL *if* the `ref` said to. This *almost* worked, except that, on the very first `popstate` event, the ref would not update before the `useEffect` ran, meaning we wouldn't read the params from the URL the first time that the user triggered `popstate` after `SearchFieldList` mounted.

The solution is to simply perform the update (i.e. read the params from the URL) directly inside the event listener callback. The only times we need to read the params from the URL are when the component first mounts (in case we're mounting with a paramful URL, i.e. because the user opened 360 from a deeplink), and when the `popstate` event is triggered. So there's really no need to have this indirection of a ref and a callback watching `location`, since we don't depend on the `location` but are simply reacting to the event.