### PR TITLE
Clicking Appearance Button Stays on Current Page

### DIFF
--- a/src/components/Nav/components/NavLinks/index.tsx
+++ b/src/components/Nav/components/NavLinks/index.tsx
@@ -143,6 +143,7 @@ const GordonNavLinks = ({ onLinkClick }: Props) => {
         onLinkClick();
         setPaletteOptionsOpen(true);
       }}
+      openUnavailableDialog={setDialog}
       linkName={'Appearance'}
       linkPath={window.location.pathname}
     />

--- a/src/components/Nav/components/NavLinks/index.tsx
+++ b/src/components/Nav/components/NavLinks/index.tsx
@@ -143,8 +143,8 @@ const GordonNavLinks = ({ onLinkClick }: Props) => {
         onLinkClick();
         setPaletteOptionsOpen(true);
       }}
-      openUnavailableDialog={setDialog}
       linkName={'Appearance'}
+      linkPath={window.location.pathname}
     />
   );
 


### PR DESCRIPTION
Fixes #2337 
Clicking the appearance button to change color modes now stays on your current page rather than navigating to the home page.