### PR TITLE
Give Pencil Icon Buttons Labels for Screen Reader

### DIFF
--- a/src/components/Profile/components/Identification/components/SocialMediaLinks/index.jsx
+++ b/src/components/Profile/components/Identification/components/SocialMediaLinks/index.jsx
@@ -50,6 +50,7 @@ const SocialMediaLinks = ({ profile, createSnackbar, myProf }) => {
                     className={styles.gc360_my_profile_edit_icon}
                     onClick={() => setSocialLinksOpen(true)}
                     size="large"
+                    aria-label="Update social media links"
                   >
                     <EditIcon />
                   </IconButton>

--- a/src/components/Profile/components/PersonalInfoList/components/UpdatePhoneDialog/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/components/UpdatePhoneDialog/index.jsx
@@ -28,7 +28,12 @@ const UpdatePhone = () => {
 
   return (
     <div>
-      <IconButton className={styles.edit_button} onClick={() => setOpen(true)} size="large">
+      <IconButton
+        className={styles.edit_button}
+        onClick={() => setOpen(true)}
+        size="large"
+        aria-label="Update mobile phone number"
+      >
         <EditIcon fontSize="small" />
       </IconButton>
       <GordonDialogBox

--- a/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
+++ b/src/components/Profile/components/PersonalInfoList/components/UpdatePlannedGraduationYear/index.jsx
@@ -29,7 +29,12 @@ const UpdatePlannedGraduationYear = (props) => {
 
   return (
     <div>
-      <IconButton style={{ marginBottom: '0.5rem' }} onClick={() => setOpen(true)} size="large">
+      <IconButton
+        style={{ marginBottom: '0.5rem' }}
+        onClick={() => setOpen(true)}
+        size="large"
+        aria-label="Update planned graduation year"
+      >
         <EditIcon style={{ fontSize: 20 }} />
       </IconButton>
       <GordonDialogBox


### PR DESCRIPTION
Added more descriptive labels for pencil edit buttons. Used to be just "button" now they say "Update planned graduation year button"...
<img width="426" alt="Screenshot 2024-07-11 at 9 52 54 AM" src="https://github.com/gordon-cs/gordon-360-ui/assets/123050501/48c92a68-efb9-4812-a0ed-f08c28a8802d">
