### PR TITLE
collapse membership requests when nothing to do

### DIFF
--- a/src/views/InvolvementsAll/components/Requests/index.jsx
+++ b/src/views/InvolvementsAll/components/Requests/index.jsx
@@ -98,7 +98,7 @@ const Requests = ({ profile, session }) => {
   } else {
     content = (
       <>
-        <Accordion defaultExpanded>
+        <Accordion defaultExpanded={requestsSent?.length > 0}>
           <AccordionSummary
             aria-controls="received-requests-content"
             expandIcon={<ExpandMore className={styles.requests_expand_icon} />}


### PR DESCRIPTION
Resolves Issue #2022 , when there is no membership request sent, it is automatically closed but when there is a request sent it is automatically open. 