### PR TITLE
Remove Under Construction Text

### DIFF
--- a/src/views/LostAndFound/views/Admin/index.tsx
+++ b/src/views/LostAndFound/views/Admin/index.tsx
@@ -111,10 +111,6 @@ const LostAndFoundAdmin = () => {
             <Grid container item xs={12}>
               {EnterFoundItem}
             </Grid>
-            <Construction color="error" />
-            <Typography>
-              Under Construction! Use the existing system in FileMaker for found items
-            </Typography>
           </Grid>
         </CardContent>
       </Card>


### PR DESCRIPTION
Removed the "Under Construction" text as it's no longer under construction :)
Looks like this now...
<img width="1440" alt="Screenshot 2025-02-24 at 4 43 51 PM" src="https://github.com/user-attachments/assets/6b9a08c9-f107-4806-96d8-e8b139cc5851" />
