### PR TITLE
Hotfix: quick search z index

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -3,6 +3,7 @@
 .app_bar {
   position: sticky;
   height: var(--header-height);
+  z-index: 100; // so quick search results appear above page.
 }
 
 .toolbar {


### PR DESCRIPTION
Apparently `position: sticky` creates a new stacking context with a default z-index of 0. This caused the Qucik search results in the header to appear underneath any raised content on the page, because it could never go higher than it's parent's stacking context z-index of 0. Setting the app bar to have a z-index of 100 resolves the issue.