### PR TITLE
graph-does-display

### DIFF
--- a/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
+++ b/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
@@ -46,7 +46,7 @@ const GraphDisplay = ({ scores }: Props) => {
         ],
       }}
       options={{
-        responsive: true,
+        responsive: false,
         plugins: {
           tooltip: {
             callbacks: {

--- a/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
+++ b/src/components/Profile/components/VictoryPromise/components/GraphDisplay.tsx
@@ -13,7 +13,7 @@ const data = new Array<number>(4);
 type Props = { scores: Record<VictoryPromiseCategory, number> };
 
 const GraphDisplay = ({ scores }: Props) => {
-  const minimumScore = Math.min(...Object.values(scores).filter((v) => v > 0)) || 1;
+  const minimumScore = Math.min(...Object.values(scores).filter((v) => v === 0)) || 1;
   /**
    * A 0 value won't display on the graph, so we use `emptySliceValue` to represent empty values,
    * which is 2/3 of the minimum non-zero score


### PR DESCRIPTION
When  a user had zero victory promise points the graph wont display, that is fixed but apparently the graph cannot be changed to its original size, there are two sizes I was able to get and I am curious of your thoughts. #2342 
![Screenshot from 2024-07-02 09-41-03](https://github.com/gordon-cs/gordon-360-ui/assets/156944565/d3f25289-688a-49a1-9374-fd5cbf4aa620)
![Screenshot from 2024-07-02 09-42-37](https://github.com/gordon-cs/gordon-360-ui/assets/156944565/19c97f7c-4ce3-4875-88d4-034776174df4)
