### PR TITLE
S25 staff schedule error fix: #2656

### DIFF
--- a/src/components/Profile/components/SchedulePanel/index.tsx
+++ b/src/components/Profile/components/SchedulePanel/index.tsx
@@ -17,6 +17,7 @@ import styles from './ScheduleHeader.module.css';
 import scheduleService, { CourseEvent, Schedule } from 'services/schedule';
 import sessionService from 'services/session';
 import { Profile } from 'services/user';
+import { AuthError } from '@azure/msal-browser';
 
 type Props = {
   profile: Profile;
@@ -38,17 +39,25 @@ const GordonSchedulePanel = ({ profile, myProf }: Props) => {
     Promise.all([
       scheduleService.getAllSessionSchedules(profile.AD_Username),
       sessionService.getCurrent(),
-    ]).then(([allSessionSchedules, currentSession]) => {
-      setAllSchedules(allSessionSchedules);
-      const defaultSchedule =
-        // If there is a schedule for the current session, make it d4fault
-        allSessionSchedules.find((s) => s.session.SessionCode === currentSession.SessionCode) ??
-        // Otherwise, use the most recent session
-        allSessionSchedules[0];
-      setSelectedSchedule(defaultSchedule);
-      setLoading(false);
-    });
+    ])
+      .then(([allSessionSchedules, currentSession]) => {
+        setAllSchedules(allSessionSchedules);
+        const defaultSchedule =
+          // If there is a schedule for the current session, make it d4fault
+          allSessionSchedules.find((s) => s.session.SessionCode === currentSession.SessionCode) ??
+          // Otherwise, use the most recent session
+          allSessionSchedules[0];
+        setSelectedSchedule(defaultSchedule);
+        setLoading(false);
+        console.log(profile);
+      })
+      .catch((reason: AuthError) => {
+        console.log('this is the type');
+        console.log(profile.Type);
+        setLoading(false);
+      });
   }, [profile.AD_Username]);
+
   const toggleIsScheduleOpen = () => {
     setIsScheduleOpen((wasOpen) => {
       localStorage.setItem(scheduleOpenKey, String(!wasOpen));

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -27,6 +27,7 @@ const Profile = ({ profile, myProf }: Props) => {
   const viewerIsPolice = useAuthGroups(AuthGroup.Police);
   const [canReadStudentSchedules, setCanReadStudentSchedules] = useState<boolean>();
   const profileIsStudent = profile.PersonType?.includes('stu');
+  const profileIsStaff = profile.Type == 'Staff';
 
   const createSnackbar = useCallback((message: string, severity: AlertColor) => {
     setSnackbar({ message, severity, open: true });

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -27,7 +27,7 @@ const Profile = ({ profile, myProf }: Props) => {
   const viewerIsPolice = useAuthGroups(AuthGroup.Police);
   const [canReadStudentSchedules, setCanReadStudentSchedules] = useState<boolean>();
   const profileIsStudent = profile.PersonType?.includes('stu');
-  const profileIsStaff = profile.Type == 'Staff';
+  const profileIsStaff = profile.Type == 'Staff'; // should we create an dict enum of the possible values?
 
   const createSnackbar = useCallback((message: string, severity: AlertColor) => {
     setSnackbar({ message, severity, open: true });
@@ -69,7 +69,7 @@ const Profile = ({ profile, myProf }: Props) => {
         </Grid>
       )}
 
-      {(myProf || !profileIsStudent || canReadStudentSchedules) && (
+      {(myProf || (!profileIsStudent && !profileIsStaff) || canReadStudentSchedules) && ( // is it only faculty that have schedule? could we say if faculty instead here?
         <Grid item xs={12} lg={10}>
           <SchedulePanel profile={profile} myProf={myProf} />
         </Grid>


### PR DESCRIPTION
Fix: #2656 

The implemented fix in this pull request is to check whether the person is a staff member (not faculty) as a condition to building the schedule section. 
I also added a catch for the initial network error that was causing the constant spinning. The server sends a 401 authorization error if the profile being viewed isn't faculty or student. The catch will set the loading to false.