### PR TITLE
Fix Header Tab Keyboard Navigation

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -132,7 +132,7 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
           label={name}
           component={NavLink}
           to={route}
-          tabIndex={name == 'People' ? 5 : 7}
+          tabIndex={0}
         />
       );
     }
@@ -159,11 +159,10 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
             aria-label="open drawer"
             onClick={onDrawerToggle}
             size="large"
-            tabIndex={1}
           >
             <MenuIcon className={styles.hamburger_menu_button_icon} />
           </IconButton>
-          <Link to="/" component={NavLink} tabIndex={2}>
+          <Link to="/" component={NavLink}>
             <picture>
               {/* pick a different image as the screen gets smaller.*/}
               <source srcSet={headerLogo72dpi} media="(min-width: 900px)" />
@@ -186,7 +185,7 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
             label="Involvements"
             component={NavLink}
             to="/involvements"
-            tabIndex={3}
+            tabIndex={0}
           />
           <Tab
             className={styles.tab}
@@ -194,7 +193,7 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
             label="Events"
             component={NavLink}
             to="/events"
-            tabIndex={4}
+            tabIndex={0}
           />
           {requiresAuthTab('People', <PeopleIcon />)}
           <Tab
@@ -203,7 +202,7 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
             label="Links"
             component={NavLink}
             to="/links"
-            tabIndex={6}
+            tabIndex={0}
           />
           {requiresAuthTab('Rec-IM', <RecIMIcon />)}
         </Tabs>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -125,7 +125,16 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
       );
     } else {
       const route = `/${name.toLowerCase().replace('-', '')}`;
-      return <Tab className={styles.tab} icon={icon} label={name} component={NavLink} to={route} />;
+      return (
+        <Tab
+          className={styles.tab}
+          icon={icon}
+          label={name}
+          component={NavLink}
+          to={route}
+          tabIndex={name == 'People' ? 5 : 7}
+        />
+      );
     }
   };
 
@@ -150,10 +159,11 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
             aria-label="open drawer"
             onClick={onDrawerToggle}
             size="large"
+            tabIndex={1}
           >
             <MenuIcon className={styles.hamburger_menu_button_icon} />
           </IconButton>
-          <Link to="/" component={NavLink}>
+          <Link to="/" component={NavLink} tabIndex={2}>
             <picture>
               {/* pick a different image as the screen gets smaller.*/}
               <source srcSet={headerLogo72dpi} media="(min-width: 900px)" />
@@ -176,7 +186,7 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
             label="Involvements"
             component={NavLink}
             to="/involvements"
-            tabIndex={0}
+            tabIndex={3}
           />
           <Tab
             className={styles.tab}
@@ -184,6 +194,7 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
             label="Events"
             component={NavLink}
             to="/events"
+            tabIndex={4}
           />
           {requiresAuthTab('People', <PeopleIcon />)}
           <Tab
@@ -192,6 +203,7 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
             label="Links"
             component={NavLink}
             to="/links"
+            tabIndex={6}
           />
           {requiresAuthTab('Rec-IM', <RecIMIcon />)}
         </Tabs>


### PR DESCRIPTION
Fixes #1390 
Allows all header tabs to be accessed via keyboard by pressing the tab key. The conversation about this was a while ago, so I'm not sure if we still want every header tab to be accessible by pressing the enter key or if the original functionality (just using the arrow keys to navigate the header tabs) is good. If the original functionality is fine then I will just close the issue referenced.