### PR TITLE
Centers all text when screen gets smaller

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/PersonalInfoList.module.scss
+++ b/src/components/Profile/components/PersonalInfoList/PersonalInfoList.module.scss
@@ -85,3 +85,19 @@
   font-size: 0.9rem;
   font-weight: bold;
 }
+.header {
+  padding-left: 0rem;
+  justify-content: left;
+  background-color: var(--mui-palette-primary-main);
+  color: var(--mui-palette-primary-contrastText);
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+@media (max-width: $break-sm) {
+  .header {
+    padding-left: 0rem;
+    justify-content: center;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+}

--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -683,7 +683,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
           alignItems="center"
           className={styles.personal_info_list_header}
         >
-          <Grid item xs={8}>
+          <Grid container className={styles.header}>
             <CardHeader title="Personal Information" />
           </Grid>
           <Grid item xs={4} align="right">

--- a/src/components/Profile/components/SchedulePanel/ScheduleHeader.module.scss
+++ b/src/components/Profile/components/SchedulePanel/ScheduleHeader.module.scss
@@ -1,3 +1,5 @@
+@import '../../../../vars';
+
 .accordionHeader {
   & :global(.MuiAccordionSummary-content) {
     margin: 0;
@@ -11,4 +13,20 @@
   overflow-wrap: break-word;
   color: var(--mui-palette-secondary-main);
   font-weight: bold;
+}
+.header {
+  padding-left: 0rem;
+  justify-content: left;
+  background-color: var(--mui-palette-primary-main);
+  color: var(--mui-palette-primary-contrastText);
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+@media (max-width: $break-sm) {
+  .header {
+    padding-left: 0rem;
+    justify-content: center;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
 }

--- a/src/components/Profile/components/SchedulePanel/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/index.tsx
@@ -74,7 +74,9 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
           id="schedule-header"
           className={`gc360_header ${styles.accordionHeader}`}
         >
-          <CardHeader title={'Schedule'} />
+          <Grid container className={styles.header}>
+            <CardHeader title={'Course Schedule'} />
+          </Grid>
         </AccordionSummary>
         <AccordionDetails>
           <Grid container justifyContent="center" spacing={4}>


### PR DESCRIPTION
This centers the text in every tab on the profile page when the screen gets smaller. This adds consistency and looks overall cleaner and more uniformed.
[#2325](https://github.com/gordon-cs/gordon-360-ui/issues/2325)