### PR TITLE
Added profile links to RD and RA with 360 link styling

### DIFF
--- a/src/views/Housing/components/ResidentView/components/MyHall/index.jsx
+++ b/src/views/Housing/components/ResidentView/components/MyHall/index.jsx
@@ -60,14 +60,15 @@ const MyHall = () => {
             </Typography>
 
             <Typography variant="body1">
-              <a
+              <Link
                 href={rdProfileLink}
+                className="gc360_text_link"
                 target="_blank"
                 rel="noopener noreferrer"
-                style={{ color: 'inherit', textDecoration: 'none' }}
+                style={{ textDecoration: 'none', color: 'inherit' }}
               >
                 <strong>RD:</strong> {rdInfo.RD_Name}
-              </a>
+              </Link>
             </Typography>
           </Grid>
 

--- a/src/views/Housing/components/ResidentView/components/MyRA/index.jsx
+++ b/src/views/Housing/components/ResidentView/components/MyRA/index.jsx
@@ -46,6 +46,7 @@ const StyledTableRow = styled(TableRow)(({ theme }) => ({
 
 const MyRA = () => {
   const [raInfo, setRaInfo] = useState({});
+  const [raProfileLink, setRaProfileLink] = useState('');
   const { profile } = useUser();
 
   useEffect(() => {
@@ -61,6 +62,12 @@ const MyRA = () => {
       });
     }
   }, [profile]);
+
+  useEffect(() => {
+    if (raInfo) {
+      setRaProfileLink(`https://360.gordon.edu/profile/${raInfo.FirstName}.${raInfo.LastName}`);
+    }
+  }, [raInfo]);
 
   // Show loading state if profile is not yet loaded
   if (!profile) {
@@ -85,7 +92,15 @@ const MyRA = () => {
           {/* Text Section */}
           <Grid item xs={8}>
             <Typography variant="body1">
-              <strong>Name:</strong> {raInfo.FirstName} {raInfo.LastName}
+              <Link
+                href={raProfileLink}
+                className="gc360_text_link"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: 'none', color: 'inherit' }}
+              >
+                <strong>RD:</strong> {raInfo.FirstName} {raInfo.LastName}
+              </Link>
             </Typography>
 
             <Typography variant="body1">
@@ -93,11 +108,11 @@ const MyRA = () => {
             </Typography>
 
             <Typography variant="body1">
-              <strong>Current Status:</strong> TBD
+              <strong>Current Status:</strong> In Class
             </Typography>
 
             <Typography variant="body1">
-              <strong>Future Status:</strong> TBD
+              <strong>Future Status:</strong> Busy
             </Typography>
           </Grid>
 
@@ -128,25 +143,22 @@ const MyRA = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {/* ROW 1 */}
               <StyledTableRow>
-                <StyledTableCell align="center">TBD</StyledTableCell>
-                <StyledTableCell align="center"></StyledTableCell>
-                <StyledTableCell align="center"></StyledTableCell>
+                <StyledTableCell align="center">In Class</StyledTableCell>
+                <StyledTableCell align="center">9:10 AM</StyledTableCell>
+                <StyledTableCell align="center">10:10 PM</StyledTableCell>
               </StyledTableRow>
 
-              {/* ROW 2 */}
               <StyledTableRow>
-                <StyledTableCell align="center">TBD</StyledTableCell>
-                <StyledTableCell align="center"></StyledTableCell>
-                <StyledTableCell align="center"></StyledTableCell>
+                <StyledTableCell align="center">Busy</StyledTableCell>
+                <StyledTableCell align="center">10:10 PM</StyledTableCell>
+                <StyledTableCell align="center">2:00 PM</StyledTableCell>
               </StyledTableRow>
 
-              {/* ROW 3 */}
               <StyledTableRow>
-                <StyledTableCell align="center">TBD</StyledTableCell>
-                <StyledTableCell align="center"></StyledTableCell>
-                <StyledTableCell align="center"></StyledTableCell>
+                <StyledTableCell align="center">Available</StyledTableCell>
+                <StyledTableCell align="center">2:00 PM</StyledTableCell>
+                <StyledTableCell align="center">4:00 PM</StyledTableCell>
               </StyledTableRow>
             </TableBody>
           </Table>


### PR DESCRIPTION
**Changes made in PR:**
![Screenshot 2024-11-25 at 1 31 19 AM](https://github.com/user-attachments/assets/1fcf3a19-298f-45f3-8720-300b8c25d189)

- Added profile links to both the RD and RA upon Ross's suggestion

I have hardcoded data in the table because it looks more visually appealing, but we can decide with Melanie how we want that to look for our MVP