### PR TITLE
[Rec-IM] Ladder Match Page

### DIFF
--- a/src/views/RecIM/components/List/Listing/Listing.module.scss
+++ b/src/views/RecIM/components/List/Listing/Listing.module.scss
@@ -166,10 +166,6 @@
   color: $neutral-white;
 }
 
-// :global(.MuiCardHeader-root).cardHeader {
-//   padding: 0.7em 16px;
-// }
-
 @media (min-width: $break-xs) {
   .rightAlignLarge {
     text-align: right;

--- a/src/views/RecIM/components/List/Listing/Listing.module.scss
+++ b/src/views/RecIM/components/List/Listing/Listing.module.scss
@@ -161,6 +161,15 @@
   order: -1;
 }
 
+.cardHeaderSecondary {
+  background-color: var(--mui-palette-primary-700);
+  color: $neutral-white;
+}
+
+// :global(.MuiCardHeader-root).cardHeader {
+//   padding: 0.7em 16px;
+// }
+
 @media (min-width: $break-xs) {
   .rightAlignLarge {
     text-align: right;

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -113,8 +113,46 @@ const ActivityListing = ({ activity }) => {
   );
 };
 
-const ExpandableTeamListing = ({ team, teamScores, attendance }) => {
-  return null;
+const ExpandableTeamListing = ({ team, teamScore, attendance }) => {
+  const log = () => {
+    console.log('');
+    console.log(team);
+    console.log(teamScore);
+    console.log(attendance);
+    console.log('');
+  };
+
+  let content = (
+    <ListItemButton onClick={() => log()}>
+      <ListItemAvatar>
+        <Avatar src={team.Logo ?? defaultLogo} className={styles.teamLogo}></Avatar>
+      </ListItemAvatar>
+      <Grid container columnSpacing={2}>
+        <Grid item xs={12}>
+          <Typography className={styles.listingTitle}>{team.Name}</Typography>
+        </Grid>
+
+        <Grid item container>
+          <Grid item xs={6}>
+            <Typography className={styles.listingSubtitle}>Score: {teamScore.TeamScore}</Typography>
+          </Grid>
+          <Grid item xs={6}>
+            <Typography className={styles.listingSubtitle}>Status: {team.Status}</Typography>
+          </Grid>
+          <Grid item xs={6}>
+            <Typography className={styles.listingSubtitle}>
+              Sportsmanship: {teamScore.SportsmanshipScore}
+            </Typography>
+          </Grid>
+        </Grid>
+      </Grid>
+    </ListItemButton>
+  );
+  return (
+    <ListItem key={team.ID} className={styles.listingWrapper}>
+      {content}
+    </ListItem>
+  );
 };
 
 const TeamListing = ({ team, invite, match, setTargetTeamID, callbackFunction }) => {

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -12,12 +12,16 @@ import {
   MenuItem,
   Checkbox,
   FormControlLabel,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from '@mui/material';
 import styles from './Listing.module.css';
 import { Link, useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import user from 'services/user';
 import { isPast } from 'date-fns';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import EventAvailableIcon from '@mui/icons-material/EventAvailable';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import ClearIcon from '@mui/icons-material/Clear';
@@ -113,7 +117,7 @@ const ActivityListing = ({ activity }) => {
   );
 };
 
-const ExpandableTeamListing = ({ team, teamScore, attendance, activityID }) => {
+const ExpandableTeamListing = ({ team, teamScore, attendance }) => {
   const log = () => {
     console.log('');
     console.log(team);
@@ -121,28 +125,25 @@ const ExpandableTeamListing = ({ team, teamScore, attendance, activityID }) => {
     console.log(attendance);
     console.log('');
   };
+  console.log(team);
 
   let content = (
-    <ListItemButton className={styles.listing} onClick={() => log()}>
+    <ListItem>
       <Typography className={styles.listingTitle} paddingRight={2}>
-        {team.ranking}
+        #{team.Ranking}
       </Typography>
-
       <ListItemAvatar>
         <Avatar src={team.Logo ?? defaultLogo} className={styles.teamLogo}></Avatar>
       </ListItemAvatar>
-      <Grid container columnSpacing={2}>
+      <Grid container columnSpacing={0}>
         <Grid item xs={8}>
-          <Typography className={styles.listingTitle}>{team.Name}</Typography>
+          <Link to={`/recim/activity/${team.ActivityID}/team/${team.ID}`}>
+            <Typography className={`${styles.listingTitle} gc360_text_link`}>
+              {team.Name}
+            </Typography>
+          </Link>
         </Grid>
-        <Grid
-          item
-          container
-          direction="row"
-          textAlign="right"
-          justifyContent="space-between"
-          xs={4}
-        >
+        <Grid item container direction="row" textAlign="right" justifyContent="space-evenly" xs={4}>
           <Grid item xs={9}>
             <Typography>Score: </Typography>
           </Grid>
@@ -158,12 +159,26 @@ const ExpandableTeamListing = ({ team, teamScore, attendance, activityID }) => {
           </Grid>
         </Grid>
       </Grid>
-    </ListItemButton>
+    </ListItem>
   );
   return (
-    <ListItem key={team.ID} className={styles.listingWrapper}>
-      {content}
-    </ListItem>
+    <Accordion disableGutters className={styles.listingWrapper}>
+      <AccordionSummary
+        justifyContent="center"
+        alignItems="center"
+        expandIcon={<ExpandMoreIcon />}
+        //sx={{ padding: 0 }}
+      >
+        {/* <ListItem
+          key={team.ID}
+          //className={styles.listingWrapper}
+        > */}
+        {content}
+        {/* </ListItem> */}
+      </AccordionSummary>
+
+      <AccordionDetails>participant list</AccordionDetails>
+    </Accordion>
   );
 };
 

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -344,6 +344,7 @@ const ParticipantListing = ({
   teamID,
   matchID,
   makeNewCaptain,
+  isMobile,
 }) => {
   const { teamID: teamIDParam, activityID } = useParams(); // for use by team page roster
   const [avatar, setAvatar] = useState();
@@ -452,10 +453,11 @@ const ParticipantListing = ({
         <ListItemAvatar>
           <Avatar
             src={`data:image/jpg;base64,${avatar}`}
-            className={minimal ? styles.avatarSmall : styles.avatar}
+            className={minimal || isMobile ? styles.avatarSmall : styles.avatar}
             variant="rounded"
-          ></Avatar>
+          />
         </ListItemAvatar>
+
         <ListItemText primary={fullName} secondary={participant.Role} />
       </>
     );
@@ -487,8 +489,9 @@ const ParticipantListing = ({
             {withAttendance && (
               <>
                 {isAdmin && (
-                  <Typography className={styles.listingSubtitle}>
-                    attended {attendanceCount} match{attendanceCount !== 1 && `es`}
+                  <Typography className={styles.listingSubtitle} textAlign="right">
+                    att{!isMobile && 'ended'}: {attendanceCount} {!isMobile && 'match'}
+                    {attendanceCount !== 1 && !isMobile && `es`}
                   </Typography>
                 )}
                 <FormControlLabel
@@ -501,7 +504,7 @@ const ParticipantListing = ({
                       disabled={!isAdmin}
                     />
                   }
-                  label={didAttend ? 'Present' : <i>Absent</i>}
+                  label={!isMobile && (didAttend ? 'Present' : <i>Absent</i>)}
                   labelPlacement="start"
                   className={!didAttend && styles.listingSubtitle}
                 />

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -135,27 +135,35 @@ const ExpandableTeamListing = ({ team, teamScore, attendance }) => {
       <ListItemAvatar>
         <Avatar src={team.Logo ?? defaultLogo} className={styles.teamLogo}></Avatar>
       </ListItemAvatar>
-      <Grid container columnSpacing={0}>
-        <Grid item xs={8}>
-          <Link to={`/recim/activity/${team.ActivityID}/team/${team.ID}`}>
-            <Typography className={`${styles.listingTitle} gc360_text_link`}>
-              {team.Name}
-            </Typography>
-          </Link>
-        </Grid>
-        <Grid item container direction="row" textAlign="right" justifyContent="space-evenly" xs={4}>
-          <Grid item xs={9}>
-            <Typography>Score: </Typography>
+      <Grid container>
+        <Grid item container xs={8}>
+          <Grid item xs={12}>
+            <Link to={`/recim/activity/${team.ActivityID}/team/${team.ID}`}>
+              <Typography className={`${styles.listingTitle} gc360_text_link`}>
+                {team.Name}
+              </Typography>
+            </Link>
           </Grid>
-          <Grid item xs={2}>
-            <Typography className={styles.listingTitle}>{teamScore.TeamScore}</Typography>
-          </Grid>
-        </Grid>
-        <Grid item container>
-          <Grid item xs={6}>
+          <Grid item xs={12}>
             <Typography className={styles.listingSubtitle}>
               Sportsmanship: {teamScore.SportsmanshipScore}
             </Typography>
+          </Grid>
+        </Grid>
+        <Grid
+          item
+          container
+          direction="row"
+          textAlign="right"
+          justifyContent="space-around"
+          alignItems="center"
+          xs={4}
+        >
+          <Grid item xs={11}>
+            <Typography className={styles.listingTitle}>{teamScore.TeamScore}</Typography>
+          </Grid>
+          <Grid item xs={1}>
+            <Typography>pts</Typography>
           </Grid>
         </Grid>
       </Grid>

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -113,6 +113,10 @@ const ActivityListing = ({ activity }) => {
   );
 };
 
+const ExpandableTeamListing = ({ team, teamScores, attendance }) => {
+  return null;
+};
+
 const TeamListing = ({ team, invite, match, setTargetTeamID, callbackFunction }) => {
   if (!team && !match) return null;
 
@@ -797,6 +801,7 @@ const SurfaceListing = ({ surface, confirmDelete, editDetails }) => {
 
 export {
   ActivityListing,
+  ExpandableTeamListing,
   TeamListing,
   ParticipantListing,
   MatchListing,

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -15,6 +15,9 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Card,
+  CardHeader,
+  CardContent,
 } from '@mui/material';
 import styles from './Listing.module.css';
 import { Link, useParams } from 'react-router-dom';
@@ -35,6 +38,7 @@ import SportsCricketIcon from '@mui/icons-material/SportsCricket';
 import LocalActivityIcon from '@mui/icons-material/LocalActivity';
 import { standardDate, formatDateTimeRange } from '../../Helpers';
 import defaultLogo from 'views/RecIM/recim_logo.png';
+import { ParticipantList } from '..';
 
 const activityTypeIconPair = [
   {
@@ -117,16 +121,7 @@ const ActivityListing = ({ activity }) => {
   );
 };
 
-const ExpandableTeamListing = ({ team, teamScore, attendance }) => {
-  const log = () => {
-    console.log('');
-    console.log(team);
-    console.log(teamScore);
-    console.log(attendance);
-    console.log('');
-  };
-  console.log(team);
-
+const ExpandableTeamListing = ({ team, teamScore, attendance, isAdmin }) => {
   let content = (
     <ListItem>
       <Typography className={styles.listingTitle} paddingRight={2}>
@@ -169,23 +164,32 @@ const ExpandableTeamListing = ({ team, teamScore, attendance }) => {
       </Grid>
     </ListItem>
   );
+
   return (
     <Accordion disableGutters className={styles.listingWrapper}>
-      <AccordionSummary
-        justifyContent="center"
-        alignItems="center"
-        expandIcon={<ExpandMoreIcon />}
-        //sx={{ padding: 0 }}
-      >
-        {/* <ListItem
-          key={team.ID}
-          //className={styles.listingWrapper}
-        > */}
+      <AccordionSummary justifyContent="center" alignItems="center" expandIcon={<ExpandMoreIcon />}>
         {content}
-        {/* </ListItem> */}
       </AccordionSummary>
 
-      <AccordionDetails>participant list</AccordionDetails>
+      <AccordionDetails>
+        <Card>
+          <CardHeader
+            title="Participants"
+            className={styles.cardHeaderSecondary}
+            titleTypographyProps={{ variant: 'h7' }}
+          />
+          <CardContent>
+            <ParticipantList
+              participants={team.Participant}
+              withAttendance
+              attendance={attendance.Attendance}
+              matchID={teamScore.MatchID}
+              teamID={team.ID}
+              isAdmin={isAdmin}
+            />
+          </CardContent>
+        </Card>
+      </AccordionDetails>
     </Accordion>
   );
 };

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -167,7 +167,12 @@ const ExpandableTeamListing = ({ team, teamScore, attendance, isAdmin }) => {
 
   return (
     <Accordion disableGutters className={styles.listingWrapper}>
-      <AccordionSummary justifyContent="center" alignItems="center" expandIcon={<ExpandMoreIcon />}>
+      <AccordionSummary
+        sx={{ paddingLeft: 0 }}
+        justifyContent="center"
+        alignItems="center"
+        expandIcon={<ExpandMoreIcon />}
+      >
         {content}
       </AccordionSummary>
 

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -113,7 +113,7 @@ const ActivityListing = ({ activity }) => {
   );
 };
 
-const ExpandableTeamListing = ({ team, teamScore, attendance }) => {
+const ExpandableTeamListing = ({ team, teamScore, attendance, activityID }) => {
   const log = () => {
     console.log('');
     console.log(team);
@@ -123,22 +123,34 @@ const ExpandableTeamListing = ({ team, teamScore, attendance }) => {
   };
 
   let content = (
-    <ListItemButton onClick={() => log()}>
+    <ListItemButton className={styles.listing} onClick={() => log()}>
+      <Typography className={styles.listingTitle} paddingRight={2}>
+        {team.ranking}
+      </Typography>
+
       <ListItemAvatar>
         <Avatar src={team.Logo ?? defaultLogo} className={styles.teamLogo}></Avatar>
       </ListItemAvatar>
       <Grid container columnSpacing={2}>
-        <Grid item xs={12}>
+        <Grid item xs={8}>
           <Typography className={styles.listingTitle}>{team.Name}</Typography>
         </Grid>
-
+        <Grid
+          item
+          container
+          direction="row"
+          textAlign="right"
+          justifyContent="space-between"
+          xs={4}
+        >
+          <Grid item xs={9}>
+            <Typography>Score: </Typography>
+          </Grid>
+          <Grid item xs={2}>
+            <Typography className={styles.listingTitle}>{teamScore.TeamScore}</Typography>
+          </Grid>
+        </Grid>
         <Grid item container>
-          <Grid item xs={6}>
-            <Typography className={styles.listingSubtitle}>Score: {teamScore.TeamScore}</Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography className={styles.listingSubtitle}>Status: {team.Status}</Typography>
-          </Grid>
           <Grid item xs={6}>
             <Typography className={styles.listingSubtitle}>
               Sportsmanship: {teamScore.SportsmanshipScore}

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -209,6 +209,14 @@ const MatchHistoryList = ({ matches, activityID }) => {
   );
 };
 
+/**
+ * Currently used in Match page to render multiple
+ * Teams that can expand into participantLists
+ */
+const ExpandableTeamList = ({ teams, teamScores }) => {
+  return null;
+};
+
 // setTargetTeamID is used for edit Match teams
 const TeamList = ({
   participant,
@@ -316,6 +324,7 @@ export {
   ParticipantList,
   MatchList,
   MatchHistoryList,
+  ExpandableTeamList,
   TeamList,
   SurfaceList,
   SportList,

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -198,8 +198,7 @@ const MatchList = ({ matches = [], activityID }) => {
 };
 
 const MatchHistoryList = ({ matches, activityID }) => {
-  console.log(matches);
-  return matches.length > 0 ? (
+  return matches?.length > 0 ? (
     <List dense>
       {matches.map((match) => (
         <MatchHistoryListing key={match?.MatchID} match={match} activityID={activityID} />

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -8,6 +8,7 @@ import {
   TeamListing,
   SportListing,
   MatchHistoryListing,
+  ExpandableTeamListing,
 } from './Listing';
 import { useNavigate } from 'react-router-dom';
 import styles from './List.module.css';
@@ -46,7 +47,6 @@ const ParticipantList = ({
   // callback to remove current captain
   const promoteNewCaptain = async (newCaptainUsername) => {
     let currentCaptain = participants.find((p) => p.Role === 'Team-captain/Creator').Username;
-    console.log(currentCaptain, newCaptainUsername);
     await editTeamParticipant(teamID, { Username: newCaptainUsername, RoleTypeID: 5 }); //captain
     await editTeamParticipant(teamID, { Username: currentCaptain, RoleTypeID: 3 }); //member
     callbackFunction((r) => !r);
@@ -214,7 +214,26 @@ const MatchHistoryList = ({ matches, activityID }) => {
  * Teams that can expand into participantLists
  */
 const ExpandableTeamList = ({ teams, teamScores, attendance }) => {
-  return null;
+  // console.log('');
+  // console.log(teams);
+  // console.log(teamScores);
+  // console.log(attendance);
+  // console.log('');
+
+  if (!teams?.length)
+    return <Typography className={styles.secondaryText}>No teams to show.</Typography>;
+
+  return (
+    <List dense>
+      {teams.map((team) => (
+        <ExpandableTeamListing
+          team={team}
+          teamScore={teamScores.find((score) => score.TeamID === team.ID)}
+          attendance={attendance.find((att) => att.TeamID === team.ID)}
+        />
+      ))}
+    </List>
+  );
 };
 
 // setTargetTeamID is used for edit Match teams

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -214,18 +214,14 @@ const MatchHistoryList = ({ matches, activityID }) => {
  * Teams that can expand into participantLists
  */
 const ExpandableTeamList = ({ teams, teamScores, attendance, activityID }) => {
-  // console.log('');
-  // console.log(teams);
-  // console.log(teamScores);
-  // console.log(attendance);
-  // console.log('');
-
   if (!teams?.length)
     return <Typography className={styles.secondaryText}>No teams to show.</Typography>;
 
   /**
    * sort by score then by sportsmanship
    */
+  let formattedTeams = [];
+
   teams.sort((a, b) => {
     let aScore = teamScores.find((ts) => ts.TeamID === a.ID);
     let bScore = teamScores.find((ts) => ts.TeamID === b.ID);
@@ -234,10 +230,21 @@ const ExpandableTeamList = ({ teams, teamScores, attendance, activityID }) => {
       if (aScore.SportsmanshipScore > bScore.SportsmanshipScore) return -1;
     return 1;
   });
+  let ranking = 1;
+  teams.forEach((team) => {
+    formattedTeams.push({
+      ...team,
+      ...{
+        Ranking: ranking,
+        ActivityID: activityID,
+      },
+    });
+    ranking++;
+  });
 
   return (
     <List dense>
-      {teams.map((team) => (
+      {formattedTeams.map((team) => (
         <ExpandableTeamListing
           key={team.ID}
           team={team}

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -10,7 +10,7 @@ import {
   MatchHistoryListing,
   ExpandableTeamListing,
 } from './Listing';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import styles from './List.module.css';
 import { getFullDate, standardDate } from '../Helpers';
 import { TabPanel } from '../TabPanel';
@@ -213,7 +213,7 @@ const MatchHistoryList = ({ matches, activityID }) => {
  * Currently used in Match page to render multiple
  * Teams that can expand into participantLists
  */
-const ExpandableTeamList = ({ teams, teamScores, attendance }) => {
+const ExpandableTeamList = ({ teams, teamScores, attendance, activityID }) => {
   // console.log('');
   // console.log(teams);
   // console.log(teamScores);
@@ -223,10 +223,23 @@ const ExpandableTeamList = ({ teams, teamScores, attendance }) => {
   if (!teams?.length)
     return <Typography className={styles.secondaryText}>No teams to show.</Typography>;
 
+  /**
+   * sort by score then by sportsmanship
+   */
+  teams.sort((a, b) => {
+    let aScore = teamScores.find((ts) => ts.TeamID === a.ID);
+    let bScore = teamScores.find((ts) => ts.TeamID === b.ID);
+    if (aScore.TeamScore > bScore.TeamScore) return -1;
+    if (aScore.TeamScore === bScore.TeamScore)
+      if (aScore.SportsmanshipScore > bScore.SportsmanshipScore) return -1;
+    return 1;
+  });
+
   return (
     <List dense>
       {teams.map((team) => (
         <ExpandableTeamListing
+          key={team.ID}
           team={team}
           teamScore={teamScores.find((score) => score.TeamID === team.ID)}
           attendance={attendance.find((att) => att.TeamID === team.ID)}

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -10,12 +10,13 @@ import {
   MatchHistoryListing,
   ExpandableTeamListing,
 } from './Listing';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styles from './List.module.css';
 import { getFullDate, standardDate } from '../Helpers';
 import { TabPanel } from '../TabPanel';
 import { addDays } from 'date-fns';
 import { editTeamParticipant, respondToTeamInvite } from 'services/recim/team';
+import { useMediaQuery } from '@mui/material';
 
 const ActivityList = ({ activities, showActivityOptions }) => {
   if (!activities?.length)
@@ -44,6 +45,8 @@ const ParticipantList = ({
   showInactive,
   callbackFunction,
 }) => {
+  const isMobile = useMediaQuery('(max-width:600px)');
+  console.log(isMobile);
   // callback to remove current captain
   const promoteNewCaptain = async (newCaptainUsername) => {
     let currentCaptain = participants.find((p) => p.Role === 'Team-captain/Creator').Username;
@@ -78,6 +81,7 @@ const ParticipantList = ({
           participant.Role !== 'Team-captain/Creator' &&
           participant.Role !== 'Requested Join' // don't promote people who haven't joined
         }
+        isMobile={isMobile}
       />
     );
   });

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -213,7 +213,7 @@ const MatchHistoryList = ({ matches, activityID }) => {
  * Currently used in Match page to render multiple
  * Teams that can expand into participantLists
  */
-const ExpandableTeamList = ({ teams, teamScores, attendance, activityID }) => {
+const ExpandableTeamList = ({ teams, teamScores, attendance, activityID, isAdmin }) => {
   if (!teams?.length)
     return <Typography className={styles.secondaryText}>No teams to show.</Typography>;
 
@@ -250,6 +250,7 @@ const ExpandableTeamList = ({ teams, teamScores, attendance, activityID }) => {
           team={team}
           teamScore={teamScores.find((score) => score.TeamID === team.ID)}
           attendance={attendance.find((att) => att.TeamID === team.ID)}
+          isAdmin={isAdmin}
         />
       ))}
     </List>

--- a/src/views/RecIM/components/List/index.jsx
+++ b/src/views/RecIM/components/List/index.jsx
@@ -213,7 +213,7 @@ const MatchHistoryList = ({ matches, activityID }) => {
  * Currently used in Match page to render multiple
  * Teams that can expand into participantLists
  */
-const ExpandableTeamList = ({ teams, teamScores }) => {
+const ExpandableTeamList = ({ teams, teamScores, attendance }) => {
   return null;
 };
 

--- a/src/views/RecIM/views/Match/index.jsx
+++ b/src/views/RecIM/views/Match/index.jsx
@@ -16,7 +16,7 @@ import GordonUnauthenticated from 'components/GordonUnauthenticated';
 import GordonSnackbar from 'components/Snackbar';
 import Header from '../../components/Header';
 import styles from './Match.module.css';
-import { MatchHistoryList, ParticipantList } from './../../components/List';
+import { ExpandableTeamList, MatchHistoryList, ParticipantList } from './../../components/List';
 import { getParticipantByUsername } from 'services/recim/participant';
 import {
   getMatchByID,
@@ -434,17 +434,12 @@ const Match = () => {
           )}
           {isMultiTeamMatch && (
             <Grid item xs={12}>
-              <RosterCard
-                participants={match.Team[0]?.Participant}
-                teamName={match.Team[0]?.Name}
-                withAttendance
-                attendance={
-                  matchAttendance?.find((item) => item.TeamID === match.Team[0]?.ID)?.Attendance
-                }
-                isAdmin={user?.IsAdmin}
-                matchID={match.ID}
-                teamID={match.Team[0]?.ID}
-              />
+              <Card>
+                <CardHeader title="Teams" className={styles.cardHeader} />
+                <CardContent>
+                  <ExpandableTeamList teams={match?.Teams} teamScores={match?.Scores} />
+                </CardContent>
+              </Card>
             </Grid>
           )}
 

--- a/src/views/RecIM/views/Match/index.jsx
+++ b/src/views/RecIM/views/Match/index.jsx
@@ -76,7 +76,6 @@ const Match = () => {
   const openMenu = Boolean(anchorEl);
   const isMultiTeamMatch = match?.Scores.length > 2;
 
-  //console.log(match);
   const createSnackbar = useCallback((message, severity) => {
     setSnackbar({ message, severity, open: true });
   }, []);
@@ -113,7 +112,6 @@ const Match = () => {
       setCurrentWinner(winner);
     }
   }, [match]);
-  console.log(match);
 
   useEffect(() => {
     const loadMatch = async () => {
@@ -375,7 +373,7 @@ const Match = () => {
     );
 
     if (loading) return <GordonLoader />;
-    // console.log(match);
+
     return (
       <>
         <Header match={match}>{headerContents}</Header>
@@ -437,7 +435,11 @@ const Match = () => {
               <Card>
                 <CardHeader title="Teams" className={styles.cardHeader} />
                 <CardContent>
-                  <ExpandableTeamList teams={match?.Teams} teamScores={match?.Scores} />
+                  <ExpandableTeamList
+                    teams={match?.Team}
+                    teamScores={match?.Scores}
+                    attendance={matchAttendance}
+                  />
                 </CardContent>
               </Card>
             </Grid>

--- a/src/views/RecIM/views/Match/index.jsx
+++ b/src/views/RecIM/views/Match/index.jsx
@@ -153,20 +153,20 @@ const Match = () => {
     // The user is not logged in
     return <GordonUnauthenticated feature={'the Rec-IM page'} />;
   } else {
-    let headerContents =
-      match?.Scores.length <= 2 ? (
-        <Grid container direction="column" className={styles.header}>
-          {/* match time/location */}
-          <Grid item container spacing={4}>
-            <Grid item xs={6} textAlign="right">
-              <Typography className={styles.subtitle}>
-                {match && standardDate(match.StartTime, true)}
-              </Typography>
-            </Grid>
-            <Grid item xs={6} textAlign="left">
-              <Typography className={styles.subtitle}>@{match?.Surface}</Typography>
-            </Grid>
+    let headerContents = (
+      <Grid container direction="column" className={styles.header}>
+        {/* match time/location */}
+        <Grid item container spacing={4}>
+          <Grid item xs={6} textAlign="right">
+            <Typography className={styles.subtitle}>
+              {match && standardDate(match.StartTime, true)}
+            </Typography>
           </Grid>
+          <Grid item xs={6} textAlign="left">
+            <Typography className={styles.subtitle}>@{match?.Surface}</Typography>
+          </Grid>
+        </Grid>
+        {match?.Scores.length <= 2 ? (
           <Grid
             item
             container
@@ -289,34 +289,45 @@ const Match = () => {
               </Grid>
             </Grid>
           </Grid>
-        </Grid>
-      ) : (
-        <Grid container direction="column" className={styles.header}>
-          <Grid item container alignItems="center" spacing={1} flexWrap="nowrap">
+        ) : (
+          <Grid
+            item
+            container
+            alignItems="center"
+            justifyContent="space-between"
+            spacing={1}
+            flexWrap="nowrap"
+          >
             <Grid
               item
               container
-              xs={5}
+              xs={1.5}
+              sm={5}
               columnSpacing={2}
               className={`${styles.teamInfo} ${styles.teamInfoRight}`}
             >
-              <Grid item sm={4} lg="auto" className={styles.headerImgContainer}>
+              <Grid item xs={4} lg="auto" className={styles.headerImgContainer}>
                 <img
-                  src={match?.Activity.Logo ?? defaultLogo}
-                  alt="Activity Icon"
+                  src={
+                    (match?.Status === 'Completed' ? currentWinner?.Logo : match?.Activity.Logo) ??
+                    defaultLogo
+                  }
+                  alt="Icon"
                   className={styles.headerImg}
                 ></img>
               </Grid>
-              <Grid item sm={8} lg="auto">
-                <LinkRouter to={`/recim/activity/${match?.Activity.ID}`}>
-                  <Typography variant="h5" className={`${styles.teamName} gc360_text_link`}>
-                    {match?.Activity.Name}
-                  </Typography>
-                </LinkRouter>
-              </Grid>
+              {match?.Status !== 'Completed' && (
+                <Grid item xs={8} lg="auto">
+                  <LinkRouter to={`/recim/activity/${match?.Activity.ID}`}>
+                    <Typography variant="h5" className={`${styles.teamName} gc360_text_link`}>
+                      {match?.Activity.Name}
+                    </Typography>
+                  </LinkRouter>
+                </Grid>
+              )}
             </Grid>
 
-            <Grid item container xs={2} alignItems="center" direction="column" sx={{ mt: 3 }}>
+            <Grid item container xs={3.5} alignItems="center" direction="column" sx={{ mt: 3 }}>
               {match?.Status === 'Completed' && (
                 <Grid item>
                   <Typography className={styles.subtitle}>Final</Typography>
@@ -357,8 +368,9 @@ const Match = () => {
               </IconButton>
             </Grid>
           </Grid>
-        </Grid>
-      );
+        )}
+      </Grid>
+    );
     // console.log(match);
     return (
       <>

--- a/src/views/RecIM/views/Match/index.jsx
+++ b/src/views/RecIM/views/Match/index.jsx
@@ -371,13 +371,10 @@ const Match = () => {
         )}
       </Grid>
     );
-    // console.log(match);
-    return (
-      <>
-        <Header match={match}>{headerContents}</Header>
-        {loading ? (
-          <GordonLoader />
-        ) : (
+
+    const content = () => {
+      if (match?.Scores.length <= 2)
+        return (
           <Grid container spacing={2}>
             <Grid item xs={12} md={6}>
               <RosterCard
@@ -506,7 +503,18 @@ const Match = () => {
               <Typography variant="body1">This action cannot be undone.</Typography>
             </GordonDialogBox>
           </Grid>
-        )}
+        );
+      else {
+        return <GordonLoader />;
+      }
+    };
+
+    if (loading) return <GordonLoader />;
+    // console.log(match);
+    return (
+      <>
+        <Header match={match}>{headerContents}</Header>
+        {content()}
         <GordonSnackbar
           open={snackbar.open}
           text={snackbar.message}

--- a/src/views/RecIM/views/Match/index.jsx
+++ b/src/views/RecIM/views/Match/index.jsx
@@ -103,10 +103,10 @@ const Match = () => {
     }
 
     if (match?.Scores.length > 0) {
-      let winnerID = match.Scores.sort(function (a, b) {
+      let winnerID = match.Scores.sort((a, b) => {
         let x = a['TeamScore'];
         let y = b['TeamScore'];
-        return x < y ? -1 : x > y ? 1 : 0;
+        return x > y ? -1 : 1;
       })[0].TeamID;
       let winner = match.Team.find((t) => t.ID === winnerID);
       setCurrentWinner(winner);
@@ -298,6 +298,9 @@ const Match = () => {
             spacing={1}
             flexWrap="nowrap"
           >
+            {/**
+             * MULTI TEAM MATCH HEADER
+             */}
             <Grid
               item
               container
@@ -327,13 +330,12 @@ const Match = () => {
               )}
             </Grid>
 
-            <Grid item container xs={3.5} alignItems="center" direction="column" sx={{ mt: 3 }}>
-              {match?.Status === 'Completed' && (
+            {match?.Status === 'Completed' && (
+              <Grid item container xs={3.5} alignItems="center" direction="column" sx={{ mt: 3 }}>
                 <Grid item>
                   <Typography className={styles.subtitle}>Final</Typography>
                 </Grid>
-              )}
-              {match?.Status === 'Completed' && (
+
                 <Grid item textAlign="center">
                   <Typography variant="h5">Winner</Typography>
                   <LinkRouter
@@ -344,8 +346,8 @@ const Match = () => {
                     </Typography>
                   </LinkRouter>
                 </Grid>
-              )}
-            </Grid>
+              </Grid>
+            )}
             {/* right team info */}
             <Grid item xs={5} textAlign={'right'}>
               <IconButton onClick={handleSettingsClick} sx={{ mr: '1rem' }}>
@@ -439,6 +441,7 @@ const Match = () => {
                     teams={match?.Team}
                     teamScores={match?.Scores}
                     attendance={matchAttendance}
+                    activityID={match.Activity.ID}
                   />
                 </CardContent>
               </Card>

--- a/src/views/RecIM/views/Match/index.jsx
+++ b/src/views/RecIM/views/Match/index.jsx
@@ -442,6 +442,7 @@ const Match = () => {
                     teamScores={match?.Scores}
                     attendance={matchAttendance}
                     activityID={match.Activity.ID}
+                    isAdmin={user?.IsAdmin}
                   />
                 </CardContent>
               </Card>


### PR DESCRIPTION
Usage is for visually displaying matches that have more than 2 teams playing.

NEW
--

<img width="434" alt="image" src="https://github.com/gordon-cs/gordon-360-ui/assets/78386128/f9c5f689-362d-442d-a180-fe80873e6d0e">

- pseudo-listing for teams. Ordered by points then sportsmanship score. 

<img width="838" alt="image" src="https://github.com/gordon-cs/gordon-360-ui/assets/78386128/f0264571-a6b8-4043-8ff4-af75cc606973">

- attendance accordion for visualization of participants on a team as well as attendance marking

<img width="868" alt="image" src="https://github.com/gordon-cs/gordon-360-ui/assets/78386128/4ec13aaa-dff0-42b0-bb8c-59700c079b6a">

- Header has the name of the activity as well as the image of the activity until marked as completed, where the winner will be listed as well as their logo picture.

<img width="881" alt="image" src="https://github.com/gordon-cs/gordon-360-ui/assets/78386128/2bbd6ee2-93ee-4ff6-a8b6-ffc8e700d673">



QOL
--
<img width="887" alt="image" src="https://github.com/gordon-cs/gordon-360-ui/assets/78386128/2c752b0e-2ef7-4803-9fed-03c423214748">

- completed activities cannot have their information edited. (API will throw an error, but preventing the options makes life easier)

<img width="339" alt="image" src="https://github.com/gordon-cs/gordon-360-ui/assets/78386128/46f16a16-34c8-4b19-8de3-e17be8ac5606">

`new`
<img width="341" alt="image" src="https://github.com/gordon-cs/gordon-360-ui/assets/78386128/9bcb8748-9a09-4b24-972e-ba87aabd4ea6">

- Mobile used to clash listing size. New smaller attendance listing 


Associated API PR:
https://github.com/gordon-cs/gordon-360-api/pull/979 
Generates more lightweight objects for multi team matches

