### PR TITLE
add graduation years for summer practicum 2023

### DIFF
--- a/src/views/About/contributors.json
+++ b/src/views/About/contributors.json
@@ -57,6 +57,6 @@
   },
   {
     "title": "Summer Practicum, 2023",
-    "body": "Jack Hammond, Arabella Ji, Matt Jones, Gideon Kim, Jae Min Lee, Eric Mo, Antonia Vontobel, Andrew Wang (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20, Amos Cha '23, and Bennett Forkner)"
+    "body": "Jack Hammond, Arabella Ji '24, Matt Jones '25, Gideon Kim '24, Jae Min Lee '24, Eric Mo '24, Antônia Vontobel '25, Andrew Wang '24 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20, Amos Cha '23, and Bennett Forkner)"
   }
 ]


### PR DESCRIPTION
**Changes made in PR:**
- added appropriate graduation years for students of the Summer 2023 Computer Science Practicum in the About page