### PR TITLE
Consider transparency in victory promise graph hex

### DIFF
--- a/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
+++ b/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
@@ -21,7 +21,7 @@ const GraphDisplay = ({ scores }: Props) => {
   Object.entries(scores).forEach((score) => {
     const [key, value] = score as [VictoryPromiseCategory, number];
     const index = GraphOrder[key];
-    const colorHex = (Colors[key].match(/#[A-Fa-f0-9]{6}/) || [''])[0];
+    const colorHex = (Colors[key].match(/#[A-Fa-f0-9]{6,8}/) || [''])[0];
     labels[index] = toTitleCase(key, '_');
     if (value > 0) {
       colorHex == '' ? (colors[index] = '#000000') : (colors[index] = colorHex);


### PR DESCRIPTION
Added possibility for transparency for the victory promise graph colors, still works for 6 digits as well as 8 digits now.