### PR TITLE
Fix Hamburger Tab Navigation

### DIFF
--- a/src/components/NavButton/index.tsx
+++ b/src/components/NavButton/index.tsx
@@ -1,5 +1,5 @@
 import { ListItem, ListItemIcon, ListItemText } from '@mui/material';
-import { Link, NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
 type GordonNavButtonProps = {
   unavailable?: string | null;

--- a/src/components/NavButton/index.tsx
+++ b/src/components/NavButton/index.tsx
@@ -1,5 +1,5 @@
 import { ListItem, ListItemIcon, ListItemText } from '@mui/material';
-import { NavLink } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 
 type GordonNavButtonProps = {
   unavailable?: string | null;
@@ -51,16 +51,21 @@ const GordonNavButton = ({
         <ListItemText primary={linkName} />
       </ListItem>
     ) : (
-      <NavLink end to={linkPath} onClick={onLinkClick}>
-        <ListItem divider={divider} button className="gc360_link">
-          {LinkIcon && (
-            <ListItemIcon>
-              <LinkIcon />
-            </ListItemIcon>
-          )}
-          <ListItemText primary={linkName} />
-        </ListItem>
-      </NavLink>
+      <ListItem
+        divider={divider}
+        button
+        className="gc360_link"
+        component={NavLink}
+        to={linkPath}
+        onClick={onLinkClick}
+      >
+        {LinkIcon && (
+          <ListItemIcon>
+            <LinkIcon />
+          </ListItemIcon>
+        )}
+        <ListItemText primary={linkName} />
+      </ListItem>
     );
 
   if (unavailable) {


### PR DESCRIPTION
Fixes #2285 
Can now navigate tabs expanded from hamburger with keyboard correctly. Only takes one tab key press to go from one item to another. When tab is highlighted and enter key is pressed you now go to the page.