### PR TITLE
took-off-coming-soon-text-for-recim

### DIFF
--- a/src/views/About/index.jsx
+++ b/src/views/About/index.jsx
@@ -48,9 +48,7 @@ const About = () => {
                     </li>
                     <li>Timesheets for student jobs on campus,</li>
                     <li>dark mode,</li>
-                    <li>
-                      (coming soon) RecIM to manage fun and competitive recreational activities,
-                    </li>
+                    <li>RecIM to manage fun and competitive recreational activities,</li>
                     <li>and more.</li>
                   </ul>
                   They also maintained the code, revising and sometimes rewriting it to use new


### PR DESCRIPTION
It seems that on the about page, in the section where it states what students have worked on for 360, there was "(coming soon)" before the brief description about RECIM, since RECIM is now completed and implemented into 360 I removed the "(coming soon)" text from the About section.
