### PR TITLE
Admin Landing Page + Admin Actions Checked Action

### DIFF
--- a/src/services/lostAndFound.ts
+++ b/src/services/lostAndFound.ts
@@ -24,7 +24,7 @@ export type MissingItemReport = {
   submitterUsername: string;
   submitterID?: null;
   forGuest: boolean;
-  lastChecked?: string;
+  adminActions?: MissingAdminAction[];
 };
 
 /**

--- a/src/services/lostAndFound.ts
+++ b/src/services/lostAndFound.ts
@@ -38,6 +38,7 @@ export type MissingAdminAction = {
   actionDate: string;
   actionNote?: string;
   username: string;
+  isPublic?: boolean;
 };
 
 /**

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/LostAndFoundAdmin.module.scss
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/LostAndFoundAdmin.module.scss
@@ -4,3 +4,7 @@
   background-color: var(--mui-palette-primary-main);
   color: var(--mui-palette-primary-contrastText);
 }
+
+.spacing {
+  padding: 5px;
+}

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/index.tsx
@@ -1,16 +1,36 @@
 import styles from './LostAndFoundAdmin.module.css';
 import { AuthGroup } from 'services/auth';
 import { useAuthGroups } from 'hooks';
-import { Card, CardContent, CardHeader } from '@mui/material';
+import { Card, CardContent, CardHeader, Typography } from '@mui/material';
 import { Grid, Button } from '@mui/material';
 import Header from 'views/CampusSafety/components/Header';
 import { useNavigate } from 'react-router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { Construction, Person, Storage } from '@mui/icons-material';
+import lostAndFoundService, { MissingItemReport } from 'services/lostAndFound';
 
 const LostAndFoundAdmin = () => {
   const isAdmin = useAuthGroups(AuthGroup.LostAndFoundDevelopers);
   // const isAdmin = true; //FOR TESTING PURPOSES
   const navigate = useNavigate();
+  const [missingReports, setMissingReports] = useState<MissingItemReport[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchMissingItems = async () => {
+      setLoading(true);
+      try {
+        const fetchedReports = await lostAndFoundService.getMissingItemReports();
+        setMissingReports(fetchedReports);
+      } catch (error) {
+        console.error('Error fetching missing items:', error);
+        setMissingReports([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMissingItems();
+  }, []);
 
   useEffect(() => {
     if (!isAdmin) {
@@ -18,23 +38,118 @@ const LostAndFoundAdmin = () => {
     }
   });
 
+  const MissingDatabaseSummary = (
+    <>
+      Active: {missingReports.filter((report) => report.status === 'active').length} {' | '} Total:{' '}
+      {missingReports.length}
+    </>
+  );
+
+  const LostItemDatabase = (
+    <>
+      <Grid container rowGap={1}>
+        <Grid item xs={12}>
+          {MissingDatabaseSummary}
+        </Grid>
+        <Grid item xs={12}>
+          <Button
+            color="secondary"
+            variant="contained"
+            onClick={() => {
+              navigate('missingitemdatabase');
+            }}
+          >
+            <Storage />
+            <span className={styles.spacing}></span>
+            <b>Lost Items Database</b>
+          </Button>
+        </Grid>
+      </Grid>
+    </>
+  );
+
+  const ReportLostItem = (
+    <Button
+      color="secondary"
+      variant="contained"
+      onClick={() => {
+        navigate('reportitemforothers');
+      }}
+    >
+      <Person />
+      <span className={styles.spacing}></span>
+      <b>Report Item for Others</b>
+    </Button>
+  );
+
+  const lostItemsCard = (
+    <>
+      <Card>
+        <CardHeader title="Lost Items" />
+        <CardContent>
+          <Grid container rowGap={2}>
+            <Grid container item xs={12}>
+              {LostItemDatabase}
+            </Grid>
+            <Grid container item xs={12}>
+              {ReportLostItem}
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+    </>
+  );
+
+  const FoundItemDatabase = (
+    <Button
+      color="secondary"
+      variant="contained"
+      disabled
+      onClick={() => {
+        navigate('founditemdatabase');
+      }}
+    >
+      <Storage />
+      <span className={styles.spacing}></span>
+      <b>Found Items Database</b>
+    </Button>
+  );
+
+  const FoundItemsCard = (
+    <>
+      <Card>
+        <CardHeader title="Found Items" />
+        <CardContent>
+          <Grid container rowGap={2}>
+            <Grid container item xs={12}>
+              {FoundItemDatabase}
+            </Grid>
+            <Construction color="error" />
+            <Typography>
+              Under Construction! Use the existing system in FileMaker for found items
+            </Typography>
+          </Grid>
+        </CardContent>
+      </Card>
+    </>
+  );
+
   return (
     <>
       <Header />
       <Grid container justifyContent={'center'}>
         <Grid item xs={11}>
           <Card>
-            <CardHeader title={'LostAndFound Admin'} className={styles.title}></CardHeader>
+            <CardHeader title={'Gordon Lost & Found Admin'} className={styles.title}></CardHeader>
             <CardContent>
-              <Button
-                color="secondary"
-                variant="contained"
-                onClick={() => {
-                  navigate('missingitemdatabase');
-                }}
-              >
-                <b>Missing Item Database</b>
-              </Button>
+              <Grid container>
+                <Grid item xs={12} md={6}>
+                  {lostItemsCard}
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  {FoundItemsCard}
+                </Grid>
+              </Grid>
             </CardContent>
           </Card>
         </Grid>

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/index.tsx
@@ -5,32 +5,13 @@ import { Card, CardContent, CardHeader, Typography } from '@mui/material';
 import { Grid, Button } from '@mui/material';
 import Header from 'views/CampusSafety/components/Header';
 import { useNavigate } from 'react-router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Construction, Person, Storage } from '@mui/icons-material';
-import lostAndFoundService, { MissingItemReport } from 'services/lostAndFound';
 
 const LostAndFoundAdmin = () => {
   const isAdmin = useAuthGroups(AuthGroup.LostAndFoundDevelopers);
   // const isAdmin = true; //FOR TESTING PURPOSES
   const navigate = useNavigate();
-  const [missingReports, setMissingReports] = useState<MissingItemReport[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-
-  useEffect(() => {
-    const fetchMissingItems = async () => {
-      setLoading(true);
-      try {
-        const fetchedReports = await lostAndFoundService.getMissingItemReports();
-        setMissingReports(fetchedReports);
-      } catch (error) {
-        console.error('Error fetching missing items:', error);
-        setMissingReports([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchMissingItems();
-  }, []);
 
   useEffect(() => {
     if (!isAdmin) {
@@ -38,19 +19,9 @@ const LostAndFoundAdmin = () => {
     }
   });
 
-  const MissingDatabaseSummary = (
-    <>
-      Active: {missingReports.filter((report) => report.status === 'active').length} {' | '} Total:{' '}
-      {missingReports.length}
-    </>
-  );
-
   const LostItemDatabase = (
     <>
       <Grid container rowGap={1}>
-        <Grid item xs={12}>
-          {MissingDatabaseSummary}
-        </Grid>
         <Grid item xs={12}>
           <Button
             color="secondary"

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/MissingItemReportData.module.scss
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/MissingItemReportData.module.scss
@@ -36,9 +36,10 @@
 
 .title {
   text-align: center;
-  & b {
-    color: var(--mui-palette-warning-main);
-  }
+}
+
+.yellowText {
+  color: var(--mui-palette-warning-main);
 }
 
 .stolenButton {

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
@@ -237,36 +237,33 @@ const MissingItemReportData = () => {
               ) : (
                 adminActionsArray?.map((adminAction) => {
                   return (
-                    <>
-                      <Grid
-                        container
-                        item
-                        className={styles.tableRow}
-                        onClick={() => {
-                          handleActionClicked(adminAction.ID);
-                        }}
-                      >
-                        <Grid item xs={1} className={styles.tableColumn}>
-                          <Launch color="secondary" />
-                        </Grid>
-                        <Grid item xs={3} sm={2} className={styles.tableColumn}>
-                          <div className={styles.dataCell}>
-                            {formatDate(adminAction.actionDate)}
-                          </div>
-                        </Grid>
-                        <Grid item xs={4} sm={3} className={styles.tableColumn}>
-                          <div className={styles.dataCell}>{adminAction.action}</div>
-                        </Grid>
-                        <Grid item xs={4} sm={3} className={styles.tableColumn}>
-                          <div className={styles.dataCell}>{adminAction.username}</div>
-                        </Grid>
-                        {!isMobile ? (
-                          <Grid item xs={3} className={styles.tableColumn}>
-                            <div className={styles.dataCell}>{adminAction.actionNote}</div>
-                          </Grid>
-                        ) : null}
+                    <Grid
+                      key={adminAction.ID}
+                      container
+                      item
+                      className={styles.tableRow}
+                      onClick={() => {
+                        handleActionClicked(adminAction.ID);
+                      }}
+                    >
+                      <Grid item xs={1} className={styles.tableColumn}>
+                        <Launch color="secondary" />
                       </Grid>
-                    </>
+                      <Grid item xs={3} sm={2} className={styles.tableColumn}>
+                        <div className={styles.dataCell}>{formatDate(adminAction.actionDate)}</div>
+                      </Grid>
+                      <Grid item xs={4} sm={3} className={styles.tableColumn}>
+                        <div className={styles.dataCell}>{adminAction.action}</div>
+                      </Grid>
+                      <Grid item xs={4} sm={3} className={styles.tableColumn}>
+                        <div className={styles.dataCell}>{adminAction.username}</div>
+                      </Grid>
+                      {!isMobile ? (
+                        <Grid item xs={3} className={styles.tableColumn}>
+                          <div className={styles.dataCell}>{adminAction.actionNote}</div>
+                        </Grid>
+                      ) : null}
+                    </Grid>
                   );
                 })
               )}

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
@@ -357,7 +357,12 @@ const MissingItemReportData = () => {
                   <>
                     <Grid container alignItems="center">
                       <Grid item xs={1}>
-                        <Button className={styles.backButton} onClick={() => navigate(-1)}>
+                        <Button
+                          className={styles.backButton}
+                          onClick={() =>
+                            navigate('/lostandfound/lostandfoundadmin/missingitemdatabase')
+                          }
+                        >
                           Back
                         </Button>
                       </Grid>

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
@@ -305,6 +305,7 @@ const MissingItemReportData = () => {
         missingID: parseInt(itemId || ''),
         actionDate: DateTime.now().toISO(),
         username: username.AD_Username,
+        isPublic: newActionFormData.action === 'Checked' && !checkedItemNotFound ? true : false,
       };
       await lostAndFoundService.createAdminAction(parseInt(itemId ? itemId : ''), requestData);
       // Since a new action was created, trigger an update, which will fetch the new actions list

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
@@ -245,6 +245,30 @@ const MissingItemReportData = () => {
 
   const formattedDateLost = DateTime.fromISO(item.dateLost).toFormat('MM-dd-yy');
 
+  const statusChip = (
+    <Chip
+      label={
+        <Typography variant="subtitle1">
+          <u>
+            <b>{item.status[0].toUpperCase() + item.status.slice(1)}</b>
+          </u>
+        </Typography>
+      }
+      //@ts-ignore
+      color={
+        item.status.toLowerCase() === 'active'
+          ? 'secondary'
+          : item.status.toLowerCase() === 'found'
+            ? 'success'
+            : item.status.toLowerCase() === 'expired'
+              ? 'neutral'
+              : item.status.toLowerCase() === 'deleted'
+                ? 'error'
+                : 'neutral'
+      }
+    />
+  );
+
   // Component for admin actions card, holding the admin actions UI elements
   const adminActions = () => {
     return (
@@ -512,8 +536,8 @@ const MissingItemReportData = () => {
               <CardHeader
                 title={
                   <>
-                    <Grid container alignItems="center">
-                      <Grid item xs={1}>
+                    <Grid container rowGap={1}>
+                      <Grid container item xs={12} md={1}>
                         <Button
                           className={styles.backButton}
                           onClick={() =>
@@ -523,10 +547,21 @@ const MissingItemReportData = () => {
                           Back
                         </Button>
                       </Grid>
-                      <Grid item sm={11} xs={12}>
+                      <Grid
+                        container
+                        item
+                        columnGap={2}
+                        rowGap={1}
+                        xs={12}
+                        md={10}
+                        justifyContent="center"
+                      >
                         <div>
-                          <b>Missing</b> Item Report Details
+                          <b className={styles.yellowText}>Lost</b> Item Report Details
                         </div>
+                        <Typography>
+                          <em>Status:</em> {statusChip}
+                        </Typography>
                       </Grid>
                     </Grid>
                   </>
@@ -630,18 +665,7 @@ const MissingItemReportData = () => {
                           InputProps={{ readOnly: true }}
                         />
                       </Grid>
-                      <Grid item xs={12}>
-                        <Chip
-                          label={'Status: ' + item.status[0].toUpperCase() + item.status.slice(1)}
-                          color={
-                            item.status.toLowerCase() === 'active'
-                              ? 'warning'
-                              : item.status.toLowerCase() === 'found'
-                                ? 'success'
-                                : 'neutral'
-                          }
-                        />
-                      </Grid>
+
                       {/* Stolen information (if marked stolen) */}
                       {item.stolen ? (
                         <>

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
@@ -30,12 +30,14 @@ const MissingItemReportData = () => {
   // Page State
   const [loading, setLoading] = useState<boolean>(true);
   const isWidescreen = useMediaQuery('(min-width:1000px)');
-  const isMobile = useMediaQuery('(max-width:470px)');
+  const isMobile = useMediaQuery('(max-width:600px)');
+
+  // Used for
   const [newActionFormData, setNewActionFormData] = useState({ action: '', actionNote: '' });
-  const [actionDetailsModalOpen, setActionDetailsModalOpen] = useState<boolean>(false);
   const [newActionModalOpen, setNewActionModalOpen] = useState<boolean>(false);
 
   // Used for details modal with dynamic content that must be set asynchronously before modal opens
+  const [actionDetailsModalOpen, setActionDetailsModalOpen] = useState<boolean>(false);
   const [actionDetailsModalLoading, setActionDetailsModalLoading] = useState<boolean>(false);
 
   // The missing item report
@@ -209,18 +211,20 @@ const MissingItemReportData = () => {
               <Grid item xs={1}>
                 <Key />
               </Grid>
-              <Grid item xs={2}>
+              <Grid item xs={3} sm={2}>
                 <div className={styles.dataCell}>Date</div>
               </Grid>
-              <Grid item xs={3}>
+              <Grid item xs={4} sm={3}>
                 <div className={styles.dataCell}>Action</div>
               </Grid>
-              <Grid item xs={3}>
+              <Grid item xs={4} sm={3}>
                 <div className={styles.dataCell}>User</div>
               </Grid>
-              <Grid item xs={3}>
-                <div className={styles.dataCell}>Notes</div>
-              </Grid>
+              {!isMobile ? (
+                <Grid item xs={3}>
+                  <div className={styles.dataCell}>Notes</div>
+                </Grid>
+              ) : null}
             </Grid>
             <Grid container>
               {adminActionsArray?.length === 0 ? (
@@ -245,20 +249,22 @@ const MissingItemReportData = () => {
                         <Grid item xs={1} className={styles.tableColumn}>
                           <Launch color="secondary" />
                         </Grid>
-                        <Grid item xs={2} className={styles.tableColumn}>
+                        <Grid item xs={3} sm={2} className={styles.tableColumn}>
                           <div className={styles.dataCell}>
                             {formatDate(adminAction.actionDate)}
                           </div>
                         </Grid>
-                        <Grid item xs={3} className={styles.tableColumn}>
+                        <Grid item xs={4} sm={3} className={styles.tableColumn}>
                           <div className={styles.dataCell}>{adminAction.action}</div>
                         </Grid>
-                        <Grid item xs={3} className={styles.tableColumn}>
+                        <Grid item xs={4} sm={3} className={styles.tableColumn}>
                           <div className={styles.dataCell}>{adminAction.username}</div>
                         </Grid>
-                        <Grid item xs={3} className={styles.tableColumn}>
-                          <div className={styles.dataCell}>{adminAction.actionNote}</div>
-                        </Grid>
+                        {!isMobile ? (
+                          <Grid item xs={3} className={styles.tableColumn}>
+                            <div className={styles.dataCell}>{adminAction.actionNote}</div>
+                          </Grid>
+                        ) : null}
                       </Grid>
                     </>
                   );
@@ -279,18 +285,18 @@ const MissingItemReportData = () => {
         cancelButtonClicked={closeModal}
         cancelButtonName="close"
       >
-        <Grid container>
-          <Grid item xs={5}>
+        <Grid container rowGap={1}>
+          <Grid item xs={12} sm={5}>
             <b>Date</b>{' '}
             {selectedAction.current ? formatDate(selectedAction.current.actionDate) : ''}
           </Grid>
-          <Grid item xs={7}>
+          <Grid item xs={12} sm={7}>
             <b>Action</b> {selectedAction.current ? selectedAction.current.action : ''}
           </Grid>
-          <Grid item xs={5}>
+          <Grid item xs={12} sm={5}>
             <b>User</b> {selectedAction.current ? selectedAction.current.username : ''}
           </Grid>
-          <Grid item xs={7}>
+          <Grid item xs={12} sm={7}>
             <b>Notes</b> {selectedAction.current ? selectedAction.current.actionNote : ''}
           </Grid>
         </Grid>

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
@@ -121,7 +121,7 @@ const MissingItemList = () => {
   const formatDate = (date: string) => DateTime.fromISO(date).toFormat('MM/dd/yy');
 
   const displayLastCheckedDate = (report: MissingItemReport) => {
-    var dateString = report.adminActions?.find((action) => {
+    var dateString = report.adminActions?.findLast((action) => {
       return action.action === 'Checked';
     })?.actionDate;
     if (dateString !== '' && dateString !== undefined) {

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
@@ -118,7 +118,17 @@ const MissingItemList = () => {
     handleFilter();
   }, [status, category, color, keywords]);
 
-  const formatDate = (date: string) => DateTime.fromISO(date).toFormat('MMM d, yyyy');
+  const formatDate = (date: string) => DateTime.fromISO(date).toFormat('MM/dd/yy');
+
+  const displayLastCheckedDate = (report: MissingItemReport) => {
+    var dateString = report.adminActions?.find((action) => {
+      return action.action === 'Checked';
+    })?.actionDate;
+    if (dateString !== '' && dateString !== undefined) {
+      return formatDate(dateString);
+    }
+    return 'Never';
+  };
 
   return (
     <>
@@ -287,7 +297,7 @@ const MissingItemList = () => {
                               {formatDate(report.dateLost)}
                             </Typography>
                             <Typography variant="body2" color="textSecondary">
-                              Last Checked: {report.lastChecked || 'Placeholder'}
+                              Last Checked: {displayLastCheckedDate(report)}
                             </Typography>
                           </Grid>
                           <Typography variant="body2" color="textSecondary">
@@ -334,7 +344,7 @@ const MissingItemList = () => {
                           <div className={styles.dataCell}>{report.description}</div>
                         </Grid>
                         <Grid item xs={1}>
-                          {report.lastChecked || 'Placeholder'}
+                          {displayLastCheckedDate(report)}
                         </Grid>
                         <Grid item xs={1} style={{ display: 'flex', justifyContent: 'flex-end' }}>
                           {report.stolen && (

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
@@ -118,8 +118,10 @@ const MissingItemList = () => {
     handleFilter();
   }, [status, category, color, keywords]);
 
-  const formatDate = (date: string) => DateTime.fromISO(date).toFormat('MM/dd/yy');
+  const dateFormat = 'MM/dd/yy';
+  const formatDate = (date: string) => DateTime.fromISO(date).toFormat(dateFormat);
 
+  // Find and format the last checked date based on the list of admin actions for a given report.
   const displayLastCheckedDate = (report: MissingItemReport) => {
     var dateString = report.adminActions?.findLast((action) => {
       return action.action === 'Checked';
@@ -128,6 +130,23 @@ const MissingItemList = () => {
       return formatDate(dateString);
     }
     return 'Never';
+  };
+
+  // Return a color based on how long ago a date was.
+  // Green < 3 days, Yellow < 7 days, Red > 7 days.
+  const dateAgeColor = (date: string) => {
+    // Convert dates into milliseconds since 1/1/1970
+    var dateGiven = Date.parse(DateTime.fromFormat(date, dateFormat).toString());
+    var today = Date.parse(DateTime.now().toString());
+    // Subtract the dates, and convert milliseconds to days.
+    var dayDiff = (today - dateGiven) / (1000 * 3600 * 24);
+    if (dayDiff < 3) {
+      return 'var(--mui-palette-success-main)';
+    } else if (dayDiff < 7) {
+      return 'var(--mui-palette-warning-main)';
+    } else {
+      return 'var(--mui-palette-error-main)';
+    }
   };
 
   return (
@@ -296,7 +315,10 @@ const MissingItemList = () => {
                             <Typography variant="body2" color="textSecondary">
                               {formatDate(report.dateLost)}
                             </Typography>
-                            <Typography variant="body2" color="textSecondary">
+                            <Typography
+                              variant="body2"
+                              color={dateAgeColor(displayLastCheckedDate(report))}
+                            >
                               Last Checked: {displayLastCheckedDate(report)}
                             </Typography>
                           </Grid>
@@ -344,7 +366,9 @@ const MissingItemList = () => {
                           <div className={styles.dataCell}>{report.description}</div>
                         </Grid>
                         <Grid item xs={1}>
-                          {displayLastCheckedDate(report)}
+                          <Typography color={dateAgeColor(displayLastCheckedDate(report))}>
+                            {displayLastCheckedDate(report)}
+                          </Typography>
                         </Grid>
                         <Grid item xs={1} style={{ display: 'flex', justifyContent: 'flex-end' }}>
                           {report.stolen && (


### PR DESCRIPTION
## Admin Actions
[Admin Actions Design Doc](url)

API Changes in [API #1104](https://github.com/gordon-cs/gordon-360-api/pull/1104)

Can now record items as checked agains the list of found items.  This also updates the status to "found" if the user says they've found it.

Form for cross-checking action:
<img width="958" alt="Screen Shot 2024-11-29 at 19 37 28" src="https://github.com/user-attachments/assets/5af77247-cc9f-400d-8aff-a2bb654bfb38">


Now the "Last Checked" date is calculated based on the most recent "Checked" action on a report.  Also the color of the date is set based on how old it is.
<img width="1680" alt="Screen Shot 2024-11-29 at 20 25 50" src="https://github.com/user-attachments/assets/324e5c52-c7ab-4b48-8667-93d120356084">



## Admin Landing Page
Updated the admin landing page.

New Appearance:
<img width="1680" alt="Screen Shot 2024-11-28 at 09 24 53" src="https://github.com/user-attachments/assets/b3b0cba1-e0af-4d20-8281-f285ecc5d03a">
