### PR TITLE
Reset page scroll position before client side navigation

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2,7 +2,7 @@ import { useMsal } from '@azure/msal-react';
 import AppRedirect from 'components/AppRedirect';
 import BirthdayMessage from 'components/BirthdayMessage';
 import { useWatchSystemColorScheme } from 'hooks';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { CustomNavigationClient } from 'services/NavigationClient';
@@ -17,6 +17,7 @@ import routes from './routes';
 const App = () => {
   useWatchSystemColorScheme();
   const location = useLocation();
+  const mainRef = useRef(null);
 
   useEffect(() => {
     analytics.onPageView();
@@ -25,7 +26,7 @@ const App = () => {
   // Setup custom navigation so that MSAL uses react-router for navigation
   const { instance } = useMsal();
   const navigate = useNavigate();
-  const navigaitonClient = new CustomNavigationClient(navigate);
+  const navigaitonClient = new CustomNavigationClient(navigate, mainRef);
   instance.setNavigationClient(navigaitonClient);
 
   const [drawerOpen, setDrawerOpen] = useState();
@@ -38,7 +39,7 @@ const App = () => {
     <ErrorBoundary>
       <GordonHeader onDrawerToggle={onDrawerToggle} />
       <GordonNav onDrawerToggle={onDrawerToggle} drawerOpen={drawerOpen} />
-      <main className={styles.app_main}>
+      <main className={styles.app_main} ref={mainRef}>
         <BirthdayMessage />
         <AppRedirect />
         <Routes>

--- a/src/services/NavigationClient.ts
+++ b/src/services/NavigationClient.ts
@@ -1,4 +1,5 @@
 import { NavigationClient, NavigationOptions } from '@azure/msal-browser';
+import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
 import { NavigateFunction } from 'react-router-dom';
 
 /**
@@ -6,11 +7,22 @@ import { NavigateFunction } from 'react-router-dom';
  */
 export class CustomNavigationClient extends NavigationClient {
   private navigate: NavigateFunction;
+  private mainComponentRef: React.MutableRefObject<HTMLElement>;
 
-  constructor(navigate: NavigateFunction) {
+  constructor(navigate: NavigateFunction, mainComponentRef: React.MutableRefObject<HTMLElement>) {
     super();
     this.navigate = navigate;
+    this.mainComponentRef = mainComponentRef;
+    this.scrollToTop();
   }
+
+  private scrollToTop = () => {
+    if (this.mainComponentRef != null && this.mainComponentRef.current != null) {
+      this.mainComponentRef.current.scroll({
+        top: 0,
+      });
+    }
+  };
 
   /**
    * Navigates to other pages within the same web application


### PR DESCRIPTION
It's been bothering me for a while that the scroll position of the "main" page element doesn't reset when navigating between pages.  Most of 360 is fine on larger screens (as the whole page can fit vertically), but on mobile this can cause issues when navigating between pages using buttons, and finding yourself halfway down the page without context.

This code seems to work, and calls the ScrollToTop method each time the react useNavigate method is called (although there may be a better way to implement this, so I'm open to suggestions, but I'd like to make this change to navigation).