### PR TITLE
Lazy load images when sensible

### DIFF
--- a/src/components/Profile/components/MembershipsList/components/MembershipInfoCard/index.jsx
+++ b/src/components/Profile/components/MembershipsList/components/MembershipInfoCard/index.jsx
@@ -136,6 +136,7 @@ const MembershipInfoCard = ({ myProf, membershipHistory, createSnackbar }) => {
         >
           <OnlineOnlyLink element={membershipHistory.Memberships[0]}>
             <img
+              loading="lazy"
               src={membershipHistory.ActivityImagePath}
               alt=""
               className={isOnline ? 'active' : ''}

--- a/src/views/InvolvementsAll/components/InvolvementsGrid/index.jsx
+++ b/src/views/InvolvementsAll/components/InvolvementsGrid/index.jsx
@@ -21,6 +21,7 @@ const InvolvementsGrid = ({ involvements, sessionCode, noInvolvementsText }) => 
                 }}
               >
                 <CardMedia
+                  loading="lazy"
                   component="img"
                   alt={activity.ActivityDescription}
                   src={activity.ActivityImagePath}

--- a/src/views/News/components/NewsItem/index.jsx
+++ b/src/views/News/components/NewsItem/index.jsx
@@ -93,7 +93,7 @@ const NewsItem = ({ posting, unapproved, size, handleNewsItemEdit, handleNewsIte
           <CardContent>
             <Typography className={styles.news_content}>"{posting.categoryName}"</Typography>
             <Typography className={styles.news_content}>{posting.Body}</Typography>
-            {posting.Image !== null && <img src={`${posting.Image}`} alt=" " />}
+            {posting.Image !== null && <img loading="lazy" src={`${posting.Image}`} alt=" " />}
           </CardContent>
           <Grid container justifyContent="space-evenly">
             {editButton}
@@ -136,7 +136,7 @@ const NewsItem = ({ posting, unapproved, size, handleNewsItemEdit, handleNewsIte
                 <Typography type="caption" className={styles.descriptionText}>
                   {posting.Body}
                 </Typography>
-                {posting.Image !== null && <img src={`${posting.Image}`} alt=" " />}
+                {posting.Image !== null && <img loading="lazy" src={`${posting.Image}`} alt=" " />}
               </Grid>
               {/* Possible action buttons */}
               <Grid item xs={4}>

--- a/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
+++ b/src/views/PeopleSearch/components/PeopleSearchResult/index.tsx
@@ -110,6 +110,7 @@ const PeopleSearchResult = ({ person, lazyLoadAvatar }: Props) => {
             <Card className={styles.result} elevation={0}>
               {avatar && (
                 <CardMedia
+                  loading="lazy"
                   src={avatar}
                   title={fullName}
                   component="img"

--- a/src/views/RecIM/components/List/Listing/index.jsx
+++ b/src/views/RecIM/components/List/Listing/index.jsx
@@ -455,6 +455,7 @@ const ParticipantListing = ({
       <>
         <ListItemAvatar>
           <Avatar
+            slotProps={{ img: { loading: 'lazy' } }}
             src={`data:image/jpg;base64,${avatar}`}
             className={minimal || isMobile ? styles.avatarSmall : styles.avatar}
             variant="rounded"
@@ -682,8 +683,8 @@ const MatchHistoryListing = ({ match, activityID }) => {
           ownScore > oppScore
             ? styles.matchHistoryListing_winner
             : ownScore < oppScore
-            ? styles.matchHistoryListing_loser
-            : styles.matchHistoryListing
+              ? styles.matchHistoryListing_loser
+              : styles.matchHistoryListing
         }
       >
         <Grid container alignItems="center">
@@ -697,6 +698,7 @@ const MatchHistoryListing = ({ match, activityID }) => {
           </Grid>
           <Grid item xs={2.8}>
             <img
+              loading="lazy"
               src={match.Opponent?.Logo ?? defaultLogo}
               alt="Team Icon"
               className={styles.teamHistoryLogo}

--- a/src/views/RecIM/views/Home/index.jsx
+++ b/src/views/RecIM/views/Home/index.jsx
@@ -334,8 +334,8 @@ const Home = () => {
     </Card>
   );
 
-  let headerAlert = (
-    participant?.Status === 'Pending' && <Alert
+  let headerAlert = participant?.Status === 'Pending' && (
+    <Alert
       severity="error"
       sx={{ mb: '1rem' }}
       action={


### PR DESCRIPTION
Add the `loading="lazy"` attribute to `img` components, so that the browser can delay loading images that are not yet in the viewport (i.e. haven't been scrolled into the visible section of the page). See [the `loading` attribute of the `img` HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading) for more info.

PS: This attribute is not yet well supported on Firefox. Also, for some reason, the MUI Avatar component is not respecting the loading attribute in the for the img slot props. Nevertheless, this serves as a great progressive enhancement for the browsers/components that employ it, and won't cause any issues in cases where it isn't supported.