### PR TITLE
Various Bugfixes

### DIFF
--- a/src/views/CampusSafety/views/LostAndFound/components/DeleteConfirmation/DeleteConfirmation.module.scss
+++ b/src/views/CampusSafety/views/LostAndFound/components/DeleteConfirmation/DeleteConfirmation.module.scss
@@ -1,7 +1,7 @@
 // Root container styles for the dialog
 .title {
-  background-color: var(--mui-palette-primary-main); // GordonBlue
-  color: var(--mui-palette-primary-contrastText); // White
+  background-color: var(--mui-palette-primary-main);
+  color: var(--mui-palette-primary-contrastText);
   text-align: center;
   font-size: 1.25rem;
   font-weight: bold;
@@ -12,7 +12,7 @@
   text-align: center;
   font-weight: 500;
   font-size: 1rem;
-  color: var(--mui-palette-secondary-main); // SnowDay
+  color: var(--mui-palette-secondary-main);
   @media (max-width: 600px) {
     font-size: 0.9rem; // Adjust for smaller screens
   }
@@ -21,7 +21,7 @@
 .subtext {
   text-align: center;
   margin-top: 0.5rem;
-  color: var(--mui-palette-neutral-700); // Light Gray
+  color: var(--mui-palette-neutral-700);
   font-size: 0.9rem;
 
   @media (max-width: 600px) {
@@ -36,21 +36,21 @@
 }
 
 .cancelButton {
-  background-color: var(--mui-palette-error-light); // NauticalRed
-  color: var(--mui-palette-primary-contrastText); // White
+  background-color: var(--mui-palette-error-light);
+  color: var(--mui-palette-primary-contrastText);
   font-weight: bold;
 
   &:hover {
-    background-color: var(--mui-palette-error-main); // ChristmasRed
+    background-color: var(--mui-palette-error-main);
   }
 }
 
 .submitButton {
-  background-color: var(--mui-palette-secondary-main); // ScottieCyan
-  color: var(--mui-palette-primary-contrastText); // White
+  background-color: var(--mui-palette-secondary-main);
+  color: var(--mui-palette-primary-contrastText);
   font-weight: bold;
 
   &:hover {
-    background-color: var(--mui-palette-secondary-dark); // ScottieCyan_opacity75
+    background-color: var(--mui-palette-secondary-dark);
   }
 }

--- a/src/views/CampusSafety/views/LostAndFound/components/DeleteConfirmation/DeleteConfirmation.module.scss
+++ b/src/views/CampusSafety/views/LostAndFound/components/DeleteConfirmation/DeleteConfirmation.module.scss
@@ -12,8 +12,7 @@
   text-align: center;
   font-weight: 500;
   font-size: 1rem;
-  color: var(--mui-palette-info-light); // SnowDay
-
+  color: var(--mui-palette-secondary-main); // SnowDay
   @media (max-width: 600px) {
     font-size: 0.9rem; // Adjust for smaller screens
   }
@@ -22,7 +21,7 @@
 .subtext {
   text-align: center;
   margin-top: 0.5rem;
-  color: var(--mui-palette-neutral-500); // Light Gray
+  color: var(--mui-palette-neutral-700); // Light Gray
   font-size: 0.9rem;
 
   @media (max-width: 600px) {

--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/components/confirmReport/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/components/confirmReport/index.tsx
@@ -49,7 +49,7 @@ const ConfirmReport: React.FC<ConfirmReportProps> = ({ formData, onEdit, onSubmi
               <strong>Item Brand/Make:</strong> {formData.brand || 'N/A'}
             </Typography>
             <Typography>
-              <strong>Date Lost:</strong> {formData.dateLost}
+              <strong>Date Lost:</strong> {new Date(formData.dateLost).toDateString()}
             </Typography>
           </Grid>
           <Grid item xs={6}>

--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/index.tsx
@@ -350,6 +350,11 @@ const MissingItemFormCreate = () => {
                   onChange={handleChange}
                   error={!!validationErrors.brand}
                   helperText={validationErrors.brand}
+                  sx={{
+                    '& .MuiFormLabel-root.Mui-focused': {
+                      color: 'var(--mui-palette-secondary-400);',
+                    },
+                  }}
                 />
               </Grid>
               <Grid item margin={2}>
@@ -364,6 +369,11 @@ const MissingItemFormCreate = () => {
                   onChange={handleChange}
                   error={!!validationErrors.description}
                   helperText={validationErrors.description}
+                  sx={{
+                    '& .MuiFormLabel-root.Mui-focused': {
+                      color: 'var(--mui-palette-secondary-400);',
+                    },
+                  }}
                 />
               </Grid>
 
@@ -380,6 +390,11 @@ const MissingItemFormCreate = () => {
                   onChange={handleChange}
                   error={!!validationErrors.locationLost}
                   helperText={validationErrors.locationLost}
+                  sx={{
+                    '& .MuiFormLabel-root.Mui-focused': {
+                      color: 'var(--mui-palette-secondary-400);',
+                    },
+                  }}
                 />
               </Grid>
               <Grid item margin={2}>

--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/index.tsx
@@ -175,7 +175,7 @@ const MissingItemFormCreate = () => {
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <DatePicker
         label="Date Lost"
-        value={formData.dateLost}
+        value={formData.dateLost === '' ? null : formData.dateLost}
         onChange={(value) => setFormData({ ...formData, dateLost: value?.toString() || '' })}
         disableFuture
         orientation="portrait"
@@ -187,7 +187,7 @@ const MissingItemFormCreate = () => {
           borderRadius: '5px;',
           width: '100%;',
           '& .Mui-focused .MuiOutlinedInput-notchedOutline': { border: 'none' },
-          '& .MuiFormLabel-root': {
+          '& .MuiInputLabel-shrink': {
             transform: 'translate(14px, 4px) scale(0.75);',
           },
           '& .MuiFormLabel-root.Mui-focused': {

--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/index.tsx
@@ -20,6 +20,8 @@ import ReportStolenModal from './components/reportStolen';
 import ConfirmReport from './components/confirmReport';
 import GordonSnackbar from 'components/Snackbar';
 import { useNavigate } from 'react-router';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
 
 const MissingItemFormCreate = () => {
   const navigate = useNavigate();
@@ -154,7 +156,7 @@ const MissingItemFormCreate = () => {
       const requestData = {
         ...formData,
         ...user,
-        dateLost: formData.dateLost || DateTime.now().toISO(),
+        dateLost: new Date(formData.dateLost).toISOString() || DateTime.now().toISO(),
         dateCreated: DateTime.now().toISO(),
         colors: formData.colors || [],
         submitterUsername: user.AD_Username,
@@ -167,6 +169,67 @@ const MissingItemFormCreate = () => {
       createSnackbar(`Failed to create the missing item report.`, `error`);
     }
   };
+
+  // Using DatePicker component from MUI/x, with custom styling to fix dark mode contrast issues
+  const customDatePicker = (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <DatePicker
+        label="Date Lost"
+        value={formData.dateLost}
+        onChange={(value) => setFormData({ ...formData, dateLost: value?.toString() || '' })}
+        disableFuture
+        orientation="portrait"
+        name="Date Lost"
+        // Custom styling for the input field, to make it look like filled variant
+        sx={{
+          backgroundColor: 'var(--mui-palette-FilledInput-bg);',
+          paddingTop: '7px;',
+          borderRadius: '5px;',
+          width: '100%;',
+          '& .Mui-focused .MuiOutlinedInput-notchedOutline': { border: 'none' },
+          '& .MuiFormLabel-root': {
+            transform: 'translate(14px, 4px) scale(0.75);',
+          },
+          '& .MuiFormLabel-root.Mui-focused': {
+            color: 'var(--mui-palette-secondary-main);',
+          },
+          '& .MuiOutlinedInput-notchedOutline': {
+            borderWidth: '0;',
+            borderBottom:
+              '1px solid rgba(var(--mui-palette-common-onBackgroundChannel) / var(--mui-opacity-inputUnderline));',
+            borderRadius: '0;',
+          },
+        }}
+        // Custom styling for popup box, better dark mode contrast
+        // Thanks to help for understanding from
+        // https://blog.openreplay.com/styling-and-customizing-material-ui-date-pickers/
+        slotProps={{
+          layout: {
+            sx: {
+              '& .MuiPickersLayout-contentWrapper .Mui-selected': {
+                backgroundColor: 'var(--mui-palette-secondary-400);',
+              },
+              '.MuiPickersLayout-contentWrapper .MuiPickersDay-root:focus.Mui-selected': {
+                backgroundColor: 'var(--mui-palette-secondary-400);',
+              },
+              '.MuiPickersLayout-contentWrapper .MuiPickersDay-root.Mui-selected': {
+                backgroundColor: 'var(--mui-palette-secondary-400);',
+              },
+            },
+          },
+          actionBar: {
+            sx: {
+              ...{
+                '& .MuiButtonBase-root': {
+                  color: 'var(--mui-palette-secondary-400);',
+                },
+              },
+            },
+          },
+        }}
+      />
+    </LocalizationProvider>
+  );
 
   return (
     <>
@@ -320,19 +383,7 @@ const MissingItemFormCreate = () => {
                 />
               </Grid>
               <Grid item margin={2}>
-                <TextField
-                  fullWidth
-                  variant="filled"
-                  label={'Date Lost'}
-                  InputLabelProps={{ shrink: true }}
-                  name="dateLost"
-                  type="date"
-                  value={formData.dateLost}
-                  onChange={handleChange}
-                  inputProps={{
-                    max: DateTime.now().toISODate(), // Restrict to today or past dates
-                  }}
-                />
+                {customDatePicker}
               </Grid>
             </Grid>
           </Grid>

--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemEdit/components/confirmReport/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemEdit/components/confirmReport/index.tsx
@@ -47,7 +47,7 @@ const ConfirmReport: React.FC<ConfirmReportProps> = ({ formData, onEdit, onSubmi
               <strong>Item Brand/Make:</strong> {formData.brand}
             </Typography>
             <Typography>
-              <strong>Date Lost:</strong> {formData.dateLost}
+              <strong>Date Lost:</strong> {new Date(formData.dateLost).toDateString()}
             </Typography>
           </Grid>
           <Grid item xs={6}>

--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemEdit/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemEdit/index.tsx
@@ -46,6 +46,7 @@ const MissingItemFormEdit = () => {
     stolen: false,
     stolenDescription: '',
     dateLost: '',
+    dateCreated: '',
     status: 'active',
   });
 
@@ -79,6 +80,7 @@ const MissingItemFormEdit = () => {
           stolen: item.stolen,
           stolenDescription: item.stolenDescription || '',
           dateLost: item.dateLost,
+          dateCreated: item.dateCreated,
           status: item.status || 'active',
         });
       }
@@ -111,7 +113,6 @@ const MissingItemFormEdit = () => {
       ...user,
       submitterUsername: user.AD_Username,
       dateLost: new Date(formData.dateLost).toISOString() || DateTime.now().toISO(),
-      dateCreated: DateTime.now().toISO(),
       forGuest: false,
     };
     await lostAndFoundService.updateMissingItemReport(requestData, parseInt(itemid || ''));

--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemEdit/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemEdit/index.tsx
@@ -124,7 +124,7 @@ const MissingItemFormEdit = () => {
     <LocalizationProvider dateAdapter={AdapterDateFns}>
       <DatePicker
         label="Date Lost"
-        value={formData.dateLost}
+        value={formData.dateLost === '' ? null : formData.dateLost}
         onChange={(value) => setFormData({ ...formData, dateLost: value?.toString() || '' })}
         disableFuture
         orientation="portrait"
@@ -136,7 +136,7 @@ const MissingItemFormEdit = () => {
           borderRadius: '5px;',
           width: '100%;',
           '& .Mui-focused .MuiOutlinedInput-notchedOutline': { border: 'none' },
-          '& .MuiFormLabel-root': {
+          '& .MuiInputLabel-shrink': {
             transform: 'translate(14px, 4px) scale(0.75);',
           },
           '& .MuiFormLabel-root.Mui-focused': {


### PR DESCRIPTION
# Bugs/Issues Squashed:

## Date Bug on Chrome not Safari
- [x] Done

The missing item edit and create forms now use a much more advanced date picker component.  I had to do a bunch of custom styling to fix dark mode contrast issues.  This fixes the bug where the field would display mm/dd/yyyy on Chrome, and is also a much nicer date picker, that actually uses the MUI theme colors (so will switch to dark mode).

<img width="940" alt="Screen Shot 2024-11-30 at 16 18 39" src="https://github.com/user-attachments/assets/54a5d54f-e681-4c85-ba0f-89ac289067db">

## Label Dark Mode Color Contrast Issue when Form Field Focused

- [x]  Done

This is actually a site wide issue, on all of the pages that use the ```TextField``` component, because of how dark mode was set up.  I found a workaround using the ```sx``` prop, and applied it to our two general user forms (create and edit).  Now the label text doesn't change to a (far too) dark color when each form field is selected by the user.
<img width="725" alt="Screen Shot 2024-11-30 at 22 55 43" src="https://github.com/user-attachments/assets/03c0992c-3764-4be8-9d6c-31dc39c9abfc">

Custom styling:
<img width="502" alt="Screen Shot 2024-11-30 at 22 55 57" src="https://github.com/user-attachments/assets/b318889b-e153-42c3-abbf-ac0fe8ea32c6">


## Stolen Description Editing
- [x] Done

You can now edit the stolen description, to add more details, etc.
<img width="738" alt="Screen Shot 2024-11-30 at 16 23 57" src="https://github.com/user-attachments/assets/33a390fb-92c6-440d-8991-af07c447bf98">

## Date Created being Erroneously Changed
- [x] Done

The missing item form ```dateCreated``` field is no longer changed by editing, so the date created will stay as the original date of form creation.

## Edit form shows before data is loaded.
- [x] Done

Added a loader that appears before the data loads in, avoids the weird pop-in effect of the data filling the form, and reduces confusion.

 ## Fixed light mode contrast issues with delete modal.
- [x] Done

### Old:
![Image](https://github.com/user-attachments/assets/d2ecf3f1-21fc-4143-8283-846b187f60ca)

### New:
<img width="729" alt="Screen Shot 2024-11-30 at 13 51 55" src="https://github.com/user-attachments/assets/ae7b4905-f83e-4a41-869d-2fede3eaf411">

### Dark Mode:
<img width="765" alt="Screen Shot 2024-11-30 at 13 52 47" src="https://github.com/user-attachments/assets/fbfe7e6d-46cd-49b0-bdc3-5c9231863877">
