### PR TITLE
changed handleUpdate to clean params when checkboxes are unchecked

### DIFF
--- a/src/views/PeopleSearch/components/SearchFieldList/index.tsx
+++ b/src/views/PeopleSearch/components/SearchFieldList/index.tsx
@@ -239,12 +239,27 @@ const SearchFieldList = ({ onSearch }: Props) => {
     return () => window.removeEventListener('popstate', readSearchParamsFromURL);
   }, [initialSearchParams]);
 
-  const handleUpdate = (event: ChangeEvent<HTMLInputElement>) =>
+  const handleUpdate = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchParams((sp) => ({
       ...sp,
       [event.target.name]:
         event.target.type === 'checkbox' ? event.target.checked : event.target.value,
     }));
+    if (event.target.name === 'includeFacStaff' && !event.target.checked) {
+      setSearchParams((sp) => ({
+        ...sp,
+        building: '',
+        department: '',
+      }));
+    } else if (event.target.name === 'includeStudent' && !event.target.checked) {
+      setSearchParams((sp) => ({
+        ...sp,
+        major: '',
+        minor: '',
+        class_year: '',
+      }));
+    }
+  };
 
   const handleEnterKeyPress = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter') {


### PR DESCRIPTION
If you had previously added parameters such as Major, Minor, or Class_Year and unchecked the student box the parameters will be cleared. This prevents a search with no results.

The same will happen for the parameters Department and Building for the faculty/Staff checkbox.

issue: https://github.com/gordon-cs/gordon-360-ui/issues/1929