### PR TITLE
Fix 2 birthday bugs: day born vs. birthday, and no birthday

### DIFF
--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -268,8 +268,6 @@ const isBirthdayToday = (): Promise<boolean> => {
   );
 };
 
-//birthday?.month === DateTime.now().month && birthday?.day === DateTime.now().day
-
 const getProfileInfo = async (username: string = ''): Promise<Profile | undefined> => {
   const profile = await getProfile(username).then(formatCountry).then(formatSocialMediaLinks);
 

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -259,7 +259,16 @@ const setImagePrivacy = (makePrivate: boolean) =>
 const getBirthdate = (): Promise<Date> =>
   http.get<string>('profiles/birthdate').then((birthdate) => new Date(birthdate));
 
-const isBirthdayToday = (): Promise<boolean> => getBirthdate().then(isToday);
+const isBirthdayToday = (): Promise<boolean> => {
+  return getBirthdate().then(
+    (birthdate) =>
+      birthdate.getMonth() == new Date().getMonth() &&
+      birthdate.getDate() == new Date().getDate() &&
+      birthdate.getFullYear() > 1800, // Birth in 1800 means no birthday in database
+  );
+};
+
+//birthday?.month === DateTime.now().month && birthday?.day === DateTime.now().day
 
 const getProfileInfo = async (username: string = ''): Promise<Profile | undefined> => {
   const profile = await getProfile(username).then(formatCountry).then(formatSocialMediaLinks);


### PR DESCRIPTION
This fixes a bug for users without a birthday, introduced by https://github.com/gordon-cs/gordon-360-api/pull/1052 which sets a default birthday of 1/1/1800 for users without a birthday, so they don't get a message on Jan 1.

This also fixes a bug introduced in in https://github.com/gordon-cs/gordon-360-ui/pull/2317, which accidentally switched from checking for matching month and day to matching full birthdate.  (That effectively turned off the birthday message, since nobody logs in until years after they are born.)

Tested by editing gordon-cs\gordon-360-api\Gordon360\Services\ProfileService.cs, line 83, to set various default dates (like today, and this date last year), then running the test API server to test the UI.