### PR TITLE
Add version.json to .gitignore so placeholder file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# default version.json; overwritten during deployment
+src/views/About/version.json


### PR DESCRIPTION
The src/views/About/version.json file is overwritten during deployment, but we maintain a dummy version in the repo to keep lint happy.  The values stored in the dummy version are self-evidently not valid so it's easy to tell if deployment failed to generate the file properly.  This PR tells git to ignore the file so developers don't inadvertently overwrite the dummy file with one that has valid (but soon to be out-of-date) data.