### PR TITLE
Guest Transcript Button for Logged Out Only

### DIFF
--- a/src/components/Nav/components/NavLinks/index.jsx
+++ b/src/components/Nav/components/NavLinks/index.jsx
@@ -69,7 +69,7 @@ const GordonNavLinks = ({ onLinkClick }) => {
     />
   );
 
-  const guestTranscriptButton = isAuthenticated ? (
+  const guestTranscriptButton = !isAuthenticated ? (
     <GordonNavButton
       onLinkClick={onLinkClick}
       linkName="Guest Transcript"


### PR DESCRIPTION
Switch guest transcript button to show only for users who aren't logged in. Was showing for logged in users... (Whoops).