### PR TITLE
Improve form contrast in dark mode

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -276,6 +276,33 @@ export const theme360 = extendTheme({
         }),
       },
     },
+    MuiFormLabel: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '[data-mui-color-scheme="dark"] &.Mui-focused': {
+            color: theme.vars.palette.secondary.light, // Focused label color, for better contrast in dark mode
+          },
+        }),
+      },
+    },
+    MuiRadio: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '[data-mui-color-scheme="dark"] &.Mui-checked': {
+            color: theme.vars.palette.secondary.light, // Checked input color, for better contrast in dark mode
+          },
+        }),
+      },
+    },
+    MuiCheckbox: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '[data-mui-color-scheme="dark"] &.Mui-checked': {
+            color: theme.vars.palette.secondary.light, // Checked input color, for better contrast in dark mode
+          },
+        }),
+      },
+    },
     MuiButton: {
       styleOverrides: {
         outlinedPrimary: ({ theme }) => ({


### PR DESCRIPTION
NightMarsh doesn't offer sufficient contrast for form elements and highlights in dark mode, so I replaced it with ScottieCyanAlt.

Realistically, we should get replace NightMarsh as the primary theme color in dark mode, since it doesn't offer sufficient contrast almost anywhere.