### PR TITLE
Fixed my profile involvements text on mobile dark mode

### DIFF
--- a/src/components/Profile/components/MembershipsList/MembershipsList.module.scss
+++ b/src/components/Profile/components/MembershipsList/MembershipsList.module.scss
@@ -33,7 +33,7 @@
       padding-left: 0rem;
       justify-content: center;
       background-color: var(--mui-palette-primary-main);
-      color: var(--mui-palette-neutral-light);
+      color: var(--mui-palette-primary-contrastText);
       border-top-left-radius: 4px;
       border-top-right-radius: 4px;
     }

--- a/src/components/Profile/components/MembershipsList/MembershipsList.module.scss
+++ b/src/components/Profile/components/MembershipsList/MembershipsList.module.scss
@@ -32,8 +32,6 @@
     &_header {
       padding-left: 0rem;
       justify-content: center;
-      background-color: var(--mui-palette-primary-main);
-      color: var(--mui-palette-primary-contrastText);
       border-top-left-radius: 4px;
       border-top-right-radius: 4px;
     }


### PR DESCRIPTION
Fixed the color of the my profile involvements text for dark mode on mobile, changing the color from "--mui-palette-neutral-light" to "--mui-palette-primary-contrastText". 