### PR TITLE
fix: display building description on my profile

### DIFF
--- a/src/components/Profile/components/OfficeInfoList/index.jsx
+++ b/src/components/Profile/components/OfficeInfoList/index.jsx
@@ -32,7 +32,14 @@ const OfficeInfoList = ({
   }
 
   // Only display if there is some info to show
-  if (!myProf && !BuildingDescription && !OnCampusRoom && !OnCampusPhone && !office_hours && !Mail_Location) {
+  if (
+    !myProf &&
+    !BuildingDescription &&
+    !OnCampusRoom &&
+    !OnCampusPhone &&
+    !office_hours &&
+    !Mail_Location
+  ) {
     return null;
   }
 
@@ -77,7 +84,7 @@ const OfficeInfoList = ({
         <Grid container spacing={0} alignItems="center">
           <Grid item>
             {BuildingDescription || OnCampusRoom
-              ? (BuildingDescription, OnCampusRoom)
+              ? `${BuildingDescription}, ${OnCampusRoom}`
               : 'Add your office location here'}
           </Grid>
           <Grid item>


### PR DESCRIPTION
The code for showing `BuildingDescription` in Office Info List was broken on My Profile.

The `BuildingDescription` and `OnCampusRoom` were put in parentheses. I believe the intent was to show the two values separated by a comma (as is done on public profile). However, the parentheses were acting as the Grouping operator, which means only the `OnCampusRoom` was rendered. I have replaced this with a template literal that displays both values separated by a comma.