### PR TITLE
schedule-status

### DIFF
--- a/src/components/Profile/components/SchedulePanel/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/index.tsx
@@ -28,6 +28,7 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
   const [allSchedules, setAllSchedules] = useState<Schedule[]>([]);
   const [selectedSchedule, setSelectedSchedule] = useState<Schedule | null>(null);
   const [selectedCourse, setSelectedCourse] = useState<CourseEvent | null>(null);
+  const [accordionState, setAccordionState] = useState<boolean>(true);
 
   useEffect(() => {
     setLoading(true);
@@ -48,11 +49,27 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
     });
   }, [profile.AD_Username]);
 
+  useEffect(() => {
+    const getAccordionState = localStorage.getItem('accordionState');
+    if (getAccordionState !== null) {
+      setAccordionState(getAccordionState === 'true');
+    }
+  }, []);
+
+  const toggleAccordionState = () => {
+    setAccordionState(!accordionState);
+    localStorage.setItem('accordionState', String(!accordionState));
+  };
+
   return loading ? (
     <GordonLoader />
   ) : (
     <>
-      <Accordion TransitionProps={{ unmountOnExit: true }}>
+      <Accordion
+        expanded={accordionState}
+        onChange={toggleAccordionState}
+        TransitionProps={{ unmountOnExit: true }}
+      >
         <AccordionSummary
           expandIcon={<ExpandMoreIcon className={styles.expandIcon} />}
           aria-controls="schedule"


### PR DESCRIPTION
Stores the status of the 'Schedule' accordion so users can toggle open or closed based on preference. Also changed the default status of the schedule on the profile page to be expanded so it is easier to notice its existence and creates a higher chance of being used.