### PR TITLE
s24-add descriptors for links

### DIFF
--- a/src/views/Links/index.jsx
+++ b/src/views/Links/index.jsx
@@ -111,7 +111,7 @@ const Links = () => (
                   className={`gc360_text_link`}
                   target="_blank"
                 >
-                  <ListItemText primary="Criterion"></ListItemText>
+                  <ListItemText primary="Criterion (Timesheets)"></ListItemText>
                 </Link>
               </ListItem>
               <ListItem>
@@ -137,7 +137,7 @@ const Links = () => (
                   className={`gc360_text_link`}
                   target="_blank"
                 >
-                  <ListItemText primary="25Live"></ListItemText>
+                  <ListItemText primary="25Live (Scheduling)"></ListItemText>
                 </Link>
               </ListItem>
               <ListItem>


### PR DESCRIPTION
**Changes made in PR:**
- Added descriptors for Criterion and 25Live on the Links page