### PR TITLE
Fix for Issue with Creating Missing Item Reports in Production

### DIFF
--- a/src/services/lostAndFound.ts
+++ b/src/services/lostAndFound.ts
@@ -96,7 +96,7 @@ const createMissingItemReport = async (
     dateCreated: DateTime.now().toISO(),
     colors: data.colors || [], // Ensures colors is an array, even if not defined
   };
-  const response = await http.post<number>('/LostAndFound/missingitem', formattedData);
+  const response = await http.post<number>('lostandfound/missingitem', formattedData);
   return response;
 };
 


### PR DESCRIPTION
This fixes the issue with calling the POST route in production returning 404.  Not sure how we missed this, apparently this route call works fine in the development environment, but as soon as you build and run for production, it doesn't work with the leading /.  Not sure how we missed this inconsistency, but it's fixed now :).

Thanks @EjPlatzer for spotting that!