### PR TITLE
Make Top Tabs Accessible

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -165,6 +165,7 @@ const GordonHeader = ({ onDrawerToggle }) => {
             label="Involvements"
             component={ForwardNavLink}
             to="/involvements"
+            tabIndex={0}
           />
           <Tab
             className={styles.tab}


### PR DESCRIPTION
Reference #2132 
Top navigation tabs were inaccessible via keyboard, now they work like before...
- Hitting tab once focuses the page tabs, and then you can use the arrow keys to move focus within the tabs. 
- Hitting tab again jumps focus to the people search box. 
- Shift+tab will take you back to the tabs.

This does not break any of the other page tab functionality (still highlights and underlines correct icon when on the corresponding page).