### PR TITLE
Fix Disabled Top Tab Contrast

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -18,7 +18,7 @@
   flex-grow: 1;
 
   &.disabled_tab {
-    color: var(--mui-palette-neutral-900);
+    color: var(--mui-palette-neutral-400);
   }
 }
 


### PR DESCRIPTION
Reference #2132 
When someone is not logged in/authenticated the disabled top tabs (People and Rec-IM) now pass contrast tests. This is what they look like now...
![Screenshot from 2024-06-10 16-24-48](https://github.com/gordon-cs/gordon-360-ui/assets/123050501/47c8a509-c6e8-4725-9ab2-568fcb08d041)
When on dark mode tabs were the same color, now they look like this...
![Screenshot from 2024-06-12 11-24-49](https://github.com/gordon-cs/gordon-360-ui/assets/123050501/30f77dcf-28cc-449d-8f4e-544fe05c07c4)

The difference isn't fairly obvious from the enabled tabs but it at least passes the contrast checker.