### PR TITLE
Testing Format for Mobile Device

### DIFF
--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/ScheduleCalendar.scss
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/ScheduleCalendar.scss
@@ -52,7 +52,7 @@ button.rbc-input::-moz-focus-inner {
 }
 
 .rbc-event-label {
-  font-size: 60%;
+  font-size: 44%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/services/schedule.ts
+++ b/src/services/schedule.ts
@@ -30,6 +30,17 @@ type DbSchedule = {
   AllCourses: DbCourse[];
 };
 
+function detectMobile() {
+  return window.innerWidth <= 800 && window.innerHeight <= 600;
+}
+
+function mobileFormat() {
+  if (detectMobile() == false) {
+    return ' | ';
+  } else {
+    return ' ';
+  }
+}
 export const scheduleCalendarResources = [
   { id: 'MO', title: 'Monday' },
   { id: 'TU', title: 'Tuesday' },
@@ -87,7 +98,7 @@ function formatCoursesFromDb(courses: DbCourse[]): CourseEvent[] {
   return courses.map((course) => {
     const sharedDetails = {
       name: course.CRS_TITLE.trim(),
-      title: course.CRS_CDE.trim(),
+      title: course.CRS_CDE + mobileFormat() + course.BLDG_CDE + '\u00A0' + course.ROOM_CDE,
       location: course.BLDG_CDE + ' ' + course.ROOM_CDE,
     };
 


### PR DESCRIPTION
We decided it would be beneficial to see your building and room number for each class when viewing the schedule because many people don't know you can click to view it. We decided a separate format would look nicer on mobile rather than computer and vice versa. I can't seem to figure out how to test if the mobile format works so we decided the best options was to view it on 360 train through a mobile device and remove it shortly after.