### PR TITLE
Implement full name into current participant get

### DIFF
--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -375,12 +375,8 @@ const ParticipantListing = ({
             participant.Username,
           );
           setAvatar(preferredImage || defaultImage);
-          const userInfo = await user.getProfileInfo(participant.Username);
-          setFullName(userInfo.fullName);
-        } else {
-          //non-gordon participant
-          setFullName(`${participant.FirstName} ${participant.LastName}`);
         }
+        setFullName(`${participant.FirstName} ${participant.LastName}`);
       }
     };
 


### PR DESCRIPTION
get participant now holds first/last names (based on a view). Thus we don't need to use the expensive getProfile hook which results in 
![image](https://github.com/gordon-cs/gordon-360-ui/assets/78386128/74acc865-fbe2-497c-8abf-db929113e5c2)
