### PR TITLE
deleted color mode text from appearance

### DIFF
--- a/src/components/PaletteSwitcherDialog/index.tsx
+++ b/src/components/PaletteSwitcherDialog/index.tsx
@@ -69,7 +69,7 @@ const PaletteSwitcherDialog = ({ dialogOpen, handleClose }: Props) => {
       buttonName="Close"
     >
       <FormControl>
-        <FormLabel id="palette-mode-group-label">Color Mode</FormLabel>
+        <FormLabel id="palette-mode-group-label"></FormLabel>
         <RadioGroup
           row
           name="palette-mode-group"


### PR DESCRIPTION
There was a small text when choosing appearance settings, it looks better without it. 
Closes #2221 