### PR TITLE
Schedule visual bugs s24

### DIFF
--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/ScheduleCalendar.scss
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/ScheduleCalendar.scss
@@ -68,12 +68,6 @@ button.rbc-input::-moz-focus-inner {
   max-width: 100%;
 }
 
-@media (max-width: 1152px) {
-  .rbc-row-segment .rbc-event-content {
-    font-size: 70%;
-  }
-}
-
 .rbc-day-slot .rbc-event-content {
   background-color: var(--mui-palette-primary-main);
   color: var(--mui-palette-primary-contrastText);
@@ -86,6 +80,7 @@ button.rbc-input::-moz-focus-inner {
   min-height: 1em;
 }
 @media (max-width: 1152px) {
+  .rbc-row-segment .rbc-event-content,
   .rbc-day-slot .rbc-event-content {
     font-size: 70%;
   }

--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/ScheduleCalendar.scss
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/ScheduleCalendar.scss
@@ -68,18 +68,28 @@ button.rbc-input::-moz-focus-inner {
   max-width: 100%;
 }
 
+@media (max-width: 1152px) {
+  .rbc-row-segment .rbc-event-content {
+    font-size: 70%;
+  }
+}
+
 .rbc-day-slot .rbc-event-content {
   background-color: var(--mui-palette-primary-main);
   color: var(--mui-palette-primary-contrastText);
   font-size: 90%;
-  width: 60%;
+  width: 75%;
   flex: 1 1 0;
-  word-wrap: break-word;
+  word-wrap: normal;
   line-height: 1;
   height: 100%;
   min-height: 1em;
 }
-
+@media (max-width: 1152px) {
+  .rbc-day-slot .rbc-event-content {
+    font-size: 70%;
+  }
+}
 .rbc-day-slot .rbc-event,
 .rbc-day-slot .rbc-background-event {
   border: 1px solid var(--mui-palette-primary-main);

--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
@@ -3,6 +3,7 @@ import { CourseEvent, Schedule, scheduleCalendarResources } from 'services/sched
 import './ScheduleCalendar.css';
 import { DateTime } from 'luxon';
 import { useWindowSize } from 'hooks';
+import { isNull } from 'lodash';
 
 const localizer = luxonLocalizer(DateTime, { firstDayOfWeek: 1 });
 
@@ -24,6 +25,8 @@ const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
 
     if (course.location.includes('ASY')) {
       title = `${course.title.replaceAll(' ', '')} | ASYNC`;
+    } else if (course.location.includes('null')) {
+      title = `${course.title.replaceAll(' ', '')}`;
     } else {
       title = `${course.title.replaceAll(' ', '')} \n${course.location}`;
     }

--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
@@ -23,7 +23,7 @@ const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
     let title;
 
     if (course.location.includes('ASY')) {
-      title = `${course.title} | ASYNC`;
+      title = `${course.title.replaceAll(' ', '')} | ASYNC`;
     } else {
       title = `${course.title.replaceAll(' ', '')} \n${course.location}`;
     }

--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
@@ -18,13 +18,13 @@ const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
   dayEnd.setHours(22, 0, 0, 0);
 
   const courseFormat = schedule.courses.map((course) => {
-    // let title = `${course.title.replaceAll(' ', '')}`;
+    let tempTitle = `${course.title.replaceAll(' ', '')}`;
     let title;
     course.location.includes('ASY')
-      ? (title = ' | ASYNC')
+      ? (title = tempTitle + ' | ASYNC')
       : course.location.includes('null')
-        ? (title = 'hello')
-        : (title = `\n${course.location}`);
+        ? (title = tempTitle)
+        : (title = tempTitle + `\n${course.location}`);
     return { ...course, title };
   });
 

--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
@@ -21,10 +21,11 @@ const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
 
   const courseFormat = schedule.courses.map((course) => {
     let title;
+
     if (course.location.includes('ASY')) {
-      title = `${course.title}${width >= 1500 ? ' | ' : ' '} ${course.location}`;
+      title = `${course.title} | ASYNC`;
     } else {
-      title = `${course.title}${width >= 2212 ? ' | ' : ' '} ${course.location}`;
+      title = `${course.title.replaceAll(' ', '')} \n${course.location}`;
     }
 
     return { ...course, title };
@@ -32,6 +33,7 @@ const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
 
   return (
     <Calendar
+      style={{ whiteSpace: 'pre-wrap' }}
       events={courseFormat}
       localizer={localizer}
       min={dayStart}

--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
@@ -2,7 +2,6 @@ import { Calendar, luxonLocalizer } from 'react-big-calendar';
 import { CourseEvent, Schedule, scheduleCalendarResources } from 'services/schedule';
 import './ScheduleCalendar.css';
 import { DateTime } from 'luxon';
-import { useWindowSize } from 'hooks';
 
 const localizer = luxonLocalizer(DateTime, { firstDayOfWeek: 1 });
 
@@ -12,7 +11,6 @@ type Props = {
 };
 
 const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
-  const [width] = useWindowSize();
   const dayStart = new Date();
   dayStart.setHours(8, 0, 0, 0);
 
@@ -20,18 +18,19 @@ const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
   dayEnd.setHours(22, 0, 0, 0);
 
   const courseFormat = schedule.courses.map((course) => {
+    // let title = `${course.title.replaceAll(' ', '')}`;
     let title;
-    if (course.location.includes('ASY')) {
-      title = `${course.title}${width >= 1500 ? ' | ' : ' '} ${course.location}`;
-    } else {
-      title = `${course.title}${width >= 2212 ? ' | ' : ' '} ${course.location}`;
-    }
-
+    course.location.includes('ASY')
+      ? (title = ' | ASYNC')
+      : course.location.includes('null')
+        ? (title = 'hello')
+        : (title = `\n${course.location}`);
     return { ...course, title };
   });
 
   return (
     <Calendar
+      style={{ whiteSpace: 'pre-wrap' }}
       events={courseFormat}
       localizer={localizer}
       min={dayStart}

--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
@@ -3,7 +3,6 @@ import { CourseEvent, Schedule, scheduleCalendarResources } from 'services/sched
 import './ScheduleCalendar.css';
 import { DateTime } from 'luxon';
 import { useWindowSize } from 'hooks';
-import { isNull } from 'lodash';
 
 const localizer = luxonLocalizer(DateTime, { firstDayOfWeek: 1 });
 
@@ -22,13 +21,10 @@ const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
 
   const courseFormat = schedule.courses.map((course) => {
     let title;
-
     if (course.location.includes('ASY')) {
-      title = `${course.title.replaceAll(' ', '')} | ASYNC`;
-    } else if (course.location.includes('null')) {
-      title = `${course.title.replaceAll(' ', '')}`;
+      title = `${course.title}${width >= 1500 ? ' | ' : ' '} ${course.location}`;
     } else {
-      title = `${course.title.replaceAll(' ', '')} \n${course.location}`;
+      title = `${course.title}${width >= 2212 ? ' | ' : ' '} ${course.location}`;
     }
 
     return { ...course, title };
@@ -36,7 +32,6 @@ const GordonScheduleCalendar = ({ schedule, onSelectEvent }: Props) => {
 
   return (
     <Calendar
-      style={{ whiteSpace: 'pre-wrap' }}
       events={courseFormat}
       localizer={localizer}
       min={dayStart}


### PR DESCRIPTION
There were issues with the text display for quad classes and I was able to fix it by having the size of the text shrink when the screen gets smaller. I also have the location display on a new line and instead of it showing 'ONLN ASY' we decided it would be easier to understand if it just said 'ASYNC' and it fit on the screen better. I also eliminated the spaces between the course and course code, MAT 210 -> MAT210. This is now more consistent with how it is printed everywhere else throughout Gordon. I also added an else if to account for courses like Discovery that have a room number and location of null. Amos previously mentioned that null refers to an object, which is true but the best way I found to prevent it from printing 'null null' was the else if statement that I added.
#2287 