### PR TITLE
Give notice that timesheets has moved to Criterion

### DIFF
--- a/src/views/Timesheets/index.jsx
+++ b/src/views/Timesheets/index.jsx
@@ -160,7 +160,7 @@ const Timesheets = (props) => {
   }
 
   if (!isUserStudent) {
-    return <GordonLimitedAvailability pageName="TimeSheets" />;
+    // return <GordonLimitedAvailability pageName="TimeSheets" />;
   }
 
   const handleSaveButtonClick = () => {
@@ -370,6 +370,25 @@ const Timesheets = (props) => {
   return (
     <>
       <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <Container>
+          <Card>
+            <CardHeader title="Timesheets is moving!" />
+            <CardContent>
+              <Typography>
+                Timesheets is moving from Gordon 360 to{' '}
+                <a
+                  class="gc360_text_link"
+                  href="https://gordon.criterionhcm.com/ui/#"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  Criterion
+                </a>
+                . All timesheets for August 20th or later must be entered in Criterion.
+              </Typography>
+            </CardContent>
+          </Card>
+        </Container>
         <Grid container spacing={2} className={styles.timesheets}>
           <Grid item xs={12}>
             <Card>
@@ -573,12 +592,18 @@ const Notice = () => (
           <a
             class="gc360_text_link"
             href="https://gordon.criterionhcm.com/ui/#"
-            rel="_noreferrer _noopener"
+            target="_blank"
+            rel="noreferrer noopener"
           >
             Criterion
           </a>
           . If you are attempting to enter time for a job worked prior to 8/20/23 please email{' '}
-          <a class="gc360_text_link" href="mailto:payroll@gordon.edu" rel="_noreferrer _noopener">
+          <a
+            class="gc360_text_link"
+            href="mailto:payroll@gordon.edu"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
             Payroll@Gordon.edu
           </a>
           .
@@ -588,4 +613,7 @@ const Notice = () => (
   </Container>
 );
 
-export default Notice;
+const switchOverDate = new Date('2023-08-27 00:00');
+const Component = () => (Date.now() > switchOverDate ? <Notice /> : <Timesheets />);
+
+export default Component;

--- a/src/views/Timesheets/index.jsx
+++ b/src/views/Timesheets/index.jsx
@@ -160,7 +160,7 @@ const Timesheets = (props) => {
   }
 
   if (!isUserStudent) {
-    // return <GordonLimitedAvailability pageName="TimeSheets" />;
+    return <GordonLimitedAvailability pageName="TimeSheets" />;
   }
 
   const handleSaveButtonClick = () => {

--- a/src/views/Timesheets/index.jsx
+++ b/src/views/Timesheets/index.jsx
@@ -1,9 +1,9 @@
-//Main timesheets page
 import {
   Button,
   Card,
   CardContent,
   CardHeader,
+  Container,
   FormControl,
   Grid,
   Input,
@@ -563,4 +563,29 @@ const Timesheets = (props) => {
   );
 };
 
-export default Timesheets;
+const Notice = () => (
+  <Container>
+    <Card>
+      <CardHeader title="Timesheets have moved" />
+      <CardContent>
+        <Typography>
+          Student Timesheets are now located on{' '}
+          <a
+            class="gc360_text_link"
+            href="https://gordon.criterionhcm.com/ui/#"
+            rel="_noreferrer _noopener"
+          >
+            Criterion
+          </a>
+          . If you are attempting to enter time for a job worked prior to 8/20/23 please email{' '}
+          <a class="gc360_text_link" href="mailto:payroll@gordon.edu" rel="_noreferrer _noopener">
+            Payroll@Gordon.edu
+          </a>
+          .
+        </Typography>
+      </CardContent>
+    </Card>
+  </Container>
+);
+
+export default Notice;


### PR DESCRIPTION
As of August 20th, all students will enter their timesheets on Criterion. Payroll has said that 360 Timesheets can stay active until the next pay period is processed so that students can continue to enter timesheets for the previous period until that date.

I have added a notice that Timesheets is moving, and set it to completely replace Timesheets as of August 27 (current approximation of switch over date).

Interim notice:
<img width="1680" alt="image" src="https://github.com/gordon-cs/gordon-360-ui/assets/35319956/7f664d70-4b4b-4e47-85c1-c9fc04410bc7">
Permanent notice:
<img width="1680" alt="image" src="https://github.com/gordon-cs/gordon-360-ui/assets/35319956/20f67029-c014-4c0b-a842-23ecd14bf65f">
