### PR TITLE
Improve Auth logging, account selection, and redirects

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,9 +22,11 @@ msalInstance.initialize().then(() => {
 
   // Listen for sign-in event and set active account
   msalInstance.addEventCallback((event) => {
+    console.log('MSAL Event');
     if (event.eventType === EventType.LOGIN_SUCCESS && event.payload) {
       const payload = event.payload as AuthenticationResult;
       const account = payload.account;
+      console.log(`Login Success event, setting active account to ${account.username}`);
       msalInstance.setActiveAccount(account);
     }
   });

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -8,6 +8,8 @@ const apiRequest = {
 
 const authenticate = () => msalInstance.loginRedirect(apiRequest);
 
+let willRedirectForAccessToken = false;
+
 const acquireAccessToken = async () => {
   const activeAccount = msalInstance.getActiveAccount();
   const accounts = msalInstance.getAllAccounts();
@@ -35,7 +37,13 @@ const acquireAccessToken = async () => {
 
   const authResult = await msalInstance.acquireTokenSilent(request).catch((error) => {
     if (error instanceof InteractionRequiredAuthError) {
-      return msalInstance.acquireTokenRedirect(apiRequest);
+      if (willRedirectForAccessToken) {
+        willRedirectForAccessToken = true;
+        console.log('Interaction Required. Redirecting for access token.');
+        return msalInstance.acquireTokenRedirect(apiRequest);
+      } else {
+        console.log('Interaction Required but already began redirecting for access token');
+      }
     } else {
       throw error;
     }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -12,16 +12,26 @@ const acquireAccessToken = async () => {
   const activeAccount = msalInstance.getActiveAccount();
   const accounts = msalInstance.getAllAccounts();
 
-  if (!activeAccount && accounts.length === 0) {
+  const request: SilentRequest = {
+    ...apiRequest,
+  };
+
+  if (activeAccount || accounts.length === 1) {
+    // Acquire token for active or only available account
+    request.account = activeAccount || accounts[0];
+  } else if (accounts.length > 1) {
     /*
+     * No active account, and multiple available accounts.
+     * Ask user which account should be used.
+     */
+    request.prompt = 'select_account';
+  } else {
+    /*
+     * No active account and list of accounts is empty.
      * User is not signed in. Throw error or wait for user to login.
      * Do not attempt to log a user in outside of the context of MsalProvider
      */
   }
-  const request: SilentRequest = {
-    ...apiRequest,
-    account: activeAccount || accounts[0],
-  };
 
   const authResult = await msalInstance.acquireTokenSilent(request).catch((error) => {
     if (error instanceof InteractionRequiredAuthError) {
@@ -36,7 +46,6 @@ const acquireAccessToken = async () => {
 
 /**
  * Check if current session is authenticated
- *
  * @description This is a naive check. The session is considered authenticated if
  * @returns Whether session is authenticated or not
  */
@@ -48,7 +57,6 @@ const isAuthenticated = () => {
 
 /**
  * Sign a user out
- *
  * @description Removes all data from storage and cache
  */
 const signOut = async () => {

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -78,6 +78,7 @@ const makeRequest = async <TResponse>(
   body?: HttpRequestBody,
   headers?: Headers,
 ): Promise<TResponse> => {
+  console.log(`${method} request to endpoint ${endpoint}`);
   const response = await fetch(`${apiBaseURL}api/${endpoint}`, {
     method,
     body,
@@ -112,12 +113,9 @@ export const parseResponse = async <TResponse>(res: Response): Promise<TResponse
 
 const handleAuthHeader = async (headers: Headers): Promise<Headers> => {
   if (isAuthenticated()) {
-    try {
-      const token = await getToken();
-      headers.append('Authorization', `Bearer ${token}`);
-    } catch (err) {
-      throw new Error('Token is not available');
-    }
+    console.log('Getting token');
+    const token = await getToken();
+    headers.append('Authorization', `Bearer ${token}`);
   }
   return headers;
 };


### PR DESCRIPTION
In an attempt to address #2370, I have added logging to our access token and authentication code.

I also added some logic that may hopefully prevent repeated redirects. Given the transient nature of this error, I think it is best to test this in develop for a long period of time to see if it fixes the redirect issue and whether it causes any new issues.

I also adjusted the access token acquisition so that if the user has multiple active Microsoft Account sessions, the user will be prompted to select the account they wish to use in 360.