### PR TITLE
Add Guest Transcript

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -92,6 +92,7 @@ const GordonHeader = ({ onDrawerToggle }) => {
         buttonClicked={() => setDialog(null)}
         buttonName={'Okay'}
       >
+        <br />
         {isOffline
           ? 'That page is not available offline. Please reconnect to internet to access this feature.'
           : 'That page is only available to authenticated users. Please log in to access it.'}

--- a/src/components/Nav/components/NavLinks/index.jsx
+++ b/src/components/Nav/components/NavLinks/index.jsx
@@ -7,6 +7,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import WorkIcon from '@mui/icons-material/Work';
 import { Divider, List } from '@mui/material';
 import RecIMIcon from '@mui/icons-material/SportsFootball';
+import TranscriptIcon from '@mui/icons-material/Receipt';
 import GordonDialogBox from 'components/GordonDialogBox';
 import GordonNavButton from 'components/NavButton';
 import PaletteSwitcherDialog from 'components/PaletteSwitcherDialog';
@@ -36,7 +37,7 @@ const GordonNavLinks = ({ onLinkClick }) => {
         break;
       case 'unauthorized':
         message = 'That page is only available to authenticated users. Please log in to access it.';
-        title = 'Unavailable Offline';
+        title = 'Login Required';
         break;
       default:
         message =
@@ -52,6 +53,7 @@ const GordonNavLinks = ({ onLinkClick }) => {
         buttonClicked={() => setDialog(null)}
         buttonName={'Okay'}
       >
+        <br />
         {message}
       </GordonDialogBox>
     );
@@ -63,6 +65,16 @@ const GordonNavLinks = ({ onLinkClick }) => {
       linkName={'Home'}
       linkPath={'/'}
       LinkIcon={HomeIcon}
+      divider={false}
+    />
+  );
+
+  const guestTranscriptButton = (
+    <GordonNavButton
+      onLinkClick={onLinkClick}
+      linkName={'Guest Transcript'}
+      linkPath={'Transcript'}
+      LinkIcon={TranscriptIcon}
       divider={false}
     />
   );
@@ -193,6 +205,7 @@ const GordonNavLinks = ({ onLinkClick }) => {
     <>
       <List className={styles.gordon_nav_links}>
         {homeButton}
+        {isAuthenticated ? '' : guestTranscriptButton}
         {involvementsButton}
         {eventsButton}
         {peopleButton}

--- a/src/components/Nav/components/NavLinks/index.jsx
+++ b/src/components/Nav/components/NavLinks/index.jsx
@@ -69,15 +69,15 @@ const GordonNavLinks = ({ onLinkClick }) => {
     />
   );
 
-  const guestTranscriptButton = (
+  const guestTranscriptButton = isAuthenticated ? (
     <GordonNavButton
       onLinkClick={onLinkClick}
-      linkName={'Guest Transcript'}
-      linkPath={'Transcript'}
+      linkName="Guest Transcript"
+      linkPath="Transcript"
       LinkIcon={TranscriptIcon}
       divider={false}
     />
-  );
+  ) : null;
 
   const involvementsButton = (
     <GordonNavButton
@@ -205,7 +205,7 @@ const GordonNavLinks = ({ onLinkClick }) => {
     <>
       <List className={styles.gordon_nav_links}>
         {homeButton}
-        {isAuthenticated ? '' : guestTranscriptButton}
+        {guestTranscriptButton}
         {involvementsButton}
         {eventsButton}
         {peopleButton}


### PR DESCRIPTION
Finishes #580 
Added the Guest Transcript to the side navigation bar for users that aren't logged in, looks like this...
![Screenshot from 2024-06-17 11-56-15](https://github.com/gordon-cs/gordon-360-ui/assets/123050501/ca150b65-1584-4e82-92cb-b466cb5690be)
Talked with Amos and adding a guest transcript button to the header would make it too cluttered. 

Once you log in it disappears from the side navigation bar. And if you are on the transcript page when you log in then it just changes to your personal transcript.

I also changed the dialog box content to more accurately reflect what the user needs to do, and added a break to just make it look better. Looks like this...
![Screenshot from 2024-06-17 11-55-11](https://github.com/gordon-cs/gordon-360-ui/assets/123050501/ccb2374a-60e5-4fdd-a1b3-70691d181bf4)
Mobile:
![Screenshot from 2024-06-17 11-55-35](https://github.com/gordon-cs/gordon-360-ui/assets/123050501/8f890b40-58e6-4908-bc40-84e7bc722a34)
