### PR TITLE
Fix PlanGradYear Link Color and Default Value

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
@@ -1,4 +1,4 @@
-import { FormControl, IconButton } from '@mui/material';
+import { FormControl, IconButton, Link } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import GordonDialogBox from 'components/GordonDialogBox';
 import GordonSnackbar from 'components/Snackbar';
@@ -46,6 +46,7 @@ const UpdatePlannedGraduationYear = (props) => {
           <SearchField
             name="Planned Graduation Year"
             value={plannedGraduationYear}
+            allIndicator={false}
             updateValue={(event) => setPlannedGraduationYear(event.target.value)}
             options={Array.from({ length: 6 }, (_, i) => ({
               value: (currentYear + i).toString(),
@@ -59,7 +60,10 @@ const UpdatePlannedGraduationYear = (props) => {
         <p className={styles.note}>
           NOTE: <br /> This does not replace the Application to Graduate, which must be filled out
           8-12 months before you plan to graduate. The application can be found in{' '}
-          <a href="https://my.gordon.edu"> my.gordon.edu</a>, in the Academics tab, on the left.
+          <Link href="https://my.gordon.edu" underline="hover" className={'gc360_text_link'}>
+            my.gordon.edu
+          </Link>
+          , in the Academics tab, on the left.
         </p>
       </GordonDialogBox>
       <GordonSnackbar

--- a/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
@@ -46,7 +46,7 @@ const UpdatePlannedGraduationYear = (props) => {
           <SearchField
             name="Planned Graduation Year"
             value={plannedGraduationYear}
-            allIndicator={false}
+            defaultLabel="None"
             updateValue={(event) => setPlannedGraduationYear(event.target.value)}
             options={Array.from({ length: 6 }, (_, i) => ({
               value: (currentYear + i).toString(),

--- a/src/views/PeopleSearch/components/SearchFieldList/components/SearchField/index.tsx
+++ b/src/views/PeopleSearch/components/SearchFieldList/components/SearchField/index.tsx
@@ -18,7 +18,7 @@ interface CommonProps {
   defaultDisabled?: boolean;
   select?: boolean;
   options?: string[] | SelectOption[];
-  allIndicator?: boolean;
+  defaultLabel: string;
 }
 
 interface SelectProps extends CommonProps {
@@ -33,16 +33,11 @@ interface TextProps extends CommonProps {
 
 type SearchFieldProps = SelectProps | TextProps;
 
-const defaultMenuItem = (indicator: boolean) =>
-  indicator ? (
-    <MenuItem value="" key="default">
-      <em>All</em>
-    </MenuItem>
-  ) : (
-    <MenuItem value="" key="default">
-      <em>None</em>
-    </MenuItem>
-  );
+const defaultMenuItem = (defaultValue: string) => (
+  <MenuItem value="" key="default">
+    <em>{defaultValue}</em>
+  </MenuItem>
+);
 
 const mapOptionsToMenuItems = (options: string[] | SelectOption[]) =>
   options.map((option) =>
@@ -66,7 +61,7 @@ const SearchField = ({
   defaultDisabled = false,
   select = false,
   options = undefined,
-  allIndicator = true,
+  defaultLabel = 'All',
 }: SearchFieldProps) => {
   const isLargeScreen = useMediaQuery('(min-width: 600px)');
 
@@ -93,7 +88,7 @@ const SearchField = ({
           {select && options
             ? defaultDisabled
               ? [mapOptionsToMenuItems(options)]
-              : [defaultMenuItem(allIndicator), mapOptionsToMenuItems(options)]
+              : [defaultMenuItem(defaultLabel), mapOptionsToMenuItems(options)]
             : null}
         </TextField>
       </Grid>

--- a/src/views/PeopleSearch/components/SearchFieldList/components/SearchField/index.tsx
+++ b/src/views/PeopleSearch/components/SearchFieldList/components/SearchField/index.tsx
@@ -18,7 +18,7 @@ interface CommonProps {
   defaultDisabled?: boolean;
   select?: boolean;
   options?: string[] | SelectOption[];
-  defaultLabel: string;
+  defaultLabel?: string;
 }
 
 interface SelectProps extends CommonProps {

--- a/src/views/PeopleSearch/components/SearchFieldList/components/SearchField/index.tsx
+++ b/src/views/PeopleSearch/components/SearchFieldList/components/SearchField/index.tsx
@@ -18,6 +18,7 @@ interface CommonProps {
   defaultDisabled?: boolean;
   select?: boolean;
   options?: string[] | SelectOption[];
+  allIndicator?: boolean;
 }
 
 interface SelectProps extends CommonProps {
@@ -32,11 +33,16 @@ interface TextProps extends CommonProps {
 
 type SearchFieldProps = SelectProps | TextProps;
 
-const defaultMenuItem = (
-  <MenuItem value="" key="default">
-    <em>All</em>
-  </MenuItem>
-);
+const defaultMenuItem = (indicator: boolean) =>
+  indicator ? (
+    <MenuItem value="" key="default">
+      <em>All</em>
+    </MenuItem>
+  ) : (
+    <MenuItem value="" key="default">
+      <em>None</em>
+    </MenuItem>
+  );
 
 const mapOptionsToMenuItems = (options: string[] | SelectOption[]) =>
   options.map((option) =>
@@ -60,6 +66,7 @@ const SearchField = ({
   defaultDisabled = false,
   select = false,
   options = undefined,
+  allIndicator = true,
 }: SearchFieldProps) => {
   const isLargeScreen = useMediaQuery('(min-width: 600px)');
 
@@ -86,7 +93,7 @@ const SearchField = ({
           {select && options
             ? defaultDisabled
               ? [mapOptionsToMenuItems(options)]
-              : [defaultMenuItem, mapOptionsToMenuItems(options)]
+              : [defaultMenuItem(allIndicator), mapOptionsToMenuItems(options)]
             : null}
         </TextField>
       </Grid>


### PR DESCRIPTION
Related to https://github.com/gordon-cs/gordon-360-api/issues/730
- Fixed the link color from purple to GordonBlue by switching from an <a> tag to Link Component
- Added indicator to SearchField Component to allow the default menu item to be "None" instead of "All" which is more applicable in this case, see below...
![Screenshot from 2024-06-05 14-35-14](https://github.com/gordon-cs/gordon-360-ui/assets/123050501/459f1493-31d6-4767-85f6-092346cb6a79)
I could also change it to be set as "Blank" if that describes it better.