### PR TITLE
Experiments with Updated Site Navigation

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -76,9 +76,6 @@
   }
 
   @media (min-width: $break-md) {
-    .menu_button {
-      display: none;
-    }
     .app_bar {
       background-image: url('./gc_seal_top_72.png');
       height: $header-height-md;

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -12,6 +12,7 @@ import GordonDialogBox from 'components/GordonDialogBox';
 import { useDocumentTitle, useNetworkStatus, useWindowSize } from 'hooks';
 import { projectName } from 'project-name';
 import { forwardRef, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
 import { NavLink, Route, Routes } from 'react-router-dom';
 import routes from 'routes';
 import { authenticate } from 'services/auth';
@@ -24,6 +25,7 @@ import styles from './Header.module.css';
 const ForwardNavLink = forwardRef((props, ref) => <NavLink innerRef={ref} {...props} />);
 
 const GordonHeader = ({ onDrawerToggle }) => {
+  const navigate = useNavigate();
   const [tabIndex, setTabIndex] = useState(0);
   const [dialog, setDialog] = useState('');
   const [width] = useWindowSize();
@@ -32,6 +34,10 @@ const GordonHeader = ({ onDrawerToggle }) => {
   const isOnline = useNetworkStatus();
   const setDocumentTitle = useDocumentTitle();
   const isAuthenticated = useIsAuthenticated();
+
+  const handleOpenProfile = () => {
+    navigate('/myprofile');
+  };
 
   /**
    * Update the tab highlight indicator based on the url
@@ -208,7 +214,7 @@ const GordonHeader = ({ onDrawerToggle }) => {
             </div>
           </div>
 
-          <GordonNavAvatarRightCorner onClick={handleOpenMenu} menuOpened={isMenuOpen} />
+          <GordonNavAvatarRightCorner onClick={handleOpenProfile} />
 
           <GordonNavButtonsRightCorner
             open={isMenuOpen}

--- a/src/components/Nav/components/NavLinks/index.jsx
+++ b/src/components/Nav/components/NavLinks/index.jsx
@@ -4,6 +4,8 @@ import HomeIcon from '@mui/icons-material/Home';
 import LocalActivityIcon from '@mui/icons-material/LocalActivity';
 import PeopleIcon from '@mui/icons-material/People';
 import WorkIcon from '@mui/icons-material/Work';
+import RememberMeIcon from '@mui/icons-material/RememberMe';
+import MapsHomeWorkIcon from '@mui/icons-material/MapsHomeWork';
 import { Divider, List } from '@mui/material';
 import GordonDialogBox from 'components/GordonDialogBox';
 import GordonNavButton from 'components/NavButton';
@@ -109,6 +111,30 @@ const GordonNavLinks = ({ onLinkClick }) => {
     />
   );
 
+  const idButton = (
+    <GordonNavButton
+      unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : null}
+      openUnavailableDialog={setDialog}
+      onLinkClick={onLinkClick}
+      linkName={'ID Cards'}
+      linkPath={'/id'}
+      LinkIcon={RememberMeIcon}
+      divider={false}
+    />
+  );
+
+  const apartAppsButton = (
+    <GordonNavButton
+      unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : null}
+      openUnavailableDialog={setDialog}
+      onLinkClick={onLinkClick}
+      linkName={'Apartment Applications'}
+      linkPath={'/apartapp'}
+      LinkIcon={MapsHomeWorkIcon}
+      divider={false}
+    />
+  );
+
   const linksButton = (
     <GordonNavButton
       unavailable={isOnline ? null : 'offline'}
@@ -175,6 +201,8 @@ const GordonNavLinks = ({ onLinkClick }) => {
         {eventsButton}
         {peopleButton}
         {timesheetsButton}
+        {idButton}
+        {apartAppsButton}
       </List>
 
       <Divider />


### PR DESCRIPTION
- Converted right side profile icon to be a link to the profile
- Added mobile side menu to all views
- Added links to id uploader and apartapps to left side menu

Header Appearance
![Screenshot from 2023-06-29 09-56-28](https://github.com/gordon-cs/gordon-360-ui/assets/115327391/9490645b-093a-41cc-b52e-10678780f4d0)

Left side nav menu appearance
![Screenshot from 2023-06-29 09-56-41](https://github.com/gordon-cs/gordon-360-ui/assets/115327391/139874cf-e899-4ead-a5f7-873b6ff9d018)

The idea going forward is to allow users to "favorite" the tabs they want to keep on the header.  This would likely be done with a star selection from the left side menu, and it would allow the selection of 4 or 5 favorite tabs, so users can customize their most used pages.  The idea for this project is to allow room to grow as more apps get added, especially with the limited real estate on the header, this seems like a natural way to fit more apps.

This is just a proof of concept, please let me know your thoughts.