### PR TITLE
Clarified Wording when Creating a Report

### DIFF
--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/components/confirmReport/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/components/confirmReport/index.tsx
@@ -25,14 +25,11 @@ const ConfirmReport: React.FC<ConfirmReportProps> = ({ formData, onEdit, onSubmi
   return (
     <Card className={styles.confirmCard}>
       <CardHeader
-        title="Missing Item Report"
+        title="Confirm the Details of your Report"
         className={styles.header}
         titleTypographyProps={{ align: 'center' }}
       />
       <CardContent>
-        <Typography variant="h6" align="center" gutterBottom>
-          Confirm the details of your report
-        </Typography>
         <Grid container spacing={2} className={styles.reportDetails}>
           <Grid item xs={6}>
             <Typography>

--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemCreate/index.tsx
@@ -474,7 +474,7 @@ const MissingItemFormCreate = () => {
                 className={styles.submit_button}
                 onClick={handleFormSubmit}
               >
-                SUBMIT
+                NEXT
               </Button>
             </Grid>
           </Grid>


### PR DESCRIPTION
Button in bottom right used to be "SUBMIT"
<img width="1243" alt="Screenshot 2024-12-10 at 6 00 15 PM" src="https://github.com/user-attachments/assets/0a5784c4-8b8d-4c00-b12c-b0a3c38ae62b">
Used to say "File a Report" in the header and then "Confirm the Details of your Report" below outside of the header.
<img width="601" alt="Screenshot 2024-12-10 at 6 01 26 PM" src="https://github.com/user-attachments/assets/755df325-c27e-440e-b080-2c53bea399a7">
