### PR TITLE
[Rec-IM] auto sched parameters

### DIFF
--- a/src/services/recim/series.ts
+++ b/src/services/recim/series.ts
@@ -87,7 +87,8 @@ type AutoScheduleParameters =
     }
   | {
       numberOfLadderMatches: number;
-    };
+    }
+  | null;
 
 //Series Routes
 const createSeries = async (

--- a/src/services/recim/series.ts
+++ b/src/services/recim/series.ts
@@ -81,10 +81,13 @@ export type BracketInfo = {
   IsLosers: boolean;
 };
 
-type AutoScheduleParameters = {
-  roundRobinMatchCapacity: number;
-  numberOfLadderMatches: number;
-};
+type AutoScheduleParameters =
+  | {
+      roundRobinMatchCapacity: number;
+    }
+  | {
+      numberOfLadderMatches: number;
+    };
 
 //Series Routes
 const createSeries = async (
@@ -115,7 +118,7 @@ const putSeriesSchedule = (schedule: UploadSeriesSchedule): Promise<SeriesSchedu
 const scheduleSeriesMatches = (
   seriesID: number,
   params: AutoScheduleParameters | null,
-): Promise<Match[]> => http.post(`recim/series/${seriesID}/autoschedule`, { ...params });
+): Promise<Match[]> => http.post(`recim/series/${seriesID}/autoschedule`, params);
 
 const deleteSeriesCascade = (seriesID: number): Promise<CreatedSeries> =>
   http.del(`recim/series/${seriesID}`);

--- a/src/services/recim/series.ts
+++ b/src/services/recim/series.ts
@@ -82,8 +82,8 @@ export type BracketInfo = {
 };
 
 type AutoScheduleParameters = {
-  RoundRobinMatchCapacity: number;
-  NumberOfLadderMatches: number;
+  roundRobinMatchCapacity: number;
+  numberOfLadderMatches: number;
 };
 
 //Series Routes

--- a/src/services/recim/series.ts
+++ b/src/services/recim/series.ts
@@ -81,6 +81,11 @@ export type BracketInfo = {
   IsLosers: boolean;
 };
 
+type AutoScheduleParameters = {
+  RoundRobinMatchCapacity: number;
+  NumberOfLadderMatches: number;
+};
+
 //Series Routes
 const createSeries = async (
   referenceSeriesID: number,
@@ -107,8 +112,10 @@ const getSeriesSchedule = (seriesID: number): Promise<SeriesSchedule> =>
 const putSeriesSchedule = (schedule: UploadSeriesSchedule): Promise<SeriesSchedule> =>
   http.put(`recim/series/schedule`, schedule);
 
-const scheduleSeriesMatches = (seriesID: number): Promise<Match[]> =>
-  http.post(`recim/series/${seriesID}/autoschedule`, {});
+const scheduleSeriesMatches = (
+  seriesID: number,
+  params: AutoScheduleParameters | null,
+): Promise<Match[]> => http.post(`recim/series/${seriesID}/autoschedule`, { ...params });
 
 const deleteSeriesCascade = (seriesID: number): Promise<CreatedSeries> =>
   http.del(`recim/series/${seriesID}`);

--- a/src/services/recim/series.ts
+++ b/src/services/recim/series.ts
@@ -87,8 +87,7 @@ type AutoScheduleParameters =
     }
   | {
       numberOfLadderMatches: number;
-    }
-  | null;
+    };
 
 //Series Routes
 const createSeries = async (
@@ -118,7 +117,7 @@ const putSeriesSchedule = (schedule: UploadSeriesSchedule): Promise<SeriesSchedu
 
 const scheduleSeriesMatches = (
   seriesID: number,
-  params: AutoScheduleParameters | null,
+  params: AutoScheduleParameters,
 ): Promise<Match[]> => http.post(`recim/series/${seriesID}/autoschedule`, params);
 
 const deleteSeriesCascade = (seriesID: number): Promise<CreatedSeries> =>

--- a/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
+++ b/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
@@ -165,7 +165,8 @@ const ScheduleList = ({
           {standardDate(series.StartDate, false)}, or the earliest available day, at{' '}
           {format(Date.parse(series.Schedule.StartTime), 'h:mmaaa')}.{' '}
         </Typography>
-        {parameterFields(series.Type, series.TeamStanding.length)}
+        {(series.Type === 'Round Robin' || series.Type === 'Ladder') &&
+          parameterFields(series.Type, series.TeamStanding.length)}
       </Typography>,
     );
     setOpenAutoSchedulerDisclaimer(true);

--- a/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
+++ b/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
@@ -123,31 +123,26 @@ const ScheduleList = ({
       }
     };
 
-    let parameterFields = (type, numTeams) => {
-      return (
-        <Box component="form">
-          <FormControl>
-            <TextField
-              variant="filled"
-              label="Num Matches"
-              helperText={
-                type === 'Round Robin'
-                  ? 'Max number of matches per team'
-                  : 'Number of matches total amongst teams'
-              }
-              value={autoscheduleParameters}
-              onChange={(event) => {
-                setAutoscheduleParameters(event.target.value);
-                setHasError(
-                  (event.target.value > numTeams || event.target.value < 1) && event.target.value,
-                );
-              }}
-              type="number"
-            />
-          </FormControl>
-        </Box>
-      );
-    };
+    let parameterFields = (
+      <TextField
+        variant="filled"
+        label="Num Matches"
+        helperText={
+          series.Type === 'Round Robin'
+            ? 'Max number of matches per team'
+            : 'Number of matches total amongst teams'
+        }
+        value={autoscheduleParameters}
+        onChange={(event) => {
+          setAutoscheduleParameters(event.target.value);
+          setHasError(
+            (event.target.value > series.TeamStanding.length || event.target.value < 1) &&
+              event.target.value,
+          );
+        }}
+        type="number"
+      />
+    );
 
     setDisclaimerContent(
       <Typography margin={4}>
@@ -165,8 +160,7 @@ const ScheduleList = ({
           {standardDate(series.StartDate, false)}, or the earliest available day, at{' '}
           {format(Date.parse(series.Schedule.StartTime), 'h:mmaaa')}.{' '}
         </Typography>
-        {(series.Type === 'Round Robin' || series.Type === 'Ladder') &&
-          parameterFields(series.Type, series.TeamStanding.length)}
+        {(series.Type === 'Round Robin' || series.Type === 'Ladder') && parameterFields}
       </Typography>,
     );
     setOpenAutoSchedulerDisclaimer(true);
@@ -174,7 +168,7 @@ const ScheduleList = ({
   };
 
   const handleConfirmAutoSchedule = () => {
-    let parameterLabel =
+    const parameterLabel =
       series.Type === 'Round Robin' ? 'roundRobinMatchCapacity' : 'numberOfLadderMatches';
     setLoading(true);
     scheduleSeriesMatches(series.ID, { [parameterLabel]: autoscheduleParameters }).then((res) => {

--- a/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
+++ b/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
@@ -124,38 +124,23 @@ const ScheduleList = ({
     };
 
     let parameterFields = (type, numTeams) => {
-      let textFieldParams = {};
-      switch (type) {
-        case 'Round Robin':
-          textFieldParams = {
-            label: 'Num Matches',
-            helperText: 'Max number of matches per team',
-            parameterLabel: 'roundRobinMatchCapacity',
-          };
-          break;
-        case 'Ladder':
-          textFieldParams = {
-            label: 'Num Matches',
-            helperText: 'Number of matches total amongst teams',
-            parameterLabel: 'numberOfLadderMatches',
-          };
-          break;
-        default:
-          textFieldParams = {};
-      }
       return (
         <Box component="form">
           <FormControl>
             <TextField
               variant="filled"
-              label={textFieldParams.label}
-              helperText={textFieldParams.helperText}
+              label="Num Matches"
+              helperText={
+                type === 'Round Robin'
+                  ? 'Max number of matches per team'
+                  : 'Number of matches total amongst teams'
+              }
               value={autoscheduleParameters}
               onChange={(event) => {
-                setAutoscheduleParameters({ [textFieldParams.parameterLabel]: event.target.value });
-                // known bug: if you type a number, you cant delete it without an error
-                if (event.target.value > numTeams || event.target.value < 1) setHasError(true);
-                else setHasError(false);
+                setAutoscheduleParameters(event.target.value);
+                setHasError(
+                  (event.target.value > numTeams || event.target.value < 1) && event.target.value,
+                );
               }}
               type="number"
             />
@@ -186,10 +171,13 @@ const ScheduleList = ({
     setOpenAutoSchedulerDisclaimer(true);
     closeMenusAndForms();
   };
+  console.log(autoscheduleParameters);
 
   const handleConfirmAutoSchedule = () => {
+    let parameterLabel =
+      series.Type === 'Round Robin' ? 'roundRobinMatchCapacity' : 'numberOfLadderMatches';
     setLoading(true);
-    scheduleSeriesMatches(series.ID, autoscheduleParameters).then((res) => {
+    scheduleSeriesMatches(series.ID, { [parameterLabel]: autoscheduleParameters }).then((res) => {
       setOpenAutoSchedulerDisclaimer(false);
       setAutoscheduleParameters(null);
       setReload((prev) => !prev);

--- a/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
+++ b/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
@@ -172,7 +172,6 @@ const ScheduleList = ({
     setOpenAutoSchedulerDisclaimer(true);
     closeMenusAndForms();
   };
-  console.log(autoscheduleParameters);
 
   const handleConfirmAutoSchedule = () => {
     let parameterLabel =

--- a/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
+++ b/src/views/RecIM/views/Activity/components/ScheduleList/index.jsx
@@ -37,9 +37,6 @@ import MatchForm from 'views/RecIM/components/Forms/MatchForm';
 import { useWindowSize } from 'hooks';
 import { windowBreakWidths } from 'theme';
 import { deleteMatchList } from 'services/recim/match';
-import GordonLoader from 'components/Loader';
-import { Box } from '@mui/system';
-import { FormControl } from '@mui/base';
 
 const ScheduleList = ({
   isAdmin,


### PR DESCRIPTION
Old API feature that was requested by the customer but was never implemented in the UI.
![image](https://github.com/gordon-cs/gordon-360-ui/assets/78386128/dc278f2a-373c-4353-a631-5cf66e94d9ab)

Adds use to `Round Robin Match Capacity` and `Ladder Matches` 