### PR TITLE
Removes schedule for non student/teachers

### DIFF
--- a/src/components/Profile/components/SchedulePanel/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/index.tsx
@@ -32,7 +32,6 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
   const [isScheduleOpen, setIsScheduleOpen] = useState<boolean>(
     localStorage.getItem(scheduleOpenKey) !== 'false',
   );
-
   useEffect(() => {
     setLoading(true);
 
@@ -47,11 +46,9 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
         // Otherwise, use the most recent session
         allSessionSchedules[0];
       setSelectedSchedule(defaultSchedule);
-
       setLoading(false);
     });
   }, [profile.AD_Username]);
-
   const toggleIsScheduleOpen = () => {
     setIsScheduleOpen((wasOpen) => {
       localStorage.setItem(scheduleOpenKey, String(!wasOpen));
@@ -68,57 +65,65 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
         onChange={toggleIsScheduleOpen}
         TransitionProps={{ unmountOnExit: true }}
       >
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon className={styles.expandIcon} />}
-          aria-controls="schedule"
-          id="schedule-header"
-          className={`gc360_header ${styles.accordionHeader}`}
-        >
-          <CardHeader title={'Schedule'} />
-        </AccordionSummary>
-        <AccordionDetails>
-          <Grid container justifyContent="center" spacing={4}>
-            <Grid item xs={12} lg={3}>
-              <TextField
-                label="Term"
-                id="schedule-session"
-                value={selectedSchedule?.session.SessionCode ?? ''}
-                onChange={(e) =>
-                  setSelectedSchedule(
-                    allSchedules.find((s) => s.session.SessionCode === e.target.value) ?? null,
-                  )
-                }
-                select
-              >
-                {allSchedules.map(
-                  ({ session: { SessionDescription: description, SessionCode: code } }) => (
-                    <MenuItem value={code} key={code}>
-                      {description}
-                    </MenuItem>
-                  ),
-                )}
-              </TextField>
-            </Grid>
-            <Grid lg={7}></Grid>
-            {selectedSchedule && (
-              <>
-                <Grid item className={styles.addCalendarInfoText}>
-                  {myProf && (
-                    <Typography className={styles.addCalendarInfoText}>
-                      Click on Course to add Schedule to Personal Calendar
-                    </Typography>
+        {allSchedules.length > 0 ? (
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon className={styles.expandIcon} />}
+            aria-controls="schedule"
+            id="schedule-header"
+            className={`gc360_header ${styles.accordionHeader}`}
+          >
+            <CardHeader title={'Course Schedule'} />
+          </AccordionSummary>
+        ) : (
+          <div></div>
+        )}
+        {allSchedules.length > 0 ? (
+          <AccordionDetails>
+            <Grid container justifyContent="center" spacing={4}>
+              <Grid item xs={12} lg={3}>
+                <TextField
+                  label="Term"
+                  id="schedule-session"
+                  value={selectedSchedule?.session.SessionCode ?? ''}
+                  onChange={(e) =>
+                    setSelectedSchedule(
+                      allSchedules.find((s) => s.session.SessionCode === e.target.value) ?? null,
+                    )
+                  }
+                  select
+                >
+                  {allSchedules.map(
+                    ({ session: { SessionDescription: description, SessionCode: code } }) => (
+                      <MenuItem value={code} key={code}>
+                        {description}
+                      </MenuItem>
+                    ),
                   )}
-                </Grid>
-                <Grid item xs={12} lg={10}>
-                  <GordonScheduleCalendar
-                    schedule={selectedSchedule}
-                    onSelectEvent={setSelectedCourse}
-                  />
-                </Grid>
-              </>
-            )}
-          </Grid>
-        </AccordionDetails>
+                </TextField>
+              </Grid>
+              <Grid lg={7}></Grid>
+              {selectedSchedule && (
+                <>
+                  <Grid item className={styles.addCalendarInfoText}>
+                    {myProf && (
+                      <Typography className={styles.addCalendarInfoText}>
+                        Click on Course to add Schedule to Personal Calendar
+                      </Typography>
+                    )}
+                  </Grid>
+                  <Grid item xs={12} lg={10}>
+                    <GordonScheduleCalendar
+                      schedule={selectedSchedule}
+                      onSelectEvent={setSelectedCourse}
+                    />
+                  </Grid>
+                </>
+              )}
+            </Grid>
+          </AccordionDetails>
+        ) : (
+          <div></div>
+        )}
       </Accordion>
       {myProf && selectedCourse && selectedSchedule && (
         <ScheduleDialog


### PR DESCRIPTION
For a someone without a schedule like an athletic coach, they will see the schedule tab and a small drop-down menu with unreadable text inside. I removed the schedule tab entirely if the user has had no courses past or present, the schedule will only display on the users profile if they have been a part of at least one course. I also made the title of the schedule tab say 'Course Schedule' instead of just 'Schedule' this will hopefully add a little more clarity for people such as athletes who might be looking for practice times or any other reason.
[#2324](https://github.com/gordon-cs/gordon-360-ui/issues/2324)