### PR TITLE
Changed Attended CL&W Link on Events Page

### DIFF
--- a/src/views/Events/index.jsx
+++ b/src/views/Events/index.jsx
@@ -10,6 +10,7 @@ import {
   FormControlLabel,
   Grid,
   TextField,
+  Link,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import EventIcon from '@mui/icons-material/Event';
@@ -185,7 +186,10 @@ const Events = () => {
                         <Button
                           color="secondary"
                           variant="contained"
-                          onClick={() => navigate('/attended')}
+                          component={Link}
+                          href="https://iattendedapp.com/"
+                          target="_blank"
+                          rel="noopener noreferrer"
                         >
                           ATTENDED CL&amp;W
                         </Button>


### PR DESCRIPTION
Changed the "Attended CL&W" Button to link to the iAttended page (same as the "Links" page).