### PR TITLE
L&F Report Details Page Improvements

### DIFF
--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/MissingItemReportData.module.scss
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/MissingItemReportData.module.scss
@@ -1,5 +1,6 @@
+@import '../../../../../../../../vars';
+
 .container {
-  padding: 1.5rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -17,7 +18,6 @@
 
 .card {
   width: 100%;
-  max-width: 900px;
   background-color: var(
     --mui-palette-background-paper
   ); // DarkGray for dark mode, light background for light mode
@@ -26,14 +26,9 @@
 
 .title {
   text-align: center;
-  margin-bottom: 1rem;
-  color: var(--mui-palette-primary-contrastText); // GordonBlue
-}
-
-.sectionTitle {
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-  color: var(--mui-palette-neutral-contrastText); // White for dark mode, Black for light mode
+  & b {
+    color: var(--mui-palette-warning-main);
+  }
 }
 
 .stolenButton {
@@ -50,29 +45,6 @@
   font-weight: bold;
 }
 
-.checkboxLabel {
-  color: var(--mui-palette-text-primary); // Adjusts based on theme
-}
-
-.boxBackground {
-  background-color: var(--mui-palette-neutral-100);
-  border-radius: 5px;
-  padding: 1rem;
-  margin-bottom: 1rem; /* Add spacing between sections */
-  border: 4px solid var(--mui-palette-neutral-300); /* Border for separation */
-}
-
-.categoryGroup,
-.checkboxGroup {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.5rem;
-}
-
-.categoryItem {
-  width: 100%;
-}
-
 .formLabel {
   font-weight: bold;
   margin-bottom: 0.5rem;
@@ -82,5 +54,10 @@
   .categoryGroup,
   .checkboxGroup {
     grid-template-columns: 1fr;
+  }
+
+  .title {
+    font-size: xx-small;
+    // color: var(--mui-palette-primary-main);
   }
 }

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
@@ -2,13 +2,11 @@ import { useParams, useNavigate } from 'react-router-dom';
 import {
   Card,
   CardContent,
-  Typography,
   Grid,
   Button,
   Checkbox,
   FormControlLabel,
   TextField,
-  FormGroup,
   FormLabel,
   CardHeader,
 } from '@mui/material';
@@ -47,156 +45,160 @@ const MissingItemReportData = () => {
   return (
     <>
       <Header />
-      <div className={styles.container}>
-        <Button className={styles.backButton} onClick={() => navigate(-1)}>
-          Back to All Reports
-        </Button>
-        <Card className={styles.card}>
-          <CardHeader
-            title={<div>Missing Item Report</div>}
-            className={`gc360_header ${styles.title}`}
-          ></CardHeader>
-          <CardContent>
-            <Grid container spacing={2} rowGap={1}>
-              <Grid item xs={12} sm={6}>
-                <TextField
-                  label="Owner's Name"
-                  variant="outlined"
-                  fullWidth
-                  value={`${item.firstName} ${item.lastName}`}
-                  InputProps={{ readOnly: true }}
-                />
-              </Grid>
-              <Grid item xs={12} sm={6}>
-                <TextField
-                  label="Location Lost"
-                  variant="outlined"
-                  fullWidth
-                  value={item.locationLost}
-                  InputProps={{ readOnly: true }}
-                />
-              </Grid>
-              <Grid item xs={12} sm={6}>
-                <TextField
-                  label="Date Lost"
-                  variant="outlined"
-                  fullWidth
-                  value={formattedDateLost}
-                  InputProps={{ readOnly: true }}
-                />
-              </Grid>
-
-              {/* Stolen information (if marked stolen) */}
-              {item.stolen ? (
+      <Grid container className={styles.container}>
+        <Grid item xs={12} sm={11}>
+          <Card className={styles.card}>
+            <CardHeader
+              title={
                 <>
-                  <Grid item xs={12} sm={6}>
-                    <div className={styles.stolenButton}>
-                      {item.stolen ? 'This Item was Reported Stolen' : ''}
-                    </div>
-                  </Grid>
-                  <Grid item xs={12}>
-                    <TextField
-                      label="Stolen - Reason Given"
-                      variant="outlined"
-                      fullWidth
-                      multiline
-                      value={item.stolenDescription}
-                      InputProps={{ readOnly: true }}
-                    />
+                  <Grid container alignItems="center">
+                    <Grid item xs={1}>
+                      <Button className={styles.backButton} onClick={() => navigate(-1)}>
+                        Back
+                      </Button>
+                    </Grid>
+                    <Grid item sm={11} xs={12}>
+                      <div>
+                        <b>Missing</b> Item Report Details
+                      </div>
+                    </Grid>
                   </Grid>
                 </>
-              ) : (
-                <Grid item xs={12} /> /*spacer to prevent formatting issues*/
-              )}
-              {/* Item Category */}
-              <Grid item xs={12} sm={6} className={styles.boxBackground}>
-                <FormLabel className={styles.formLabel}>Item Category:</FormLabel>
-                <Grid container className={styles.categoryGroup}>
-                  {[
-                    'Clothing/Shoes',
-                    'Electronics',
-                    'Jewelry/Watches',
-                    'Keys/Keychains',
-                    'Glasses',
-                    'Bottles/Mugs',
-                    'Books',
-                    'Bags/Purses',
-                    'Office Supplies',
-                    'IDs/Wallets',
-                    'Cash/Cards',
-                    'Other',
-                  ].map((category) => (
-                    <FormControlLabel
-                      key={category}
-                      control={
-                        <Checkbox
-                          checked={item.category === category.toLowerCase().replace(/ /g, '/')}
-                          disabled
-                        />
-                      }
-                      label={category}
-                      className={styles.categoryItem}
-                    />
-                  ))}
+              }
+              className={`gc360_header ${styles.title}`}
+            />
+            <CardContent>
+              <Grid container spacing={2} rowGap={1}>
+                {/* Left Column Content */}
+                <Grid item xs={12} sm={6}>
+                  <Grid container rowGap={2}>
+                    <Grid item xs={12}>
+                      <TextField
+                        label="Owner's Name"
+                        variant="filled"
+                        disabled
+                        fullWidth
+                        value={`${item.firstName} ${item.lastName}`}
+                        InputProps={{ readOnly: true }}
+                      />
+                    </Grid>
+                    {/* Owner's contact info */}
+                    <Grid item xs={12}>
+                      <TextField
+                        label="Owner's Contact Info"
+                        variant="filled"
+                        disabled
+                        fullWidth
+                        multiline
+                        minRows={2}
+                        value={`Email: ${item.email}\nPhone: ${item.phone}`}
+                        InputProps={{ readOnly: true }}
+                      />
+                    </Grid>
+                    {/* Item Category */}
+                    <Grid item xs={12} className={styles.boxBackground}>
+                      <TextField
+                        label="Category"
+                        variant="filled"
+                        disabled
+                        fullWidth
+                        value={`${item.category}`}
+                        InputProps={{ readOnly: true }}
+                      />
+                    </Grid>
+                    {/*Color Category*/}
+                    <Grid item xs={12} className={styles.boxBackground}>
+                      <TextField
+                        label="Colors"
+                        variant="filled"
+                        disabled
+                        fullWidth
+                        value={`${item.colors}`}
+                        InputProps={{ readOnly: true }}
+                      />
+                    </Grid>
+                    <Grid item xs={12}>
+                      <TextField
+                        label="Brand or Make"
+                        variant="filled"
+                        disabled
+                        fullWidth
+                        value={item.brand || 'N/A'}
+                        InputProps={{ readOnly: true }}
+                      />
+                    </Grid>
+                    <Grid item xs={12}>
+                      <TextField
+                        label="Description of Item"
+                        variant="filled"
+                        disabled
+                        fullWidth
+                        multiline
+                        minRows={5}
+                        value={item.description}
+                        InputProps={{ readOnly: true }}
+                      />
+                    </Grid>
+                  </Grid>
+                </Grid>
+                {/* Right Column */}
+                <Grid item xs={12} sm={6}>
+                  <Grid container rowGap={2}>
+                    <Grid item xs={12}>
+                      <TextField
+                        label="Location Lost"
+                        variant="filled"
+                        disabled
+                        fullWidth
+                        value={item.locationLost}
+                        InputProps={{ readOnly: true }}
+                      />
+                    </Grid>
+                    <Grid item xs={12}>
+                      <TextField
+                        label="Date Lost"
+                        variant="filled"
+                        disabled
+                        fullWidth
+                        value={formattedDateLost}
+                        InputProps={{ readOnly: true }}
+                      />
+                    </Grid>
+
+                    {/* Stolen information (if marked stolen) */}
+                    {item.stolen ? (
+                      <>
+                        <Grid item xs={12}>
+                          <hr />
+                        </Grid>
+                        <Grid item xs={12}>
+                          <div className={styles.stolenButton}>
+                            {item.stolen ? 'This Item was Reported Stolen' : ''}
+                          </div>
+                        </Grid>
+                        <Grid item xs={12}>
+                          <TextField
+                            label="Stolen - Reason Given"
+                            variant="filled"
+                            disabled
+                            fullWidth
+                            multiline
+                            minRows={4}
+                            value={item.stolenDescription}
+                            InputProps={{ readOnly: true }}
+                          />
+                        </Grid>
+                      </>
+                    ) : (
+                      <Grid item xs={12} /> /*spacer to prevent formatting issues*/
+                    )}
+                  </Grid>
                 </Grid>
               </Grid>
-              {/*Color Category*/}
-              <Grid item xs={12} sm={6} className={styles.boxBackground}>
-                <FormLabel className={styles.formLabel}>Item Color:</FormLabel>
-                <Grid container className={styles.checkboxGroup}>
-                  {[
-                    'Black',
-                    'Blue',
-                    'Brown',
-                    'Gold',
-                    'Gray',
-                    'Green',
-                    'Maroon',
-                    'Orange',
-                    'Pink',
-                    'Purple',
-                    'Red',
-                    'Silver',
-                    'Tan',
-                    'White',
-                    'Yellow',
-                  ].map((color) => (
-                    <FormControlLabel
-                      key={color}
-                      control={<Checkbox checked={item.colors?.includes(color)} disabled />}
-                      label={color}
-                    />
-                  ))}
-                </Grid>
-              </Grid>
-              <Grid item xs={12} sm={6}>
-                <TextField
-                  label="Item Brand or Make"
-                  variant="outlined"
-                  fullWidth
-                  value={item.brand || 'N/A'}
-                  InputProps={{ readOnly: true }}
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <TextField
-                  label="Item Description"
-                  variant="outlined"
-                  fullWidth
-                  multiline
-                  value={item.description}
-                  InputProps={{ readOnly: true }}
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <Button variant="contained" color="primary" fullWidth onClick={handleContact}>
-                  Contact Owner
-                </Button>
-              </Grid>
-            </Grid>
-          </CardContent>
-        </Card>
-      </div>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
     </>
   );
 };


### PR DESCRIPTION
Improved the styling and content of the admin missing item report details page to be more in line with the Figma design, and have all the needed content.

<img width="1071" alt="Screen Shot 2024-11-19 at 23 56 47" src="https://github.com/user-attachments/assets/41354030-184b-4375-b243-7074990c2764">
