### PR TITLE
Sticky List Header

### DIFF
--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/MissingItemList.module.scss
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/MissingItemList.module.scss
@@ -1,3 +1,7 @@
+.filterCardPosition {
+  transform: translateY(15px);
+}
+
 .filterTitle {
   color: var(--mui-palette-primary-contrastText); // Warning color for emphasis
   background-color: var(--mui-palette-primary-main); // Primary color for header
@@ -36,17 +40,47 @@
   text-align: center;
 }
 
+.listCard {
+  // Move the card to behind the sticky bar
+  margin-top: 0.3rem;
+}
+
 .listContainer {
   padding: 0rem;
 }
 
+.stickyHeader {
+  margin-left: -0.5rem;
+  background-color: var(--mui-palette-neutral-light);
+  position: sticky;
+  top: -1rem;
+  z-index: 9; // this component defaults to a higher z-index that overlays quick search
+  // Move so stuck position is below breadcrumbs bar
+  transform: translateY(55px);
+  // Move left
+  width: calc(100% + 1rem);
+  // clip-path removes box shadow below this nav bar
+  clip-path: inset(0px -10px 0px -10px);
+}
+
 .tableHeader {
-  // display: flex;
-  // justify-content: space-between;
   padding: 1rem;
+  padding-bottom: -1rem;
   background-color: var(--mui-palette-primary-main);
   color: var(--mui-palette-primary-contrastText);
-  font-weight: bold;
+}
+
+.noWrap {
+  text-wrap: nowrap;
+}
+
+.headerPlaceholder {
+  padding: 1rem;
+  padding-bottom: -1rem;
+}
+
+.verticalSpacer {
+  height: 1rem;
 }
 
 .reportRow {

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
@@ -11,6 +11,7 @@ import {
   FormControl,
   InputLabel,
   CardHeader,
+  AppBar,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 import lostAndFoundService, { MissingItemReport } from 'services/lostAndFound';
@@ -171,8 +172,8 @@ const MissingItemList = () => {
       <Header />
       {/* Filter Bar */}
       <Grid container justifyContent="center" spacing={2} marginBottom={2}>
-        <Grid item xs={11}>
-          <Card>
+        <Grid item xs={12} md={11}>
+          <Card className={styles.filterCardPosition}>
             <CardHeader
               title={
                 <span className={styles.filterTitleText}>
@@ -280,38 +281,48 @@ const MissingItemList = () => {
       </Grid>
 
       {/* Reports Table */}
+      {!isMobile && (
+        // Header row for larger screens, sticky to the top of the screen on scroll
+        <AppBar className={styles.stickyHeader}>
+          <Grid container className={styles.tableHeader} justifyContent={'center'}>
+            <Grid container item xs={11.85}>
+              <Grid item xs={2}>
+                Date Lost
+              </Grid>
+              <Grid item xs={2}>
+                Owner's Name
+              </Grid>
+              <Grid item xs={2}>
+                Location
+              </Grid>
+              <Grid item xs={1.5}>
+                Category
+              </Grid>
+              <Grid item xs={3}>
+                Description
+              </Grid>
+              <Grid item xs={1} className={styles.noWrap}>
+                Last Checked
+              </Grid>
+              <Grid item xs={1}></Grid>
+            </Grid>
+          </Grid>
+        </AppBar>
+      )}
       <Grid container justifyContent="center" spacing={2}>
-        <Grid item xs={11}>
-          <Card>
+        <Grid item xs={12}>
+          <Card className={styles.listCard}>
             <CardContent className={styles.listContainer}>
+              {!isMobile && (
+                // Size Placeholder for sticky header for Larger Screens
+                <Grid container className={styles.headerPlaceholder}>
+                  <Grid item xs={2} className={styles.verticalSpacer}></Grid>
+                </Grid>
+              )}
               {loading ? (
                 <GordonLoader />
               ) : (
                 <>
-                  {!isMobile && (
-                    // Header Row for Larger Screens
-                    <Grid container className={styles.tableHeader}>
-                      <Grid item xs={2}>
-                        Date Lost
-                      </Grid>
-                      <Grid item xs={2}>
-                        Owner's Name
-                      </Grid>
-                      <Grid item xs={2}>
-                        Location
-                      </Grid>
-                      <Grid item xs={1.5}>
-                        Category
-                      </Grid>
-                      <Grid item xs={3}>
-                        Description
-                      </Grid>
-                      <Grid item xs={1}>
-                        Last Checked
-                      </Grid>
-                      <Grid item xs={1}></Grid>
-                    </Grid>
-                  )}
                   {filteredReports.map((report, index) =>
                     isMobile ? (
                       // Mobile Layout


### PR DESCRIPTION
On desktop, the header bar on the list of missing item reports will now stick to the top of the screen when the user scrolls down.  The CSS workaround I had to do to make this work is a little stupid, but it works.

Also, please test on Safari, and I will cry when it breaks catastrophically 🤞 

<img width="1680" alt="Screen Shot 2024-12-02 at 23 38 05" src="https://github.com/user-attachments/assets/25432ad8-d5a3-43b1-8985-7d770f16cb36">
