### PR TITLE
WMR RD View Setup

### DIFF
--- a/src/views/Housing/components/RDView/index.jsx
+++ b/src/views/Housing/components/RDView/index.jsx
@@ -1,0 +1,51 @@
+import { Card, CardContent, CardHeader, Container, Grid, Typography } from '@mui/material';
+import { ListItemIcon, ListItemText, ListSubheader, List, ListItem, Link } from '@mui/material';
+import UpdateTasks from './updateTasks';
+
+const RDView = () => (
+  <Grid container>
+    <Grid item xs={12} md={12} padding={1}>
+      <Card sx={{ width: '100%' }}>
+        <CardHeader title={`Edit Documents`} className="gc360_header" />
+        <CardContent>
+          <Typography>
+            <List>
+              <ListItem>
+                <Link underline="hover" className={`gc360_text_link`} target="_blank">
+                  <ListItemText primary="RA/AC Task List"></ListItemText>
+                </Link>
+                <Grid item>
+                  <UpdateTasks />
+                </Grid>
+              </ListItem>
+              <ListItem>
+                <Link
+                  // Change link later when we have a SharePoint Link
+                  href="https://www.microsoft.com/en-us/microsoft-365/sharepoint/collaboration"
+                  underline="hover"
+                  className={`gc360_text_link`}
+                  target="_blank"
+                >
+                  <ListItemText primary="Sharepoint"></ListItemText>
+                </Link>
+              </ListItem>
+              <ListItem>
+                <Link
+                  // Change link later when we have actual Room Range page
+                  href="http://127.0.0.1:5500/index.html"
+                  underline="hover"
+                  className={`gc360_text_link`}
+                  target="_blank"
+                >
+                  <ListItemText primary="Room Ranges"></ListItemText>
+                </Link>
+              </ListItem>
+            </List>
+          </Typography>
+        </CardContent>
+      </Card>
+    </Grid>
+  </Grid>
+);
+
+export default RDView;

--- a/src/views/Housing/components/RDView/updateTasks/index.jsx
+++ b/src/views/Housing/components/RDView/updateTasks/index.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react'; // Import useState for managing open state
+import { IconButton } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import GordonDialogBox from 'components/GordonDialogBox';
+
+const UpdateTasks = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <IconButton onClick={() => setOpen(true)} size="large" aria-label="Update RA/AC Tasks">
+        <EditIcon fontSize="small" />
+      </IconButton>
+
+      <GordonDialogBox
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Update RA/AC Tasks"
+        buttonName="UPDATE"
+        cancelButtonName="CANCEL"
+        cancelButtonClicked={() => setOpen(false)}
+      />
+    </div>
+  );
+};
+
+export default UpdateTasks;

--- a/src/views/Housing/components/RDView/updateTasks/index.jsx
+++ b/src/views/Housing/components/RDView/updateTasks/index.jsx
@@ -7,7 +7,7 @@ const UpdateTasks = () => {
   const [open, setOpen] = useState(false);
 
   return (
-    <div>
+    <>
       <IconButton onClick={() => setOpen(true)} size="large" aria-label="Update RA/AC Tasks">
         <EditIcon fontSize="small" />
       </IconButton>
@@ -20,7 +20,7 @@ const UpdateTasks = () => {
         cancelButtonName="CANCEL"
         cancelButtonClicked={() => setOpen(false)}
       />
-    </div>
+    </>
   );
 };
 

--- a/src/views/Housing/index.jsx
+++ b/src/views/Housing/index.jsx
@@ -1,9 +1,22 @@
-import { Card, CardContent, CardHeader, Container, Grid, Typography } from '@mui/material';
+import { Card, Grid } from '@mui/material';
+import { useAuthGroups } from 'hooks';
+import { AuthGroup } from 'services/auth';
+import RDView from './components/RDView';
 
-const Housing = () => (
-  <Grid Container>
-    <Card></Card>
-  </Grid>
-);
+const Housing = () => {
+  const isFaculty = useAuthGroups(AuthGroup.Faculty);
+
+  if (isFaculty) {
+    return (
+      <Grid container>
+        <Card>
+          <RDView className="jsx" />
+        </Card>
+      </Grid>
+    );
+  } else {
+    return null;
+  }
+};
 
 export default Housing;

--- a/src/views/Housing/index.jsx
+++ b/src/views/Housing/index.jsx
@@ -1,12 +1,9 @@
 import { Card, Grid } from '@mui/material';
-import { useAuthGroups } from 'hooks';
-import { AuthGroup } from 'services/auth';
 import RDView from './components/RDView';
+import { isFacStaff as checkIsFacStaff, isFacStaff } from 'services/user';
 
 const Housing = () => {
-  const isFaculty = useAuthGroups(AuthGroup.Faculty);
-
-  if (isFaculty) {
+  if (isFacStaff) {
     return (
       <Grid container>
         <Card>


### PR DESCRIPTION
Changes made in PR:

- Changed the housing index.jsx to go to the RD View only if you are faculty ( We can change this when we make a group for RD's). 
- Created an RDView folder within the housing/components folder. This new folder is where all of the RDView components will go as well as where the index.jsx for the RD View is.
- Created a card to edit documents in he RD View which has links to SharePoint and our room range program, as well as a dialog box that pops up when you click the edit button next to "RA/AC Task List". The code for the edit button is in a folder within RDView called components which will hold any components needed for the RD View.
- The code to edit tasks is just the dialog box that pops up, you cannot type anything yet.