### PR TITLE
Remove luxon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
         "@mui/material": "^5.15.10",
         "@mui/x-date-pickers": "^6.19.4",
         "add-to-calendar-button": "^2.5.10",
+        "caniuse-lite": "^1.0.30001589",
         "chart.js": "^4.4.3",
         "cropperjs": "^1.6.1",
         "date-fns": "^3.3.1",
         "history": "^5.3.0",
         "lodash": "^4.17.21",
-        "luxon": "^3.4.4",
         "prop-types": ">=15.7.2",
         "react": "^18.3.1",
         "react-big-calendar": "^1.10.3",
@@ -45,7 +45,6 @@
       },
       "devDependencies": {
         "@types/lodash": "^4.14.202",
-        "@types/luxon": "^3.4.2",
         "@types/react-big-calendar": "^1.8.8",
         "@types/react-dom": "^18.3.0",
         "@types/react-router-dom": "^5.3.3",
@@ -3810,12 +3809,6 @@
       "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
-    "node_modules/@types/luxon": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
-      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
-      "dev": true
-    },
     "node_modules/@types/markdown-it": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
@@ -4772,7 +4765,6 @@
       "version": "1.0.30001669",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
       "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "date-fns": "^3.3.1",
     "history": "^5.3.0",
     "lodash": "^4.17.21",
-    "luxon": "^3.4.4",
     "prop-types": ">=15.7.2",
     "react": "^18.3.1",
     "react-big-calendar": "^1.10.3",
@@ -42,7 +41,6 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.202",
-    "@types/luxon": "^3.4.2",
     "@types/react-big-calendar": "^1.8.8",
     "@types/react-dom": "^18.3.0",
     "@types/react-router-dom": "^5.3.3",

--- a/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/components/ScheduleCalendar/index.tsx
@@ -1,9 +1,19 @@
-import { Calendar, luxonLocalizer } from 'react-big-calendar';
+import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
 import { CourseEvent, Schedule, scheduleCalendarResources } from 'services/schedule';
 import './ScheduleCalendar.css';
-import { DateTime } from 'luxon';
+import { format, getDay, startOfWeek } from 'date-fns';
+import { enUS } from 'date-fns/locale';
 
-const localizer = luxonLocalizer(DateTime, { firstDayOfWeek: 1 });
+const locales = {
+  'en-US': enUS,
+};
+
+const localizer = dateFnsLocalizer({
+  format,
+  startOfWeek,
+  getDay,
+  locales,
+});
 
 type Props = {
   schedule: Schedule;

--- a/src/services/event.ts
+++ b/src/services/event.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import http from './http';
 import session from './session';
 import { compareByProperty, filter } from './utils';
@@ -37,13 +36,16 @@ type EventDisplayProperties = {
 type Event = UnformattedEvent & EventDisplayProperties;
 type AttendedEvent = UnformattedAttendedEvent & EventDisplayProperties;
 
+const shortTimeFormatter = new Intl.DateTimeFormat('en-US', { timeStyle: 'short' });
+const shortDateFormatter = new Intl.DateTimeFormat('en-US', { dateStyle: 'short' });
+
 function formatEvent<T extends BaseEvent>(event: T): T & EventDisplayProperties {
+  const startDate = new Date(event.StartDate);
+  const endDate = new Date(event.EndDate);
   return {
     ...event,
-    timeRange: `${DateTime.fromISO(event.StartDate).toFormat('t')} - ${DateTime.fromISO(
-      event.EndDate,
-    ).toFormat('t')}`,
-    date: DateTime.fromISO(event.StartDate).toFormat('LLL d, yyyy'),
+    timeRange: shortTimeFormatter.formatRange(startDate, endDate),
+    date: shortDateFormatter.format(startDate),
     title: event.Event_Title || event.Event_Name,
     location: event.Location || 'No Location Listed',
     Description:

--- a/src/services/news.ts
+++ b/src/services/news.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import http from './http';
 import { filter, map } from './utils';
 
@@ -35,8 +34,6 @@ const getPostingByID = (id: number): Promise<NewsObject> => http.get(`news/${id}
 
 type FormattedNewsObject = NewsObject & {
   dayPosted: string;
-  yearPosted: number;
-  datePosted: string;
   author: string;
 };
 
@@ -47,17 +44,16 @@ type StudentNewsUpload = {
   image: string;
 };
 
-function formatPosting(posting: NewsObject): FormattedNewsObject {
-  const timestamp = DateTime.fromISO(posting.Entered);
-  const dayPosted = timestamp.weekdayShort + ', ' + timestamp.monthLong + ' ' + timestamp.day;
-  const yearPosted = timestamp.year;
-  const datePosted = timestamp.month + '/' + timestamp.day;
+const dayPostedFormatter = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'long',
+  day: 'numeric',
+});
 
+function formatPosting(posting: NewsObject): FormattedNewsObject {
   return {
     ...posting,
-    dayPosted,
-    yearPosted,
-    datePosted,
+    dayPosted: dayPostedFormatter.format(new Date(posting.Entered)),
     author: posting.ADUN.replace('.', ' '),
   };
 }

--- a/src/views/ApartmentApp/components/StaffMenu/index.jsx
+++ b/src/views/ApartmentApp/components/StaffMenu/index.jsx
@@ -1,14 +1,14 @@
-import { Button, Card, CardContent, CardHeader, Grid, Typography } from '@mui/material/';
 import GetAppIcon from '@mui/icons-material/GetApp';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import { Button, Card, CardContent, CardHeader, Grid, Typography } from '@mui/material/';
 import GordonLoader from 'components/Loader';
 import { sortBy } from 'lodash';
-import { DateTime } from 'luxon';
 import { forwardRef, useCallback, useEffect, useState } from 'react';
 import { CSVLink } from 'react-csv';
 import { NotFoundError } from 'services/error';
 import housing from 'services/housing';
 // @TODO CSSMODULES - outside directory
+import { format } from 'date-fns';
 import styles from '../../ApartmentApp.module.css';
 import ApplicationsTable from './components/ApplicationTable';
 
@@ -81,7 +81,7 @@ const StaffMenu = ({ userProfile }) => {
     loadAllCurrentApplications();
 
     // Generate string of today's date in ISO format for use in CSV filename
-    setDateStr(DateTime.now().toISODate({ includeOffset: false }));
+    setDateStr(format(new Date(), 'yyyy-MM-dd'));
   }, [userProfile, loadAllCurrentApplications]);
 
   useEffect(() => {

--- a/src/views/ApartmentApp/components/StudentApplication/components/ApplicationDataTable/index.jsx
+++ b/src/views/ApartmentApp/components/StudentApplication/components/ApplicationDataTable/index.jsx
@@ -10,7 +10,6 @@ import {
   Typography,
 } from '@mui/material/';
 import EmailIcon from '@mui/icons-material/Email';
-import { DateTime } from 'luxon';
 // @TODO CSSMODULES - outside directory
 import styles from '../../../../ApartmentApp.module.css';
 
@@ -35,11 +34,11 @@ const ApplicationDataTable = ({ applicationDetails }) => {
   let rows = [
     createData(
       'Last Submitted: ',
-      dateSubmitted ? DateTime.fromISO(dateSubmitted).toLocaleString() : 'Not yet submitted',
+      dateSubmitted ? new Date(dateSubmitted).toLocaleString() : 'Not yet submitted',
     ),
     createData(
       'Last Modified: ',
-      dateModified ? DateTime.fromISO(dateModified).toLocaleString() : 'Not yet saved',
+      dateModified ? new Date(dateModified).toLocaleString() : 'Not yet saved',
     ),
     createData('Application Editor: ', editorUsername ?? 'None'),
   ];

--- a/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
+++ b/src/views/CampusSafety/views/LostAndFoundAdmin/views/MissingItemList/components/MissingItemReportData/index.tsx
@@ -22,12 +22,12 @@ import styles from './MissingItemReportData.module.scss';
 import { useEffect, useRef, useState } from 'react';
 import lostAndFoundService from 'services/lostAndFound';
 import type { MissingItemReport, MissingAdminAction } from 'services/lostAndFound';
-import { DateTime } from 'luxon';
 import Header from 'views/CampusSafety/components/Header';
 import GordonLoader from 'components/Loader';
 import GordonDialogBox from 'components/GordonDialogBox';
 import userService from 'services/user';
 import SimpleSnackbar from 'components/Snackbar';
+import { format } from 'date-fns';
 
 const MissingItemReportData = () => {
   const navigate = useNavigate();
@@ -327,7 +327,7 @@ const MissingItemReportData = () => {
       let requestData = {
         ...newActionFormData,
         missingID: parseInt(itemId || ''),
-        actionDate: DateTime.now().toISO(),
+        actionDate: new Date().toISOString(),
         username: username.AD_Username,
         isPublic: newActionFormData.action === 'Checked' && !checkedItemNotFound ? true : false,
       };
@@ -348,11 +348,11 @@ const MissingItemReportData = () => {
   }, [checkedActionFormData]);
 
   // Format date strings for display
-  const formatDate = (date: string) => DateTime.fromISO(date).toFormat('M/d/yy');
+  const formatDate = (date: string) => format(date, 'M/d/yy');
 
   if (!item) return null;
 
-  const formattedDateLost = DateTime.fromISO(item.dateLost).toFormat('MM-dd-yy');
+  const formattedDateLost = format(new Date(item.dateLost), 'MM-dd-yy');
 
   const statusChip = (
     <Chip


### PR DESCRIPTION
Finally removing `luxon` as a dependency, since we've decided to use the native `Date` object along with `date-fns` instead. 

There were a few lingering uses of `luxon` that were easily replaced with the above combination. 

The main blocker to removing `luxon` in the past was lack of support in `react-big-calendar` for localization via `date-fns`, but since they have added a `dateFnsLocalizer`, that is no longer an issue.

Now that [`Temporal`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) has been added to the spec, we will eventually want to start adopting that as the preferred (and much nicer and safer) native method of working with dates and times in JS. However, browser support is still a long ways off for `Temporal`, so there's no rush to replace existing `Date` code that works well. We may want to add the `Temporal` polyfill in the short-term so that all new code can immediately start using `Temporal`, but I have not done that for this PR, since this was focused on removing `luxon`.