### PR TITLE
Show Office Info for Users who Only Have Mail_Location -- CTS Ticket 169936

### DIFF
--- a/src/components/Profile/components/OfficeInfoList/index.jsx
+++ b/src/components/Profile/components/OfficeInfoList/index.jsx
@@ -32,7 +32,7 @@ const OfficeInfoList = ({
   }
 
   // Only display if there is some info to show
-  if (!myProf && !BuildingDescription && !OnCampusRoom && !OnCampusPhone && !office_hours) {
+  if (!myProf && !BuildingDescription && !OnCampusRoom && !OnCampusPhone && !office_hours && !Mail_Location) {
     return null;
   }
 


### PR DESCRIPTION
This PR will fix a bug with the OfficeInfoList block on the user profile where the block does not show if a user only has a Mail_Location.