### PR TITLE
Added option to cancel when editing a task

### DIFF
--- a/src/views/ResLife/components/RDView/components/TaskList/index.jsx
+++ b/src/views/ResLife/components/RDView/components/TaskList/index.jsx
@@ -173,6 +173,10 @@ const TaskList = () => {
     setEditing(true);
   };
 
+  const cancelEdit = () => {
+    resetTaskForm();
+  };
+
   // Function to delete a task
   const deleteTask = async (taskID) => {
     try {
@@ -363,9 +367,20 @@ const TaskList = () => {
                 </>
               )}
 
-              <Button variant="contained" color="primary" type="submit" fullWidth>
-                {editing ? 'Edit Task' : 'Create Task'}
-              </Button>
+              <Grid container spacing={2}>
+                {editing && (
+                  <Grid item xs={6}>
+                    <Button variant="contained" color="primary" onClick={cancelEdit} fullWidth>
+                      Cancel Edit
+                    </Button>
+                  </Grid>
+                )}
+                <Grid item xs={editing ? 6 : 12}>
+                  <Button variant="contained" color="secondary" type="submit" fullWidth>
+                    {editing ? 'Save Changes' : 'Create Task'}
+                  </Button>
+                </Grid>
+              </Grid>
             </form>
           </CardContent>
         </Card>


### PR DESCRIPTION
When editing a task you are stuck in edit mode until you save changes

![image](https://github.com/user-attachments/assets/c12a9ba6-198d-4352-97d5-c26b15a00b81)

This PR just adds the cancel option

![image](https://github.com/user-attachments/assets/5b334517-65e4-4018-b000-c77fccd65300)
