### PR TITLE
Fix Report Column Color Contrast

### DIFF
--- a/src/views/CampusSafety/views/LostAndFound/LostAndFound.module.scss
+++ b/src/views/CampusSafety/views/LostAndFound/LostAndFound.module.scss
@@ -40,7 +40,7 @@
 }
 
 .headerText {
-  color: var(--mui-palette-neutral-400);
+  color: var(--mui-palette-primary-contrastText);
 }
 
 .rowPadding {


### PR DESCRIPTION
Figured it was best to play it safe with plain old white.
<img width="570" alt="Screenshot 2024-12-10 at 2 00 20 AM" src="https://github.com/user-attachments/assets/bbb68a80-cf90-4494-bd47-6726c6302245">
<img width="592" alt="Screenshot 2024-12-10 at 2 00 41 AM" src="https://github.com/user-attachments/assets/f70f4828-2908-4082-98fd-3e03df9f50cb">
