### PR TITLE
HOTFIX for sticky header padding on admin list Page.

### DIFF
--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/MissingItemList.module.scss
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/MissingItemList.module.scss
@@ -64,8 +64,7 @@
 }
 
 .tableHeader {
-  padding: 1rem;
-  padding-bottom: -1rem;
+  padding: 1rem; // Ensure this style applies in production build
   background-color: var(--mui-palette-primary-main);
   color: var(--mui-palette-primary-contrastText);
 }
@@ -75,8 +74,7 @@
 }
 
 .headerPlaceholder {
-  padding: 1rem;
-  padding-bottom: -1rem;
+  padding: 1rem; // Ensure this style applies in production build
 }
 
 .verticalSpacer {


### PR DESCRIPTION
Fixes this CSS issue with the header bar in the production build environment.
<img width="1680" alt="Screen Shot 2024-12-07 at 11 41 15" src="https://github.com/user-attachments/assets/dff81492-1333-4e07-a128-2a5d7d884765">
