### PR TITLE
Update Timesheets Move Notice

### DIFF
--- a/src/views/Timesheets/index.jsx
+++ b/src/views/Timesheets/index.jsx
@@ -613,7 +613,7 @@ const Notice = () => (
   </Container>
 );
 
-const switchOverDate = new Date('2023-08-27 00:00');
+const switchOverDate = new Date('2023-08-22 12:00');
 const Component = () => (Date.now() > switchOverDate ? <Notice /> : <Timesheets />);
 
 export default Component;


### PR DESCRIPTION
Payroll has indicated that no further Timesheets submitted via 360 will be processed. All future timesheets must be submitted to Criterion, and retroactive timesheets must be negotiated with Payroll directly.