### PR TITLE
Fix Profile Not Found link cycle problem

### DIFF
--- a/src/views/Page404/index.jsx
+++ b/src/views/Page404/index.jsx
@@ -5,17 +5,18 @@ import styles from './Page404.module.css';
 const message_line_1 = "Hmmm... We're not quite sure";
 const message_line_2 = "what you're looking for";
 
-const Page404 = () => {
+const Page404 = (props) => {
+  let messageLines = props.messages ?? [message_line_1, message_line_2]
+
   return (
     <Grid container className={styles.page404_main}>
       {/* 404 message */}
       <Grid item className={styles.page404_message}>
-        <Typography variant="h4" className={styles.page404_title}>
-          {message_line_1}
-        </Typography>
-        <Typography variant="h4" className={styles.page404_title}>
-          {message_line_2}
-        </Typography>
+        {messageLines.map((msg) =>
+          <Typography variant="h4" className={styles.page404_title}>
+            {msg}
+          </Typography>
+        )}
       </Grid>
       {/* Gordon mascot image */}
       <Grid item align="center" className={styles.page404_image}>

--- a/src/views/ProfileNotFound/index.jsx
+++ b/src/views/ProfileNotFound/index.jsx
@@ -1,14 +1,7 @@
-import { Typography, Grid } from '@mui/material';
-import styles from './ProfileNotFound.module.css';
+import Page404 from 'views/Page404';
 
 const ProfileNotFound = () => (
-  <Grid item>
-    <br />
-    <br />
-    <Typography variant="h4" align="center" className={styles.profileNotFound_title}>
-      No profile exists for this user
-    </Typography>
-  </Grid>
+  <Page404 messages={['This Profile is Unavailable']} />
 );
 
 export default ProfileNotFound;

--- a/src/views/PublicProfile/index.jsx
+++ b/src/views/PublicProfile/index.jsx
@@ -5,9 +5,9 @@ import GordonLoader from 'components/Loader';
 import Profile from 'components/Profile';
 import useNetworkStatus from 'hooks/useNetworkStatus';
 import { useEffect, useState } from 'react';
-import { Navigate } from 'react-router';
 import { useParams } from 'react-router-dom';
 import userService from 'services/user';
+import ProfileNotFound from 'views/ProfileNotFound';
 
 const PublicProfile = () => {
   const [loading, setLoading] = useState(true);
@@ -41,7 +41,7 @@ const PublicProfile = () => {
   }
 
   if ((error && error.name === 'NotFoundError') || !profile) {
-    return <Navigate to="/profilenotfound" />;
+    return <ProfileNotFound />;
   }
 
   if (loading) {


### PR DESCRIPTION
Apparently the route /profilenotfound did not exist so navigation to this route always resulted in a Page404 error.  Pressing the back button then returned to a non-existing route at which point the cycle repeated.

This fixes that problem, and allows custom message to be sent to the default 404 page, overriding the default (custom) 404 message.

I raised this issue, but Amos Cha wrote all the code changes here (thanks Amos!)