### PR TITLE
Remove Timesheets from header and side bar

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -34,7 +34,6 @@ const TabUrlPatterns = [
   /^\/involvements\/?$|^\/activity/,
   /^\/events\/?$/,
   /^\/people$|^\/myprofile|^\/profile/,
-  /^\/timesheets$/,
   /^\/recim$/,
 ];
 
@@ -173,7 +172,6 @@ const GordonHeader = ({ onDrawerToggle }) => {
             to="/events"
           />
           {requiresAuthTab('People', <PeopleIcon />)}
-          {requiresAuthTab('Timesheets', <WorkIcon />)}
           {requiresAuthTab('Rec-IM', <RecIMIcon />)}
         </Tabs>
         <div className={styles.side_container}>

--- a/src/components/Nav/components/NavLinks/index.jsx
+++ b/src/components/Nav/components/NavLinks/index.jsx
@@ -3,7 +3,6 @@ import EventIcon from '@mui/icons-material/Event';
 import HomeIcon from '@mui/icons-material/Home';
 import LocalActivityIcon from '@mui/icons-material/LocalActivity';
 import PeopleIcon from '@mui/icons-material/People';
-import WorkIcon from '@mui/icons-material/Work';
 import { Divider, List } from '@mui/material';
 import RecIMIcon from '@mui/icons-material/SportsFootball';
 import GordonDialogBox from 'components/GordonDialogBox';
@@ -100,18 +99,6 @@ const GordonNavLinks = ({ onLinkClick }) => {
     />
   );
 
-  const timesheetsButton = (
-    <GordonNavButton
-      unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : null}
-      openUnavailableDialog={setDialog}
-      onLinkClick={onLinkClick}
-      linkName={'Timesheets'}
-      linkPath={'/timesheets'}
-      LinkIcon={WorkIcon}
-      divider={false}
-    />
-  );
-
   const recimButton = (
     <GordonNavButton
       unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : null}
@@ -200,7 +187,6 @@ const GordonNavLinks = ({ onLinkClick }) => {
         {involvementsButton}
         {eventsButton}
         {peopleButton}
-        {timesheetsButton}
         {recimButton}
       </List>
 

--- a/src/components/QuickLinksDialog/index.tsx
+++ b/src/components/QuickLinksDialog/index.tsx
@@ -56,6 +56,10 @@ const otherLinks: ListItemProps[] = [
   { href: 'https://www.gordon.edu/titleix', name: 'Sexual Discrimination and Harassment' },
   { href: 'https://www.gordon.edu/map', name: 'Gordon College Maps' },
   { href: 'https://outlook.office.com/mail/', name: 'Gordon Email' },
+  {
+    href: 'https://gordon.criterionhcm.com/?continue=https://gordon.criterionhcm.com/ui/',
+    name: 'Criterion Timesheets',
+  },
 ];
 
 type Props = {
@@ -68,11 +72,10 @@ const GordonQuickLinksDialog = ({ linkopen, handleLinkClose }: Props) => {
     <GordonDialogBox
       aria-labelledby="useful-links"
       open={linkopen}
-      title=""
+      title="Useful Links"
       buttonClicked={handleLinkClose}
       buttonName="Close"
     >
-      <CardHeader title="Useful Links" className="gc360_header" />
       <List
         component="nav"
         subheader={


### PR DESCRIPTION
Removed the time sheets tab from the header and the sidebar. I moved the criterion link to the quick links dialog box. Inside the dialog box I fixed the issue with the title.