### PR TITLE
Fix broken public office info

### DIFF
--- a/src/components/Profile/components/OfficeInfoList/index.jsx
+++ b/src/components/Profile/components/OfficeInfoList/index.jsx
@@ -1,20 +1,14 @@
-import { useState, Fragment } from 'react';
-import { Card, CardContent, CardHeader, Grid, List, Typography, IconButton } from '@mui/material';
+import { Card, CardContent, CardHeader, Grid, List, Typography } from '@mui/material';
 import ProfileInfoListItem from '../ProfileInfoListItem';
-import { Markup } from 'interweave';
 import styles from './OfficeInfoList.module.css';
-import { gordonColors } from 'theme';
 import UpdateOffice from './UpdateOfficeLocationDialog';
 import UpdateOfficeHours from './UpdateOfficeHoursDialog';
 import UpdateMail from './UpdateMailDestinationDialog';
 import GordonTooltip from 'components/GordonTooltip';
-import user from 'services/user';
-import EditIcon from '@mui/icons-material/Edit';
 
 const OfficeInfoList = ({
   myProf,
   profile: {
-    AD_Username,
     BuildingDescription,
     OnCampusDepartment,
     OnCampusRoom,
@@ -110,23 +104,8 @@ const OfficeInfoList = ({
       }
     />
   ) : Mail_Location ? (
-    <ProfileInfoListItem title="Mailstop:" contentText={{ Mail_Location }} />
+    <ProfileInfoListItem title="Mailstop:" contentText={Mail_Location} />
   ) : null;
-
-  const updateOfficeInfo =
-    myProf && PersonType?.includes('fac') ? (
-      <Typography align="left" className={styles.note}>
-        NOTE: Update your office info{' '}
-        <a
-          href="https://go.gordon.edu/general/myaccount.cfm"
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: gordonColors.primary.blue }}
-        >
-          here
-        </a>
-      </Typography>
-    ) : null;
 
   return (
     <Grid item xs={12} lg={12}>

--- a/src/components/Profile/components/OfficeInfoList/index.jsx
+++ b/src/components/Profile/components/OfficeInfoList/index.jsx
@@ -63,7 +63,7 @@ const OfficeInfoList = ({
       }
     />
   ) : office_hours ? (
-    <ProfileInfoListItem title="Office Hours:" contentText={`${office_hours}`} />
+    <ProfileInfoListItem title="Office Hours:" contentText={office_hours} />
   ) : null;
 
   const room = myProf ? (
@@ -83,7 +83,7 @@ const OfficeInfoList = ({
       }
     />
   ) : BuildingDescription || OnCampusRoom ? (
-    <ProfileInfoListItem title="Room:" contentText={({ BuildingDescription }, { OnCampusRoom })} />
+    <ProfileInfoListItem title="Room:" contentText={`${BuildingDescription}, ${OnCampusRoom}`} />
   ) : null;
 
   const mailstop = myProf ? (


### PR DESCRIPTION
The public profile of any user with Office Info is currently broken in develop because the code is passing an object as a React child. The fix is to pass strings instead.

I also fixed all the linting warnings because of unused code and imports.