### PR TITLE
Fixes bar when between summer and fall semester

### DIFF
--- a/src/views/Home/components/DaysLeft/index.jsx
+++ b/src/views/Home/components/DaysLeft/index.jsx
@@ -102,8 +102,8 @@ const DaysLeft = () => {
           name: 'Post-Summer',
           label: 'Fall',
           type: 'Break',
-          start: addDays(termDates.summer?.end, 1),
-          end: addDays(termDates.fall?.start, -1),
+          start: addDays(termDates.fall?.start, -1),
+          end: addDays(termDates.summer?.end, 1),
         },
       };
       const termLoop = [
@@ -115,8 +115,8 @@ const DaysLeft = () => {
         termValues.postSummer,
       ];
 
-      let currentTerm = 'Fall';
-      let currentLabel = 'Fall';
+      let currentTerm = '';
+      let currentLabel = '';
       let currentDaysLeft = '';
       let currentProgress = '';
       let currentType = '';
@@ -142,8 +142,8 @@ const DaysLeft = () => {
       a condition to make days singular if there is only 1 day left*/
       const termDialogue =
         currentType === 'Academic'
-          ? `${currentDaysLeft} Day${currentDaysLeft > 1 ? 's' : ''} Remaining in ${currentTerm} Term`
-          : `${currentDaysLeft} Day${currentDaysLeft > 1 ? 's' : ''} Until ${currentLabel} Term`;
+          ? `${currentDaysLeft} Day${currentDaysLeft == 1 ? '' : 's'} Remaining in ${currentTerm} Term`
+          : `${currentDaysLeft} Day${currentDaysLeft == 1 ? '' : 's'} Until ${currentLabel} Term`;
       setTermDialogue(termDialogue);
       setTermProgress(currentProgress);
     }

--- a/src/views/Home/components/DaysLeft/index.jsx
+++ b/src/views/Home/components/DaysLeft/index.jsx
@@ -102,10 +102,17 @@ const DaysLeft = () => {
           name: 'Post-Summer',
           label: 'Fall',
           type: 'Break',
-          start: addDays(termDates.fall?.start, -1),
-          end: addDays(termDates.summer?.end, 1),
+          start:
+            (termDates.fall?.start - termDates.summer?.end) * msToDays > 1
+              ? addDays(termDates.summer?.end, 1)
+              : termDates.summer?.end,
+          end:
+            (termDates.fall?.start - termDates.summer?.end) * msToDays > 1
+              ? addDays(termDates.fall?.start, -1)
+              : termDates.fall?.start,
         },
       };
+
       const termLoop = [
         termValues.fall,
         termValues.winter,


### PR DESCRIPTION
The progress bar didn't know what to do when the current date is between the summer and fall semesters. The issue was that postSummer's start and end dates were accidentally switched, but everything seems to work properly after changing them back.