### PR TITLE
Fix alumni search no image case and no email visibility

### DIFF
--- a/src/components/Profile/components/Identification/index.jsx
+++ b/src/components/Profile/components/Identification/index.jsx
@@ -555,7 +555,7 @@ const Identification = ({ profile, myProf, isOnline, createSnackbar }) => {
 
       <div className={styles.identification_card_content}>
         {/* SHOWS THE CARD'S CONTENT IF THE GIVEN USER'S INFORMATION IS AVAILABLE. OTHERWISE A LOADER */}
-        {userProfile && (defaultUserImage || preferredUserImage) ? (
+        {userProfile ? (
           <Grid
             container
             className={styles.identification_card_content_card}
@@ -693,26 +693,28 @@ const Identification = ({ profile, myProf, isOnline, createSnackbar }) => {
                     </Typography>
                   </Grid>
                 )}
-                <Grid
-                  item
-                  xs={12}
-                  className={styles.identification_card_content_card_container_info_email}
-                >
-                  <a href={`mailto:${userProfile.Email}`}>
-                    <div
-                      className={
-                        styles.identification_card_content_card_container_info_email_container
-                      }
-                    >
-                      <EmailIcon
+                {userProfile.Email ? (
+                  <Grid
+                    item
+                    xs={12}
+                    className={styles.identification_card_content_card_container_info_email}
+                  >
+                    <a href={`mailto:${userProfile.Email}`}>
+                      <div
                         className={
-                          styles.identification_card_content_card_container_info_email_container_icon
+                          styles.identification_card_content_card_container_info_email_container
                         }
-                      />
-                      <Typography paragraph>{userProfile.Email}</Typography>
-                    </div>
-                  </a>
-                </Grid>
+                      >
+                        <EmailIcon
+                          className={
+                            styles.identification_card_content_card_container_info_email_container_icon
+                          }
+                        />
+                        <Typography paragraph>{userProfile.Email}</Typography>
+                      </div>
+                    </a>
+                  </Grid>
+                ) : null}
 
                 {isOnline && createPhotoDialogBox()}
               </Grid>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -86,15 +86,17 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
       break;
   }
 
-  const emailIcon = !isMobileView && (
-    <div className={styles.mailing_icon_container}>
-      <CardActionArea className={styles.mail_card_action}>
-        <a href={`mailto:${person.Email}`}>
-          <MailOutlineIcon className={styles.mail_outline} />
-        </a>
-      </CardActionArea>
-    </div>
-  );
+  const emailIcon = person.Email
+    ? !isMobileView && (
+        <div className={styles.mailing_icon_container}>
+          <CardActionArea className={styles.mail_card_action}>
+            <a href={`mailto:${person.Email}`}>
+              <MailOutlineIcon className={styles.mail_outline} />
+            </a>
+          </CardActionArea>
+        </div>
+      )
+    : null;
 
   return (
     <>


### PR DESCRIPTION
Removed the case for no image in identification card, we want the card to still show up even if there is no image, instead of just having a loader.
Added logic to check if a user has an email to identification card and people search result list