### PR TITLE
Fixes bugs with the schedule

### DIFF
--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
@@ -21,11 +21,13 @@ const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
 
   const courseFormat = schedule.courses.map((course) => {
     let title;
-    if (course.location.includes('ASY')) {
-      title = `${course.title}${width >= 1500 ? ' | ' : ' '} ${course.location}`;
-    } else {
+    if (course.location.includes('ASY') || course.location.includes('null')) {
+      title = `${course.title}`;
+    } 
+    else {
       title = `${course.title}${width >= 2212 ? ' | ' : ' '} ${course.location}`;
     }
+
 
     return { ...course, title };
   });


### PR DESCRIPTION
I noticed that if a course has no building or room number, such as Discovery, it will print ‘null null’ for both. Along with that I don’t see the need for the building and room number to be shown for asynchronous courses because it is already in its own section on the schedule and easy to tell. It also created an issue with sizing that I found when working on my Mac. I simply modified the if statement to only print the title if it is an asynchronous course or the building and room number include ‘null’.