### PR TITLE
Fixed Starting Status

### DIFF
--- a/src/components/Profile/components/SchedulePanel/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/index.tsx
@@ -30,7 +30,7 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
   const [selectedSchedule, setSelectedSchedule] = useState<Schedule | null>(null);
   const [selectedCourse, setSelectedCourse] = useState<CourseEvent | null>(null);
   const [isScheduleOpen, setIsScheduleOpen] = useState<boolean>(
-    localStorage.getItem('scheduleOpenKey') === 'true' ?? true,
+    localStorage.getItem(scheduleOpenKey) === 'true' ?? true,
   );
 
   useEffect(() => {
@@ -54,7 +54,7 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
 
   const toggleIsScheduleOpen = () => {
     setIsScheduleOpen((wasOpen) => {
-      localStorage.setItem('scheduleOpenKey', String(!isScheduleOpen));
+      localStorage.setItem(scheduleOpenKey, String(!isScheduleOpen));
       return !wasOpen;
     });
   };
@@ -64,7 +64,7 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
   ) : (
     <>
       <Accordion
-        expanded={!isScheduleOpen}
+        expanded={isScheduleOpen}
         onChange={toggleIsScheduleOpen}
         TransitionProps={{ unmountOnExit: true }}
       >

--- a/src/components/Profile/components/SchedulePanel/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/index.tsx
@@ -23,14 +23,14 @@ type Props = {
   myProf: boolean;
 };
 
-const scheduleOpenKey = 'profile.schedule.isOpen';
+const scheduleOpenKey = 'profile.schedule.isOpenOrNot';
 const GordonSchedulePanel = ({ profile, myProf }: Props) => {
   const [loading, setLoading] = useState(true);
   const [allSchedules, setAllSchedules] = useState<Schedule[]>([]);
   const [selectedSchedule, setSelectedSchedule] = useState<Schedule | null>(null);
   const [selectedCourse, setSelectedCourse] = useState<CourseEvent | null>(null);
   const [isScheduleOpen, setIsScheduleOpen] = useState<boolean>(
-    localStorage.getItem(scheduleOpenKey) === 'true' ?? true,
+    localStorage.getItem(scheduleOpenKey) !== 'true',
   );
 
   useEffect(() => {
@@ -54,7 +54,7 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
 
   const toggleIsScheduleOpen = () => {
     setIsScheduleOpen((wasOpen) => {
-      localStorage.setItem(scheduleOpenKey, String(!isScheduleOpen));
+      localStorage.setItem(scheduleOpenKey, String(isScheduleOpen));
       return !wasOpen;
     });
   };

--- a/src/components/Profile/components/SchedulePanel/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/index.tsx
@@ -23,7 +23,7 @@ type Props = {
   myProf: boolean;
 };
 
-const scheduleOpenKey = 'profile.schedule.isOpenOrNot';
+const scheduleOpenKey = 'profile.schedule.isOpen';
 const GordonSchedulePanel = ({ profile, myProf }: Props) => {
   const [loading, setLoading] = useState(true);
   const [allSchedules, setAllSchedules] = useState<Schedule[]>([]);
@@ -54,7 +54,7 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
 
   const toggleIsScheduleOpen = () => {
     setIsScheduleOpen((wasOpen) => {
-      localStorage.setItem(scheduleOpenKey, String(isScheduleOpen));
+      localStorage.setItem(scheduleOpenKey, String(!wasOpen));
       return !wasOpen;
     });
   };

--- a/src/components/Profile/components/SchedulePanel/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/index.tsx
@@ -30,7 +30,7 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
   const [selectedSchedule, setSelectedSchedule] = useState<Schedule | null>(null);
   const [selectedCourse, setSelectedCourse] = useState<CourseEvent | null>(null);
   const [isScheduleOpen, setIsScheduleOpen] = useState<boolean>(
-    localStorage.getItem(scheduleOpenKey) !== 'true',
+    localStorage.getItem(scheduleOpenKey) !== 'false',
   );
 
   useEffect(() => {


### PR DESCRIPTION
The starting status of the schedule accordion was closed and line 33 was giving a warning. After editing line 33 the problem seems to be fixed, it displays no warnings and after clearing my cache, the starting status seems to be open. If this seems inefficient or could possibly cause bugs I would appreciate another approach.