### PR TITLE
Hotfix: redirect for auth exactly once

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -37,7 +37,7 @@ const acquireAccessToken = async () => {
 
   const authResult = await msalInstance.acquireTokenSilent(request).catch((error) => {
     if (error instanceof InteractionRequiredAuthError) {
-      if (willRedirectForAccessToken) {
+      if (!willRedirectForAccessToken) {
         willRedirectForAccessToken = true;
         console.log('Interaction Required. Redirecting for access token.');
         return msalInstance.acquireTokenRedirect(apiRequest);


### PR DESCRIPTION
This hotfix addresses a bug introduced in #2377 that prevented our authentication code from ever redirecting to MS for authentication when an access token was requested and interaction is required.