### PR TITLE
Dark Mode Form Label Text Contrast Fix

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -198,7 +198,7 @@ export const theme360 = extendTheme({
           100: '#BBDDF0',
           200: '#92C8E6',
           300: '#6BB2DC',
-          400: ScottieCyanAlt,
+          400: '#4EA2D7',
           500: '#3394D1',
           600: '#2886C5',
           700: '#1C75B3',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -28,9 +28,8 @@ const GordonBlue_opacity50 = '#01498382';
 
 // Secondary
 const ScottieCyan = '#00AEEF';
-// Slightly darker versions of Scottie Cyan
-const ScottieCyanAltDark = '#4EA2D7';
-const ScottieCyanAltLight = '#4EA2D7';
+// Slightly lighter version of Scottie Cyan
+const ScottieCyanAlt = '#4EA2D7';
 const ScottieCyan_opacity75 = '#00AEEFBF';
 const ScottieCyan_opacity10 = '#00AEEF1A';
 
@@ -97,7 +96,7 @@ export const theme360 = extendTheme({
         secondary: {
           main: ScottieCyan,
           dark: ScottieCyan_opacity75,
-          light: ScottieCyanAltLight,
+          light: ScottieCyanAlt,
           contrastText: Black,
           50: ScottieCyan_opacity10,
           100: '#B0E2F9',
@@ -193,13 +192,13 @@ export const theme360 = extendTheme({
         },
         secondary: {
           main: ScottieCyan,
-          light: ScottieCyanAltDark,
+          light: ScottieCyanAlt,
           contrastText: Black,
           50: GordonBlue_opacity50,
           100: '#BBDDF0',
           200: '#92C8E6',
           300: '#6BB2DC',
-          400: '#4EA2D7',
+          400: ScottieCyanAlt,
           500: '#3394D1',
           600: '#2886C5',
           700: '#1C75B3',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,3 +1,4 @@
+import { BorderColor } from '@mui/icons-material';
 import { experimental_extendTheme as extendTheme } from '@mui/material/styles';
 
 // Colors from http://www.gordon.edu/brandstandards
@@ -28,8 +29,8 @@ const GordonBlue_opacity50 = '#01498382';
 
 // Secondary
 const ScottieCyan = '#00AEEF';
-// Slightly lighter version of Scottie Cyan
-const ScottieCyanAlt = '#4EA2D7';
+// Slightly darker version of Scottie Cyan, for more subtle applications
+const ScottieCyanAlt = '#3394D1';
 const ScottieCyan_opacity75 = '#00AEEFBF';
 const ScottieCyan_opacity10 = '#00AEEF1A';
 
@@ -249,6 +250,24 @@ export const theme360 = extendTheme({
     },
   },
   components: {
+    MuiFilledInput: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '&::after': {
+            borderColor: theme.palette.secondary.light, // Focused bottom border color
+          },
+        }),
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.secondary.light, // Focused border color
+          },
+        }),
+      },
+    },
     MuiInputLabel: {
       styleOverrides: {
         root: ({ theme }) => ({

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,3 @@
-import { BorderColor } from '@mui/icons-material';
 import { experimental_extendTheme as extendTheme } from '@mui/material/styles';
 
 // Colors from http://www.gordon.edu/brandstandards

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -28,6 +28,9 @@ const GordonBlue_opacity50 = '#01498382';
 
 // Secondary
 const ScottieCyan = '#00AEEF';
+// Slightly darker versions of Scottie Cyan
+const ScottieCyanAltDark = '#4EA2D7';
+const ScottieCyanAltLight = '#4EA2D7';
 const ScottieCyan_opacity75 = '#00AEEFBF';
 const ScottieCyan_opacity10 = '#00AEEF1A';
 
@@ -94,6 +97,7 @@ export const theme360 = extendTheme({
         secondary: {
           main: ScottieCyan,
           dark: ScottieCyan_opacity75,
+          light: ScottieCyanAltLight,
           contrastText: Black,
           50: ScottieCyan_opacity10,
           100: '#B0E2F9',
@@ -189,6 +193,7 @@ export const theme360 = extendTheme({
         },
         secondary: {
           main: ScottieCyan,
+          light: ScottieCyanAltDark,
           contrastText: Black,
           50: GordonBlue_opacity50,
           100: '#BBDDF0',
@@ -245,6 +250,15 @@ export const theme360 = extendTheme({
     },
   },
   components: {
+    MuiInputLabel: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '&.Mui-focused': {
+            color: theme.vars.palette.secondary.light, // Focused label color, for better contrast in dark mode
+          },
+        }),
+      },
+    },
     MuiButton: {
       styleOverrides: {
         outlinedPrimary: ({ theme }) => ({


### PR DESCRIPTION
This has been an issue for several years now.  Figured I'd finally fix it, since it's kinda annoying, and relatively easy to fix :).  Added a style override to the theme, fixing the colors of the label and border elements when focusing form fields.

### Old: 
<img width="528" alt="Screen Shot 2024-12-01 at 00 30 59" src="https://github.com/user-attachments/assets/06166f57-2dec-4a53-a1dc-e92d6cd9bb49">

### New:
<img width="499" alt="Screen Shot 2024-12-01 at 01 00 31" src="https://github.com/user-attachments/assets/7642399c-c5ab-4364-bccd-ef7307e97fdd">


