### PR TITLE
Header highlight fix for RecIM

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -35,6 +35,7 @@ const TabUrlPatterns = [
   /^\/events\/?$/,
   /^\/people$|^\/myprofile|^\/profile/,
   /^\/timesheets$/,
+  /^\/recim$/,
 ];
 
 /**


### PR DESCRIPTION
On the header of Gordon 360, the tab for  RecIM would not highlight when user is using RecIM so it was fixed