### PR TITLE
Add Filter Reminder for Events Page

### DIFF
--- a/src/views/Events/index.jsx
+++ b/src/views/Events/index.jsx
@@ -38,7 +38,7 @@ const Events = () => {
   const [includePast, setIncludePast] = useState(false);
   const [loading, setLoading] = useState(true);
   const [filters, setFilters] = useState([]);
-  const [timeFilter, setTimeFilter] = useState('');
+  const [timeFilter, setTimeFilter] = useState('2 Weeks');
   const [hasInitializedEvents, setHasInitializedEvents] = useState(false);
   const futureEvents = useMemo(() => gordonEvent.getFutureEvents(allEvents), [allEvents]);
   const [width] = useWindowSize();
@@ -144,6 +144,24 @@ const Events = () => {
       Events
     </div>
   );
+
+  let filterReminder;
+
+  if (timeFilter != '') {
+    filterReminder = (
+      <div align="center">
+        Your search is limited to {timeFilter}. Check out the top of the page if you want to change
+        your filters.
+      </div>
+    );
+  } else {
+    filterReminder = (
+      <div align="center">
+        You have reached the end of Gordon's events. Check out the top of the page if you want to
+        add filters.
+      </div>
+    );
+  }
 
   if (width >= 920) {
     return (
@@ -280,6 +298,7 @@ const Events = () => {
           <Grid item xs={12}>
             {content}
           </Grid>
+          <CardHeader item xs={12} className="gc360_header" title={filterReminder} />
         </Grid>
       </Grid>
     );
@@ -420,6 +439,7 @@ const Events = () => {
           <Grid item xs={12}>
             {content}
           </Grid>
+          <CardHeader item xs={12} className="gc360_header" title={filterReminder} />
         </Grid>
       </Grid>
     );


### PR DESCRIPTION
Sets default filter to "2 Weeks" and adds a card header at the bottom of the event list to remind the user of the current time filter being used.
For "2 Weeks" default filter
<img width="1088" alt="Screenshot 2024-07-08 at 9 19 45 AM" src="https://github.com/gordon-cs/gordon-360-ui/assets/123050501/7f677b3f-5d0d-4e6c-bacc-7dc95dd7ead8">
Mobile:
<img width="284" alt="Screenshot 2024-07-08 at 9 19 56 AM" src="https://github.com/gordon-cs/gordon-360-ui/assets/123050501/9da79d64-e5a7-4a8f-b1cc-fffb9aeca692">
For "All" events
<img width="1073" alt="Screenshot 2024-07-08 at 9 21 29 AM" src="https://github.com/gordon-cs/gordon-360-ui/assets/123050501/18499b92-c856-4615-824d-d70f0f8c955d">
Mobile:
<img width="279" alt="Screenshot 2024-07-08 at 9 21 21 AM" src="https://github.com/gordon-cs/gordon-360-ui/assets/123050501/8d822d88-3966-4615-9220-ed799ed976a7">
