### PR TITLE
LostAndFound No Longer Visible in Guest Mode

### DIFF
--- a/src/views/CampusSafety/index.tsx
+++ b/src/views/CampusSafety/index.tsx
@@ -8,9 +8,22 @@ import MissingItemList from './views/LostAndFoundAdmin/views/MissingItemList';
 import MissingItemReportData from './views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData';
 import ReportItemPage from './views/LostAndFoundAdmin/views/MissingItemList/components/ReportItemPageOther';
 import ReportFound from './views/LostAndFound/views/ReportFound';
+import GordonLoader from 'components/Loader';
+import GordonUnauthenticated from 'components/GordonUnauthenticated';
+import { useUser } from 'hooks';
 
 // Routing between Campus Safety App pages
 const CampusSafetyApp = () => {
+  const { profile, loading: loadingProfile } = useUser();
+
+  if (loadingProfile) {
+    return <GordonLoader />;
+  }
+
+  if (!profile) {
+    return <GordonUnauthenticated feature="Lost and Found" />;
+  }
+
   return (
     <Routes>
       <Route path="/:itemid" element={<MissingItemFormEdit />} />

--- a/src/views/Links/index.jsx
+++ b/src/views/Links/index.jsx
@@ -24,9 +24,11 @@ import CallIcon from '@mui/icons-material/Call';
 import ReportIcon from '@mui/icons-material/Report';
 import styles from '/src/views/Links/Links.module.scss';
 import { useNavigate } from 'react-router';
+import { useUser } from 'hooks';
 
 const Links = () => {
   const navigate = useNavigate();
+  const { profile } = useUser();
 
   // Academics Resources UI
   const academicsCard = (
@@ -283,6 +285,7 @@ const Links = () => {
                   <Button
                     color="secondary"
                     variant="contained"
+                    disabled={!profile}
                     onClick={() => {
                       navigate('/lostandfound');
                     }}


### PR DESCRIPTION
Code copied directly from people search, super quick fix.

Button on links page disabled:
<img width="541" alt="Screen Shot 2024-12-02 at 23 51 28" src="https://github.com/user-attachments/assets/1da27474-bb30-4ac5-88d0-d741e16b2252">

Direct navigation to any routes yields:
<img width="1049" alt="Screen Shot 2024-12-02 at 23 51 59" src="https://github.com/user-attachments/assets/62c11a3b-d067-4f6e-b5fb-9c5b998cfe45">
