### PR TITLE
Fixed bug to be able to clear date input

### DIFF
--- a/src/views/HousingLottery/adminView/index.jsx
+++ b/src/views/HousingLottery/adminView/index.jsx
@@ -47,7 +47,10 @@ const AdminView = () => {
   const handleDateChange = (event) => {
     let input = event.target.value.replace(/\D/g, '');
 
-    if (/^\d+$/.test(input)) {
+    if (input === '') {
+      setDueDate('');
+    }
+    else if (/^\d+$/.test(input)) {
       if (input.length <= 2) {
         setDueDate(input);
       } else if (input.length <= 4) {
@@ -170,7 +173,6 @@ const AdminView = () => {
         headers={csvHeaders}
         filename={'admin_data.csv'}
         className={styles.csvLink}
-
       >
         Export as CSV
       </CSVLink>


### PR DESCRIPTION
It was a very simple bug that did not allow us to completely remove the input field text and always left a '0' in there. Now fully fixed.