### PR TITLE
Fix People Rec-IM Tab Error

### DIFF
--- a/src/components/Nav/components/NavLinks/index.tsx
+++ b/src/components/Nav/components/NavLinks/index.tsx
@@ -105,7 +105,7 @@ const GordonNavLinks = ({ onLinkClick }: Props) => {
 
   const peopleButton = (
     <GordonNavButton
-      unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : ''}
+      unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : null}
       onLinkClick={onLinkClick}
       openUnavailableDialog={setDialog}
       divider={false}
@@ -125,21 +125,9 @@ const GordonNavLinks = ({ onLinkClick }: Props) => {
     />
   );
 
-  const timesheetsButton = (
-    <GordonNavButton
-      unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : ''}
-      openUnavailableDialog={setDialog}
-      onLinkClick={onLinkClick}
-      linkName={'Timesheets'}
-      linkPath={'/timesheets'}
-      LinkIcon={WorkIcon}
-      divider={false}
-    />
-  );
-
   const recimButton = (
     <GordonNavButton
-      unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : ''}
+      unavailable={!isOnline ? 'offline' : !isAuthenticated ? 'unauthorized' : null}
       openUnavailableDialog={setDialog}
       onLinkClick={onLinkClick}
       linkName={'Rec-IM'}


### PR DESCRIPTION
When a user is logged in, the People and Rec-IM tabs are disabled in the hamburger menu...
![image](https://github.com/gordon-cs/gordon-360-ui/assets/156944565/8460877e-9490-4bf0-80bc-2e0b6e60132f)
Now the user is able to navigate through the hamburger menu for both people and RECIM the rest worked prior to this issue so those were left alone. #2329 