### PR TITLE
Update actions to v4 and simplify npm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Cache npm files
-        uses: actions/cache@v3
+      - uses: actions/setup-node@v4
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version-file: .nvmrc
+          cache: npm
 
       - name: Install Dependencies
         run: npm install
@@ -48,14 +44,14 @@ jobs:
 
       - name: Upload develop build artifacts for deployment
         if: ${{ github.ref == 'refs/heads/develop' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-train
           path: dist
 
       - name: Upload master build artifacts for deployment
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-prod
           path: dist


### PR DESCRIPTION
GitHub has updated most of their official Actions to v4, to move away from unsupported Node versions. None of the breaking changes for these new versions should affect our workflows.