### PR TITLE
Updated Header Profile Button Alt text for screen reader

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,4 +7,4 @@
  VITE_API_URL=https://360ApiTrain.gordon.edu/
 
 # @LOCALHOST
-#  VITE_API_URL=http://localhost:51626/
+# VITE_API_URL=http://localhost:51626/

--- a/.env.development
+++ b/.env.development
@@ -7,4 +7,4 @@
  VITE_API_URL=https://360ApiTrain.gordon.edu/
 
 # @LOCALHOST
-# VITE_API_URL=http://localhost:51626/
+#  VITE_API_URL=http://localhost:51630/

--- a/.env.development
+++ b/.env.development
@@ -7,4 +7,4 @@
  VITE_API_URL=https://360ApiTrain.gordon.edu/
 
 # @LOCALHOST
-#  VITE_API_URL=http://localhost:51630/
+#  VITE_API_URL=http://localhost:51626/

--- a/src/components/Header/components/NavAvatarRightCorner/index.jsx
+++ b/src/components/Header/components/NavAvatarRightCorner/index.jsx
@@ -42,7 +42,7 @@ export const GordonNavAvatarRightCorner = ({ onClick }) => {
       <Tooltip className={styles.tooltip} id="tooltip_avatar" title={name ?? 'Nav Avatar'}>
         <IconButton
           className={styles.root}
-          aria-label="More"
+          aria-label="My Profile"
           aria-owns={'global-menu'}
           aria-haspopup="true"
           onClick={onClick}


### PR DESCRIPTION
An issue was mentioned in the Triage board where when hovering over the profile icon in the header of Gordon 360 it's alternate text only read "More". I changed the aria label in "src/components/Header/components/NavAvatarRightCorner/index.jsx" to say "My Profile" then tested it with a screen reader.

Fixes #2134