### PR TITLE
Fixed Details Button Contrast on CrossCheck Page

### DIFF
--- a/src/views/LostAndFound/views/FoundItemConfirm/index.tsx
+++ b/src/views/LostAndFound/views/FoundItemConfirm/index.tsx
@@ -412,9 +412,6 @@ const FoundItemConfirmation = () => {
                     >
                       <Grid item xs={2} className={FoundItemConfirmationStyles.tableCell}>
                         <Button
-                          variant="text"
-                          size="small"
-                          color="info"
                           onClick={(e) => {
                             e.stopPropagation();
                             navigate(
@@ -422,7 +419,7 @@ const FoundItemConfirmation = () => {
                             );
                           }}
                         >
-                          Details
+                          <Launch color="secondary" />
                         </Button>
                       </Grid>
                       <Grid item xs={2} className={FoundItemConfirmationStyles.tableCell}>


### PR DESCRIPTION
Looks like this (on the far left) (matches the Figma now):
<img width="1341" alt="Screenshot 2025-03-23 at 4 35 52 PM" src="https://github.com/user-attachments/assets/2c4fc9f5-03cc-45af-9d12-09e466ef7d37" />

Also seems like the columns are broken for the data cells :)