### PR TITLE
Fixed case-sensitive issues for item categories

### DIFF
--- a/src/views/CampusSafety/views/LostAndFound/views/MissingItemEdit/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFound/views/MissingItemEdit/index.tsx
@@ -406,7 +406,10 @@ const MissingItemFormEdit = () => {
                                 category: (e.target as HTMLInputElement).value,
                               }))
                             }
-                            checked={formData.category === label.toLowerCase().replace(/ /g, '/')}
+                            checked={
+                              formData.category.toLowerCase().replace(/ /g, '/') ===
+                              label.toLowerCase().replace(/ /g, '/')
+                            }
                             className={styles.category_item}
                           />
                         ))}

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/ReportItemPageOther/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/ReportItemPageOther/index.tsx
@@ -618,14 +618,14 @@ const ReportItemPage = () => {
                         key={label}
                         control={<Radio />}
                         label={label}
-                        value={label}
+                        value={label.toLowerCase().replace(/ /g, '/')}
                         onChange={(e) =>
                           setFormData((prevData) => ({
                             ...prevData,
                             category: (e.target as HTMLInputElement).value,
                           }))
                         }
-                        checked={formData.category === label}
+                        checked={formData.category === label.toLowerCase().replace(/ /g, '/')}
                         className={styles.category_item}
                       />
                     ))}


### PR DESCRIPTION
Changed admin missing item form to match the lowercase formatting of the item category from the general user form and changed the edit form to be case insensitive so that previous upper case entries don't cause issues.