### PR TITLE
Fix Last Checked Date

### DIFF
--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
@@ -124,9 +124,15 @@ const MissingItemList = () => {
 
   // Find and format the last checked date based on the list of admin actions for a given report.
   const displayLastCheckedDate = (report: MissingItemReport) => {
-    var dateString = report.adminActions?.findLast((action) => {
-      return action.action === 'Checked';
-    })?.actionDate;
+    console.log(report.recordID, report.adminActions);
+    var dateString = report.adminActions
+      ?.sort(
+        (action1, action2) =>
+          new Date(action1.actionDate).getTime() - new Date(action2.actionDate).getTime(),
+      )
+      .findLast((action) => {
+        return action.action === 'Checked';
+      })?.actionDate;
     if (dateString !== '' && dateString !== undefined) {
       return formatDate(dateString);
     }

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/index.tsx
@@ -124,7 +124,6 @@ const MissingItemList = () => {
 
   // Find and format the last checked date based on the list of admin actions for a given report.
   const displayLastCheckedDate = (report: MissingItemReport) => {
-    console.log(report.recordID, report.adminActions);
     var dateString = report.adminActions
       ?.sort(
         (action1, action2) =>


### PR DESCRIPTION
Last checked date would not always update to the most recent, and was simply based on the order the admin actions were fetched from the database.

<img width="1667" alt="Screen Shot 2025-01-16 at 11 32 24" src="https://github.com/user-attachments/assets/dbe28d2a-42c3-461d-a4c5-1a09f906da4a" />

<img width="739" alt="Screen Shot 2025-01-16 at 11 32 09" src="https://github.com/user-attachments/assets/ba185cdc-d00b-458b-95ec-cbffd83c9c00" />
