### PR TITLE
Added Lost and Found Section to Safety Page

### DIFF
--- a/src/views/CampusSafety/index.tsx
+++ b/src/views/CampusSafety/index.tsx
@@ -1,4 +1,14 @@
-import { Typography, Card, CardContent, CardHeader, Grid, Link } from '@mui/material';
+import {
+  Typography,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  Grid,
+  Link,
+} from '@mui/material';
 import styles from './CampusSafety.module.scss';
 
 const policeCard = (
@@ -53,6 +63,25 @@ const policeCard = (
         >
           Gordon Police Resources
         </Link>
+        <br />
+        <br />
+        <Grid item xs={12}>
+          <br />
+          <Divider orientation="horizontal" variant="middle" sx={{ borderBorderWidth: 10 }} />
+          <br />
+          <Typography variant="h5" align="center">
+            Missing Something?
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <br />
+          <Box textAlign={'center'}>
+            <Button color="secondary" variant="contained">
+              Lost and Found
+            </Button>
+          </Box>
+          <br />
+        </Grid>
       </Grid>
     </CardContent>
   </Card>

--- a/src/views/CampusSafety/index.tsx
+++ b/src/views/CampusSafety/index.tsx
@@ -67,7 +67,7 @@ const policeCard = (
         <br />
         <Grid item xs={12}>
           <br />
-          <Divider orientation="horizontal" variant="middle" sx={{ borderBorderWidth: 10 }} />
+          <Divider orientation="horizontal" variant="middle" />
           <br />
           <Typography variant="h5" align="center">
             Missing Something?


### PR DESCRIPTION
Button does not navigate anywhere since I need to figure out how to do navigation like the Rec-IM page.
![Screenshot 2024-10-13 at 9 54 24 PM](https://github.com/user-attachments/assets/08f13b93-2a82-4949-b2d4-a0f402c1f162)
