### PR TITLE
Fix Broken Victory Promise Graph to have Color

### DIFF
--- a/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
+++ b/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
@@ -21,7 +21,7 @@ const GraphDisplay = ({ scores }: Props) => {
   Object.entries(scores).forEach((score) => {
     const [key, value] = score as [VictoryPromiseCategory, number];
     const index = GraphOrder[key];
-    const colorHex = (Colors[key].match(/#[A-Fa-f0-9]{6}/) || '')[0];
+    const colorHex = (Colors[key].match(/#[A-Fa-f0-9]{6}/) || [''])[0];
     labels[index] = toTitleCase(key, '_');
     if (value > 0) {
       colorHex == '' ? (colors[index] = '#000000') : (colors[index] = colorHex);

--- a/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
+++ b/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
@@ -21,9 +21,10 @@ const GraphDisplay = ({ scores }: Props) => {
   Object.entries(scores).forEach((score) => {
     const [key, value] = score as [VictoryPromiseCategory, number];
     const index = GraphOrder[key];
+    const colorHex = (Colors[key].match(/#[A-Fa-f0-9]{6}/) || '')[0];
     labels[index] = toTitleCase(key, '_');
     if (value > 0) {
-      colors[index] = Colors[key];
+      colorHex == '' ? (colors[index] = '#000000') : (colors[index] = colorHex);
       data[index] = value;
     } else {
       colors[index] = light_gray;


### PR DESCRIPTION
Setting colors[index] = Colors[key] on line 26 set colors[index] = var(--mui-palette-error-main, #B53228), which is why it kept setting the colors to black.
How I fixed: 
- Used RegEx to pull out the hex from var(--mui-palette-error-main, #B53228), or returned empty string which takes care of the case where match returns null.
- Added a check to return black (#000000) if the match function returns an empty string, else return the appropriate colors.
Works for all combinations of color modes and screen displays.