### PR TITLE
Help Page Extra Navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "react-imask": "^7.4.0",
         "react-router": "^6.22.1",
         "react-router-dom": "^6.22.1",
+        "react-router-hash-link": "^2.4.3",
         "react-to-print": "^2.15.1",
         "react-visibility-sensor": "^5.1.1",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"
@@ -8719,6 +8720,18 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-router-hash-link": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
+      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=15",
+        "react-router-dom": ">=4"
       }
     },
     "node_modules/react-swipeable-views": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-imask": "^7.4.0",
     "react-router": "^6.22.1",
     "react-router-dom": "^6.22.1",
+    "react-router-hash-link": "^2.4.3",
     "react-to-print": "^2.15.1",
     "react-visibility-sensor": "^5.1.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"

--- a/src/views/Help/index.jsx
+++ b/src/views/Help/index.jsx
@@ -1,10 +1,76 @@
 import styles from './Help.module.css';
-
+import { HashLink as Link } from 'react-router-hash-link';
 import { Typography, Grid, Button, Card, CardHeader, CardContent } from '@mui/material';
 
 const Help = () => {
   return (
     <Grid container justifyContent="center">
+      <Grid item xs={12} md={2}>
+        <Card className={styles.help}>
+          <CardHeader
+            className={styles.help_title}
+            title="Jump To:"
+            titleTypographyProps={{ variant: 'h5' }}
+          />
+          <CardContent container="row">
+            <li>
+              <Link
+                className={`gc360_text_link`}
+                style={{ padding: '0 1vw' }}
+                to="#site-navigation"
+                smooth
+              >
+                Site Navigation
+              </Link>
+            </li>
+            <li>
+              <Link
+                className={`gc360_text_link`}
+                style={{ padding: '0 0.5vw' }}
+                to="#involvement-user-levels"
+                smooth
+              >
+                Involvement User Levels
+              </Link>
+            </li>
+            <li>
+              <Link
+                className={`gc360_text_link`}
+                style={{ padding: '0 0.5vw' }}
+                to="#management-&-editing-involvements"
+                smooth
+              >
+                Management & Editing Involvements
+              </Link>
+            </li>
+            <li>
+              <Link
+                className={`gc360_text_link`}
+                style={{ padding: '0.5vw' }}
+                to="#issues-&-troubleshooting"
+                smooth
+              >
+                Issues & Troubleshooting
+              </Link>
+            </li>
+            <li>
+              <Link
+                className={`gc360_text_link`}
+                style={{ padding: '0.5vw' }}
+                to="#supported-platforms"
+                smooth
+              >
+                Supported Platforms
+              </Link>
+            </li>
+            <li>
+              <Link className={`gc360_text_link`} style={{ padding: '0.5vw' }} to="#faq" smooth>
+                FAQ
+              </Link>
+            </li>
+          </CardContent>
+        </Card>
+      </Grid>
       <Grid item xs={12} lg={8}>
         <Card className={styles.help}>
           <CardHeader
@@ -12,9 +78,20 @@ const Help = () => {
             title="Gordon 360 Help"
             titleTypographyProps={{ variant: 'h4' }}
           />
+          <Typography variant="body"></Typography>
+
+          {/* <CardContent>
+            Jump To:
+          </CardContent>
+          <Link className={`gc360_text_link`} style={{ padding: '0 1vw'}}  to="#site-navigation" smooth>Site Navigation</Link>
+          <Link className={`gc360_text_link`} style={{ padding: '0 0.5vw'}} to="#involvement-user-levels" smooth>Involvement User Levels</Link>
+          <Link className={`gc360_text_link`} style={{ padding: '0 0.5vw'}} to="#management-&-editing-involvements" smooth>Management & Editing Involvements</Link>
+          <Link className={`gc360_text_link`} style={{ padding: '0.5vw'}} to ="#issues-&-troubleshooting" smooth>Issues & Troubleshooting</Link>
+          <Link className={`gc360_text_link`} style={{ padding: '0.5vw'}} to="#supported-platforms" smooth>Supported Platforms</Link>
+          <Link className={`gc360_text_link`} style={{ padding: '0.5vw'}} to="#faq" smooth>FAQ</Link> */}
           <br />
           <CardContent>
-            <Card className={styles.help_section}>
+            <Card className={styles.help_section} id="login-instructions">
               <CardHeader className="gc360_header" title="Login Instructions" />
               <CardContent>
                 <Typography variant="body1" component="ul">
@@ -23,8 +100,7 @@ const Help = () => {
                 </Typography>
               </CardContent>
             </Card>
-
-            <Card className={styles.help_section}>
+            <Card className={styles.help_section} id="site-navigation">
               <CardHeader className="gc360_header" title="Site Navigation" />
 
               <CardContent>
@@ -32,16 +108,14 @@ const Help = () => {
                   <li>
                     <strong>Home</strong> &ndash; Contains various tiles with charts or information.
                     <Typography variant="body1" component="ul">
-                      <li>
+                      <div>
                         <strong>Student:</strong> Includes your Dining “Meal Wheel’ tracker synced
-                        to days remaining in the semester and your Christian Life & Worship (CL&W)
-                        credits. You can click on the CL&W tracker to see which events are recorded
-                        for you.
-                      </li>
-                      <li>
+                        to days remaining in the semester.
+                      </div>
+                      <div>
                         <strong>Faculty/Staff:</strong> Includes days remaining wheel and a separate
                         Dining Dollars tracker.
-                      </li>
+                      </div>
                     </Typography>
                   </li>
                   <li>
@@ -61,6 +135,18 @@ const Help = () => {
                     <strong>People</strong> &ndash; Allows searching the campus community with more
                     in-depth filters than the normal search bar. You can filter students, staff, and
                     faculty by name or hall and by academic, home, and office info.
+                  </li>
+                  <li>
+                    <strong>Links</strong> &ndash; Provides quick links to important services such
+                    as academics,financial/career and more general information.
+                  </li>
+                  <li>
+                    <strong>Rec-IM</strong> &ndash; Recreational-Intramural(Rec-IM) offers services
+                    to manage fun and competitive recreational activities tailored for Gordon's
+                    campus. RecIM ensures a vibrant and engaging campus life for students. With a
+                    focus on fostering teamwork, wellness, and community spirit. RecIM provides a
+                    platform for students to enjoy a wide range of recreational pursuits while
+                    enhancing their college experience.
                   </li>
                   <li>
                     <strong>Quick Search</strong> &ndash; Quick searches by name of Gordon students,
@@ -91,7 +177,7 @@ const Help = () => {
               </CardContent>
             </Card>
 
-            <Card className={styles.help_section}>
+            <Card className={styles.help_section} id="involvement-user-levels">
               <CardHeader className="gc360_header" title="Involvement User Levels" />
 
               <CardContent>
@@ -132,7 +218,7 @@ const Help = () => {
               </CardContent>
             </Card>
 
-            <Card className={styles.help_section}>
+            <Card className={styles.help_section} id="management-&-editing-involvements">
               <CardHeader className="gc360_header" title="Management & Editing Involvements" />
               <CardContent>
                 <Typography variant="body1" component="ul">
@@ -178,7 +264,7 @@ const Help = () => {
               </CardContent>
             </Card>
 
-            <Card className={styles.help_section}>
+            <Card className={styles.help_section} id="issues-&-troubleshooting">
               <CardHeader className="gc360_header" title="Issues & Troubleshooting" />
 
               <CardContent>
@@ -197,7 +283,7 @@ const Help = () => {
               </CardContent>
             </Card>
 
-            <Card className={styles.help_section}>
+            <Card className={styles.help_section} id="supported-platforms">
               <CardHeader className="gc360_header" title="Supported Platforms" />
 
               <CardContent>
@@ -211,7 +297,7 @@ const Help = () => {
               </CardContent>
             </Card>
 
-            <Card className={styles.help_section}>
+            <Card className={styles.help_section} id="faq">
               <CardHeader className="gc360_header" title="FAQ" />
 
               <CardContent>

--- a/src/views/Help/index.jsx
+++ b/src/views/Help/index.jsx
@@ -1,6 +1,11 @@
 import styles from './Help.module.css';
 import { HashLink as Link } from 'react-router-hash-link';
 import { Typography, Grid, Button, Card, CardHeader, CardContent } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+
+const FloatingHashlink = () => {
+  const [floating, setFloating] = useState(false);
+};
 
 const Help = () => {
   return (
@@ -27,20 +32,20 @@ const Help = () => {
               <Link
                 className={`gc360_text_link`}
                 style={{ padding: '0 0.5vw' }}
-                to="#involvement-user-levels"
+                to="#involvement-user-types"
                 smooth
               >
-                Involvement User Levels
+                Involvement User Types
               </Link>
             </li>
             <li>
               <Link
                 className={`gc360_text_link`}
                 style={{ padding: '0 0.5vw' }}
-                to="#managing-&-editing-involvements"
+                to="#managing-involvements"
                 smooth
               >
-                Managing & Editing Involvements
+                Managing Involvements
               </Link>
             </li>
             <li>
@@ -79,16 +84,6 @@ const Help = () => {
             titleTypographyProps={{ variant: 'h4' }}
           />
           <Typography variant="body"></Typography>
-
-          {/* <CardContent>
-            Jump To:
-          </CardContent>
-          <Link className={`gc360_text_link`} style={{ padding: '0 1vw'}}  to="#site-navigation" smooth>Site Navigation</Link>
-          <Link className={`gc360_text_link`} style={{ padding: '0 0.5vw'}} to="#involvement-user-levels" smooth>Involvement User Levels</Link>
-          <Link className={`gc360_text_link`} style={{ padding: '0 0.5vw'}} to="#management-&-editing-involvements" smooth>Management & Editing Involvements</Link>
-          <Link className={`gc360_text_link`} style={{ padding: '0.5vw'}} to ="#issues-&-troubleshooting" smooth>Issues & Troubleshooting</Link>
-          <Link className={`gc360_text_link`} style={{ padding: '0.5vw'}} to="#supported-platforms" smooth>Supported Platforms</Link>
-          <Link className={`gc360_text_link`} style={{ padding: '0.5vw'}} to="#faq" smooth>FAQ</Link> */}
           <br />
           <CardContent>
             <Card className={styles.help_section} id="login-instructions">
@@ -177,8 +172,8 @@ const Help = () => {
               </CardContent>
             </Card>
 
-            <Card className={styles.help_section} id="involvement-user-levels">
-              <CardHeader className="gc360_header" title="Involvement User Levels" />
+            <Card className={styles.help_section} id="involvement-user-types">
+              <CardHeader className="gc360_header" title="Involvement User Types" />
 
               <CardContent>
                 <Typography variant="body1" component="ul">
@@ -218,8 +213,8 @@ const Help = () => {
               </CardContent>
             </Card>
 
-            <Card className={styles.help_section} id="managing-&-editing-involvements">
-              <CardHeader className="gc360_header" title="Managing & Editing Involvements" />
+            <Card className={styles.help_section} id="managing-involvements">
+              <CardHeader className="gc360_header" title="Managing Involvements" />
               <CardContent>
                 <Typography variant="body1" component="ul">
                   <li>

--- a/src/views/Help/index.jsx
+++ b/src/views/Help/index.jsx
@@ -5,18 +5,18 @@ import { Typography, Grid, Button, Card, CardHeader, CardContent } from '@mui/ma
 const Help = () => {
   return (
     <Grid container justifyContent="center">
-      <Grid item xs={12} md={2}>
+      <Grid item xs={12} lg={3} md={12}>
         <Card className={styles.help}>
           <CardHeader
             className={styles.help_title}
             title="Jump To:"
-            titleTypographyProps={{ variant: 'h5' }}
+            titleTypographyProps={{ variant: 'h4' }}
           />
           <CardContent container="row">
             <li>
               <Link
                 className={`gc360_text_link`}
-                style={{ padding: '0 1vw' }}
+                style={{ padding: '0 0.5vw' }}
                 to="#site-navigation"
                 smooth
               >
@@ -37,10 +37,10 @@ const Help = () => {
               <Link
                 className={`gc360_text_link`}
                 style={{ padding: '0 0.5vw' }}
-                to="#management-&-editing-involvements"
+                to="#managing-&-editing-involvements"
                 smooth
               >
-                Management & Editing Involvements
+                Managing & Editing Involvements
               </Link>
             </li>
             <li>
@@ -218,8 +218,8 @@ const Help = () => {
               </CardContent>
             </Card>
 
-            <Card className={styles.help_section} id="management-&-editing-involvements">
-              <CardHeader className="gc360_header" title="Management & Editing Involvements" />
+            <Card className={styles.help_section} id="managing-&-editing-involvements">
+              <CardHeader className="gc360_header" title="Managing & Editing Involvements" />
               <CardContent>
                 <Typography variant="body1" component="ul">
                   <li>


### PR DESCRIPTION
Below I added a jump to side grid, like an anchor, to make it more accessible for users to navigate to a certain section/header on the help page. The more we keep adding to 360 the longer the help page gets so I assumed this could be a good add for user accessibility. I also added a recIM and links paragraph for the site navigation, since those weren't added yet. I don't believe this will be my final result so I am just looking for any feedback, recommendation's to help this look better. #Issue2278

![Screenshot from 2024-06-06 10-12-38](https://github.com/gordon-cs/gordon-360-ui/assets/156944565/00a3b789-11df-41bd-8a49-91f492a9cd42)
