### PR TITLE
HashLinks to Top/Bottom Events Page

### DIFF
--- a/src/views/Events/index.jsx
+++ b/src/views/Events/index.jsx
@@ -16,6 +16,7 @@ import {
   Select,
   TextField,
 } from '@mui/material';
+import { HashLink } from 'react-router-hash-link';
 import AddIcon from '@mui/icons-material/Add';
 import EventIcon from '@mui/icons-material/Event';
 import FilterListIcon from '@mui/icons-material/FilterList';
@@ -149,17 +150,45 @@ const Events = () => {
 
   if (timeFilter != '') {
     filterReminder = (
-      <div align="center">
-        Your search is limited to {timeFilter}. Check out the top of the page if you want to change
-        your filters.
-      </div>
+      <>
+        <div align="center">
+          Your search is limited to {timeFilter}. Check out the top of the page if you want to
+          change your filters.
+        </div>
+        <div align="center">
+          <Button
+            variant="contained"
+            color="secondary"
+            component={HashLink}
+            to="#top"
+            smooth
+            id="bottom"
+          >
+            Jump to Top
+          </Button>
+        </div>
+      </>
     );
   } else {
     filterReminder = (
-      <div align="center">
-        You have reached the end of Gordon's events. Check out the top of the page if you want to
-        add filters.
-      </div>
+      <>
+        <div align="center">
+          You have reached the end of Gordon's events. Check out the top of the page if you want to
+          add filters.
+        </div>
+        <div align="center">
+          <Button
+            variant="contained"
+            color="secondary"
+            component={HashLink}
+            to="#top"
+            smooth
+            id="bottom"
+          >
+            Jump to Top
+          </Button>
+        </div>
+      </>
     );
   }
 
@@ -167,7 +196,7 @@ const Events = () => {
     return (
       <Grid container justifyContent="center" spacing={6}>
         <Grid item xs={12} lg={10} xl={8}>
-          <CardHeader title={searchPageTitle} className="gc360_header" />
+          <CardHeader title={searchPageTitle} className="gc360_header" id="top" />
           <Card style={{ padding: '0 3vw' }}>
             <CardContent>
               {/* Search Bar and Filters */}
@@ -248,7 +277,7 @@ const Events = () => {
                           }
                           value={filters}
                           renderInput={(param) => (
-                            <TextField {...param} variant="filled" label="Filters" />
+                            <TextField {...param} variant="filled" label="Event Type" />
                           )}
                         />
                       </Grid>
@@ -291,6 +320,18 @@ const Events = () => {
                       </Grid>
                     </Grid>
                   </Collapse>
+                  <Grid item container marginTop={2} justifyContent="center" alignItems="center">
+                    <Button
+                      variant="contained"
+                      color="secondary"
+                      component={HashLink}
+                      to="#bottom"
+                      smooth
+                      id="top"
+                    >
+                      Jump to Bottom
+                    </Button>
+                  </Grid>
                 </Grid>
               </Grid>
             </CardContent>
@@ -302,7 +343,7 @@ const Events = () => {
           <Grid item xs={12}>
             {content}
           </Grid>
-          <CardHeader item xs={12} className="gc360_header" title={filterReminder} />
+          <CardHeader item xs={12} className="gc360_header" title={filterReminder} id="bottom" />
         </Grid>
       </Grid>
     );
@@ -310,7 +351,7 @@ const Events = () => {
     return (
       <Grid container justifyContent="center" spacing={6}>
         <Grid item xs={12} lg={10} xl={8}>
-          <CardHeader title={searchPageTitle} className="gc360_header" />
+          <CardHeader title={searchPageTitle} className="gc360_header" id="top" />
           <Card style={{ padding: '0 3vw' }}>
             <CardContent>
               {/* Search Bar and Filters */}
@@ -408,7 +449,7 @@ const Events = () => {
                           ))
                         }
                         renderInput={(param) => (
-                          <TextField {...param} variant="filled" label="Filters" />
+                          <TextField {...param} variant="filled" label="Event Type" />
                         )}
                       />
                     </Grid>
@@ -439,6 +480,18 @@ const Events = () => {
                     </Grid>
                   </Grid>
                 </Collapse>
+                <Grid item container marginTop={2} justifyContent="center" alignItems="center">
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    component={HashLink}
+                    to="#bottom"
+                    smooth
+                    id="top"
+                  >
+                    Jump to Bottom
+                  </Button>
+                </Grid>
               </Grid>
             </CardContent>
           </Card>

--- a/src/views/Events/index.jsx
+++ b/src/views/Events/index.jsx
@@ -300,7 +300,7 @@ const Events = () => {
 
                       <Grid item xs={8}>
                         <FormControl fullWidth variant="filled">
-                          <InputLabel id="event-time">Time Filters</InputLabel>
+                          <InputLabel id="event-time">Time Window</InputLabel>
                           <Select
                             labelId="event-time"
                             id="even-time"
@@ -460,7 +460,7 @@ const Events = () => {
                     )}
                     <Grid item xs={11}>
                       <FormControl fullWidth variant="filled">
-                        <InputLabel id="event-time">Time Filters</InputLabel>
+                        <InputLabel id="event-time">Time Window</InputLabel>
                         <Select
                           labelId="event-time"
                           id="even-time"


### PR DESCRIPTION
Changed Filter names to be more descriptive. "Filter" to "Event Types" and "Time Filters" to "Time Window"
Added HashLinks to Events Page so you can jump from top to bottom and vice versa.
<img width="1179" alt="Screenshot 2024-07-10 at 4 22 18 PM" src="https://github.com/gordon-cs/gordon-360-ui/assets/123050501/45354a9d-1e9e-44e3-a80b-9f8ed24e4417">
<img width="1178" alt="Screenshot 2024-07-10 at 4 22 34 PM" src="https://github.com/gordon-cs/gordon-360-ui/assets/123050501/ae6f6576-48a5-4cdd-b019-1c9cc9259a9a">
<img width="362" alt="Screenshot 2024-07-10 at 4 29 47 PM" src="https://github.com/gordon-cs/gordon-360-ui/assets/123050501/5344bbff-356b-41b2-bbfc-359d23bcb567">
<img width="362" alt="Screenshot 2024-07-10 at 4 23 01 PM" src="https://github.com/gordon-cs/gordon-360-ui/assets/123050501/b3f73ac0-9dd1-4b61-ac3f-9bafce0c7619">
