### PR TITLE
Make Enter Key Expand Event

### DIFF
--- a/src/components/EventList/components/EventItem/index.jsx
+++ b/src/components/EventList/components/EventItem/index.jsx
@@ -16,7 +16,11 @@ const EventItem = ({ event }) => {
       onClick={() => setExpanded((e) => !e)}
       className={styles.event_item}
       tabIndex={0}
-      onKeyDown={(e) => (e.key === 'Enter' ? setExpanded((e) => !e) : {})}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' && e.currentTarget === e.target) {
+          setExpanded((e) => !e);
+        }
+      }}
     >
       <Grid item xs={12} sm={4}>
         <Typography variant="h6" className={styles.event_column}>

--- a/src/components/EventList/components/EventItem/index.jsx
+++ b/src/components/EventList/components/EventItem/index.jsx
@@ -16,6 +16,7 @@ const EventItem = ({ event }) => {
       onClick={() => setExpanded((e) => !e)}
       className={styles.event_item}
       tabIndex={0}
+      onKeyDown={(e) => (e.key === 'Enter' ? setExpanded((e) => !e) : {})}
     >
       <Grid item xs={12} sm={4}>
         <Typography variant="h6" className={styles.event_column}>


### PR DESCRIPTION
Related to #2133 and #2135 
Can now expand an event using the enter key **BUT** anytime you press enter while focused on an event it opens or closes it no matter what. So if you tab to "Add to Calendar" but press enter it just closes the event.

You can however press space while focused on "Add to Calendar" and that doesn't close the event. So it's not perfect, but you can at least open the event now.