### PR TITLE
S24 mailbox information

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -98,7 +98,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
     async function loadPersonalInfo() {
       if (isStudent) {
         if (myProf) {
-          const info = await userService.getMailboxCombination();
+          const info = await userService.getMailboxInformation();
           setMailCombo(info.Combination);
         }
         if (canViewAcademicInfo || myProf) {

--- a/src/components/Profile/components/PersonalInfoList/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/index.jsx
@@ -94,6 +94,8 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }) => {
 
   // FacStaff spouses are private for private users
   const isSpousePrivate = isFacStaff && keepPrivate && profile.SpouseName !== PRIVATE_INFO;
+
+  // Get a student's mailbox combination and advisor using information in their profile
   useEffect(() => {
     async function loadPersonalInfo() {
       if (isStudent) {

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -229,7 +229,7 @@ const getProfile = (username: string = ''): Promise<UnformattedProfileInfo> =>
 const getAdvisors = (username: string): Promise<StudentAdvisorInfo[]> =>
   http.get(`profiles/Advisors/${username}/`);
 
-const getMailboxCombination = () => http.get('profiles/mailbox-combination/');
+const getMailboxInformation = () => http.get('profiles/mailbox-information/');
 
 const getMailStops = (): Promise<string[]> => http.get(`profiles/mailstops`);
 
@@ -355,7 +355,7 @@ const userService = {
   getDiningInfo,
   getProfileInfo,
   getAdvisors,
-  getMailboxCombination,
+  getMailboxInformation,
   getMembershipHistory,
   resetImage,
   postImage,


### PR DESCRIPTION
Adjusted API route name from `/api/profiles/mailbox-combination` to `/api/profiles/mailbox-information` since other information than just the combination may be present in the JSON received.  This change is probably not important enough to warrant a change on its own, but matches changes in the API that were made to clean things up while removing an unnecessary thrown exception.

See PR 1056 in gordon-360-api