### PR TITLE
Added RA option to check in to additional halls

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,8 +4,8 @@
 # VITE_API_URL=https://360Api.gordon.edu/
 
 # @TRAIN
-VITE_API_URL=https://360Apisp.gordon.edu/
+#VITE_API_URL=https://360Apisp.gordon.edu/
 
 # @LOCALHOST
-# VITE_API_URL=http://localhost:51660/
+ VITE_API_URL=http://localhost:51660/
 

--- a/src/services/residentLife/RA_Checkin.ts
+++ b/src/services/residentLife/RA_Checkin.ts
@@ -9,4 +9,7 @@ const submitCheckIn = async (raId: string, hallIds: string[]): Promise<void> => 
   await http.post(`Housing/ras/${raId}/checkin`, hallIds);
 };
 
-export { checkIfCheckedIn, submitCheckIn };
+const getRACurrentHalls = (userName: string): Promise<String[]> =>
+  http.get(`Housing/halls/on-calls/${userName}/locations`);
+
+export { checkIfCheckedIn, submitCheckIn, getRACurrentHalls };

--- a/src/views/ResLife/components/RAView/index.jsx
+++ b/src/views/ResLife/components/RAView/index.jsx
@@ -23,7 +23,11 @@ import MyHall from '../ResidentView/components/MyHall/index';
 import { React, useCallback, useEffect, useState } from 'react';
 import SimpleSnackbar from 'components/Snackbar';
 import GordonDialogBox from 'components/GordonDialogBox';
-import { checkIfCheckedIn, submitCheckIn } from 'services/residentLife/RA_Checkin';
+import {
+  checkIfCheckedIn,
+  submitCheckIn,
+  getRACurrentHalls,
+} from 'services/residentLife/RA_Checkin';
 import { preferredContact, PrefContactMethod } from 'services/residentLife/ResidentStaff';
 import { useUser } from 'hooks';
 import HousingBanner from '../ResidentView/components/HousingWelcome/Banner';
@@ -38,6 +42,7 @@ const RAView = () => {
   const [selectedContact, setSelectedContact] = useState('');
   const [hallName, setHallName] = useState('');
   const [snackbar, setSnackbar] = useState({ message: '', severity: null, open: false });
+  const [checkedInHalls, setCheckedInHalls] = useState([]);
 
   const isMobile = useMediaQuery('(max-width:600px)');
 
@@ -53,7 +58,16 @@ const RAView = () => {
           const isChecked = await checkIfCheckedIn(profile.ID);
           setCheckedIn(isChecked);
 
-          if (profile.hall) {
+          if (isChecked) {
+            const currentHalls = await getRACurrentHalls(profile.AD_Username);
+            setHallState((prevState) => {
+              const updatedState = { ...prevState };
+              currentHalls.forEach((hall) => {
+                updatedState[hall] = true;
+              });
+              return updatedState;
+            });
+          } else if (profile.hall) {
             setHallState((prevState) => ({
               ...prevState,
               [profile.hall]: true,
@@ -65,7 +79,20 @@ const RAView = () => {
         }
       }
     };
+    fetchData();
+  }, [profile?.ID]);
 
+  useEffect(() => {
+    const fetchData = async () => {
+      if (profile?.ID) {
+        try {
+          const halls = await getRACurrentHalls(profile.AD_Username);
+          setCheckedInHalls(halls);
+        } catch (error) {
+          console.error('Error fetching checked-in halls:', error);
+        }
+      }
+    };
     fetchData();
   }, [profile?.ID]);
 
@@ -107,7 +134,7 @@ const RAView = () => {
     let tempName = '';
 
     for (let hall in hallState) {
-      if (hallState[hall] && hall !== 'village') {
+      if (hallState[hall] && hall !== 'village' && !checkedInHalls.includes(hall)) {
         // Map hall codes to names using the mapping object
         const hallName = hallCodeToNameMap[hall];
         tempName = tempName ? `${tempName}, ${hallName}` : hallName;
@@ -119,7 +146,7 @@ const RAView = () => {
 
   const handleSubmit = async () => {
     const selectedHallCodes = Object.keys(hallState).filter(
-      (hall) => hallState[hall] && hall !== 'village',
+      (hall) => hallState[hall] && hall !== 'village' && !checkedInHalls.includes(hall),
     ); //exclude village for checkin
 
     if (!profile?.ID || selectedHallCodes.length === 0) {
@@ -214,20 +241,14 @@ const RAView = () => {
   const checkInButton = () => (
     <Grid container item justifyContent="center" alignItems="center">
       <Grid item xs={12} md={4}>
-        <Button
-          variant="contained"
-          fullWidth={true}
-          onClick={() => setOpen(true)}
-          disabled={isCheckedIn}
-        >
-          {isCheckedIn ? 'You Are Checked In To Your Shift' : 'Check In To Your Shift'}
+        <Button variant="contained" fullWidth={true} onClick={() => setOpen(true)}>
+          {isCheckedIn ? 'check in to additional Halls?' : 'Check In To Your Shift'}
         </Button>
         <Grid item xs={12} md={4} padding={1}>
           <GordonDialogBox
             open={open}
             onClose={() => setOpen(false)}
             title={'Choose Which Hall to Check Into'}
-            isButtonDisabled={!isChecked}
             buttonName="Check In"
             buttonClicked={handleConfirm}
             cancelButtonName="CANCEL"
@@ -238,63 +259,81 @@ const RAView = () => {
                 <FormLabel error>Select a Hall</FormLabel>
                 <FormGroup>
                   <FormControlLabel
+                    key="BRO"
                     checked={BRO}
+                    disabled={checkedInHalls?.includes('BRO')}
                     control={<Checkbox />}
                     onChange={handleHallChecked}
                     label="Bromley"
                     name="BRO"
                   />
                   <FormControlLabel
+                    key="CHA"
                     checked={CHA}
+                    disabled={checkedInHalls?.includes('CHA')}
                     control={<Checkbox />}
                     onChange={handleHallChecked}
                     label="Chase"
                     name="CHA"
                   />
                   <FormControlLabel
+                    key="EVN"
                     checked={EVN}
+                    disabled={checkedInHalls?.includes('EVN')}
                     control={<Checkbox />}
                     onChange={handleHallChecked}
                     label="Evans"
                     name="EVN"
                   />
                   <FormControlLabel
+                    key="FER"
                     checked={FER}
+                    disabled={checkedInHalls?.includes('FER')}
                     control={<Checkbox />}
                     onChange={handleHallChecked}
                     label="Ferrin"
                     name="FER"
                   />
                   <FormControlLabel
+                    key="FUL"
                     checked={FUL}
+                    disabled={checkedInHalls?.includes('FUL')}
                     control={<Checkbox />}
                     onChange={handleHallChecked}
                     label="Fulton"
                     name="FUL"
                   />
                   <FormControlLabel
+                    key="NYL"
                     checked={NYL}
+                    disabled={checkedInHalls?.includes('NYL')}
                     control={<Checkbox />}
                     onChange={handleHallChecked}
                     label="Nyland"
                     name="NYL"
                   />
                   <FormControlLabel
+                    key="TAV"
                     checked={TAV}
+                    disabled={checkedInHalls?.includes('TAV')}
                     control={<Checkbox />}
                     onChange={handleHallChecked}
                     label="Tavilla"
                     name="TAV"
                   />
                   <FormControlLabel
+                    key="WIL"
                     checked={WIL}
+                    disabled={checkedInHalls?.includes('WIL')}
                     control={<Checkbox />}
                     onChange={handleHallChecked}
                     label="Wilson"
                     name="WIL"
                   />
                   <FormControlLabel
+                    key="village"
                     checked={village}
+                    disabled={checkedInHalls?.includes('village')}
                     control={<Checkbox />}
                     onChange={handleHallChecked}
                     label="The Village"


### PR DESCRIPTION
As usual RA will have a button to check in to their shift

![image](https://github.com/user-attachments/assets/ff63a75c-3f5e-42e0-abbd-4663f31830c1)

When the RA is checked in the button text will change asking if they want to check in to additional halls. Previously the button would be disabled

![image](https://github.com/user-attachments/assets/610a31dc-0af4-4304-b380-1146e4998dc9)

When clicked any halls the RA is currently checked in to will be checked and disabled as they are unable to check out of a hall and unable to check into a hall they are already in.

![image](https://github.com/user-attachments/assets/27f277b2-12be-4dfe-8971-47a062e6c0c1)

The API call will only deal with the newly selected halls

![image](https://github.com/user-attachments/assets/7fc1912e-b8fc-479f-9396-e42e502b85e2)
