### PR TITLE
Update information for the planned graduation year on MyProfile page

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,4 +7,4 @@
  VITE_API_URL=https://360ApiTrain.gordon.edu/
 
 # @LOCALHOST
-# VITE_API_URL=http://localhost:51626/
+# VITE_API_URL=http://localhost:51634/

--- a/.env.development
+++ b/.env.development
@@ -7,4 +7,4 @@
  VITE_API_URL=https://360ApiTrain.gordon.edu/
 
 # @LOCALHOST
-# VITE_API_URL=http://localhost:51634/
+# VITE_API_URL=http://localhost:51626/

--- a/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/UpdatePlannedGradYear.module.scss
+++ b/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/UpdatePlannedGradYear.module.scss
@@ -4,4 +4,5 @@
   padding: 0.3rem 1rem;
   margin-top: 1rem;
   border-radius: 5px;
+  max-width: 315px;
 }

--- a/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
@@ -57,16 +57,9 @@ const UpdatePlannedGraduationYear = (props) => {
           />
         </FormControl>
         <p className={styles.note}>
-          NOTE: <br /> This does not replace the Application to
-          <br />
-          Graduate.
-          <br />
-          Please fill that out 8-12 months before
-          <br />
-          you plan to graduate. The application <br />
-          can be found in
-          <a href="https://my.gordon.edu"> my.gordon.edu</a>, in the
-          <br /> Academics tab, on the left.
+          NOTE: <br /> This does not replace the Application to Graduate, which must be filled out
+          8-12 months before you plan to graduate. The application can be found in{' '}
+          <a href="https://my.gordon.edu"> my.gordon.edu</a>, in the Academics tab, on the left.
         </p>
       </GordonDialogBox>
       <GordonSnackbar

--- a/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
@@ -57,9 +57,16 @@ const UpdatePlannedGraduationYear = (props) => {
           />
         </FormControl>
         <p className={styles.note}>
-          NOTE: <br /> This does not set your official graduation <br />
-          year. To make an official change, please <br /> contact{' '}
-          <a href="mailto:registrar@gordon.edu">the Registrar's Office</a>.
+          NOTE: <br /> This does not replace the Application to
+          <br />
+          Graduate.
+          <br />
+          Please fill that out 8-12 months before
+          <br />
+          you plan to graduate. The application <br />
+          can be found in
+          <a href="https://my.gordon.edu"> my.gordon.edu</a>, in the
+          <br /> Academics tab, on the left.
         </p>
       </GordonDialogBox>
       <GordonSnackbar

--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -274,31 +274,6 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
       />
     ) : null;
 
-  const matriculationYear =
-    myProf && isStudent ? (
-      <ProfileInfoListItem
-        title={'Matriculation Date:'}
-        contentText={
-          <Grid container spacing={0} alignItems="center">
-            <Grid item>
-              {!profPlannedGradYear
-                ? 'Fill in with your planned graduation year'
-                : profPlannedGradYear}
-            </Grid>
-            <Grid item>
-              <UpdatePlannedGraduationYear change={setProfPlannedGradYear} />
-            </Grid>
-          </Grid>
-        }
-      />
-    ) : profPlannedGradYear ? (
-      <ProfileInfoListItem
-        title={'Planned Graduation Year:'}
-        contentText={profile.PlannedGradYear}
-        myProf={myProf}
-      />
-    ) : null;
-
   const updateAlumniInfoButton =
     isAlumni && isOnline && myProf ? (
       <Grid container justifyContent="center">
@@ -735,7 +710,6 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
             {majors}
             {minors}
             {plannedGraduationYear}
-            {matriculationYear}
             {graduationYear}
             {cliftonStrengths}
             {advisors}

--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -657,8 +657,8 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
           <li>
             <Typography>
               Setting your planned graduation date above does not replace the Application to
-              Graduate. Please fill out that application 8-12 months before you plan to graduate.
-              The application can be found in{' '}
+              Graduate, which must be filled out 8-12 months before you plan to graduate. The
+              application can be found in{' '}
               <a href="https://my.gordon.edu" className={`gc360_text_link ${styles.note_link}`}>
                 my.gordon.edu
               </a>

--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -631,6 +631,17 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
           </li>
           <li>
             <Typography>
+              Setting your planned graduation date above does not replace the Application to
+              Graduate. Please fill out that application 8-12 months before you plan to graduate.
+              The application can be found in{' '}
+              <a href="https://my.gordon.edu" className={`gc360_text_link ${styles.note_link}`}>
+                my.gordon.edu
+              </a>
+              , in the Academics tab, on the left.
+            </Typography>
+          </li>
+          <li>
+            <Typography>
               For all other changes or to partially/fully prevent your data from displaying, please
               contact the{' '}
               <a

--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -274,6 +274,31 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
       />
     ) : null;
 
+  const matriculationYear =
+    myProf && isStudent ? (
+      <ProfileInfoListItem
+        title={'Matriculation Date:'}
+        contentText={
+          <Grid container spacing={0} alignItems="center">
+            <Grid item>
+              {!profPlannedGradYear
+                ? 'Fill in with your planned graduation year'
+                : profPlannedGradYear}
+            </Grid>
+            <Grid item>
+              <UpdatePlannedGraduationYear change={setProfPlannedGradYear} />
+            </Grid>
+          </Grid>
+        }
+      />
+    ) : profPlannedGradYear ? (
+      <ProfileInfoListItem
+        title={'Planned Graduation Year:'}
+        contentText={profile.PlannedGradYear}
+        myProf={myProf}
+      />
+    ) : null;
+
   const updateAlumniInfoButton =
     isAlumni && isOnline && myProf ? (
       <Grid container justifyContent="center">
@@ -710,6 +735,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
             {majors}
             {minors}
             {plannedGraduationYear}
+            {matriculationYear}
             {graduationYear}
             {cliftonStrengths}
             {advisors}


### PR DESCRIPTION
Updated the "NOTES" on the MyProfile page for planned graduation date according to Dr. Tuck's suggestions on https://github.com/gordon-cs/gordon-360-api/issues/730 (I couldn't find a way to link it since it was closed and then reopened later).
This is what the changes look like.
![Screenshot from 2024-05-28 09-04-53](https://github.com/gordon-cs/gordon-360-ui/assets/123050501/c1648921-b688-4c38-b201-a6daf3dd728d)
![Screenshot from 2024-05-28 09-05-15](https://github.com/gordon-cs/gordon-360-ui/assets/123050501/fe455607-7b55-4e52-ac57-862b3d7cbce4)
