### PR TITLE
new-menu-linked-on-dining-balance

### DIFF
--- a/src/views/Home/components/DiningBalance/index.jsx
+++ b/src/views/Home/components/DiningBalance/index.jsx
@@ -228,7 +228,7 @@ const DiningBalance = () => {
                 variant="contained"
                 color="secondary"
                 component={Link}
-                href="https://gordon.cafebonappetit.com/"
+                href="https://www.gordonmetz.com/"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
I have gotten the link for metz and the new dining services so now That link is clickable for Todays Menu on dining balance. Website is mainly operational, some things will be upgraded but the link should work no matter what. 
https://github.com/orgs/gordon-cs/projects/15/views/1?pane=issue&itemId=65814033