### PR TITLE
S25 graduation flag

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -54,7 +54,7 @@ type Props = {
   myProf: boolean;
   profile: profileType;
   isOnline: boolean;
-  createSnackbar: (message: string, severity: AlertColor) => void;
+  createSnackbar: (message: string, severity: AlertColor, link?: string) => void;
 };
 
 const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) => {
@@ -163,10 +163,11 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
 
       if (plannedGradDate && differenceInYears(plannedGradDate, currentDate) <= 1) {
         createSnackbar(
-          `Please submit the intent to graduate form by the year before ${
+          `Please submit the intent to graduate form 8-12 months months before ${
             profPlannedGradYear || graduationInfo.WhenGraduated
           }.`,
           'info',
+          'https://my.gordon.edu',
         );
       }
     }
@@ -718,6 +719,27 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
           </li>
           <li>
             <Typography>
+              It can take several weeks to process graduation applications. As a result, there may
+              be a delay of a few weeks between when a student submits the form and when this field
+              is updated.
+            </Typography>
+          </li>
+          <li>
+            <Typography>
+              <>Check the </>
+              <a
+                href="https://www.gordon.edu/academics/resources/registrar/undergraduate/degree
+              -checklist#:~:text=Apply%20for%20graduation%20(application%20on,available%20for%20
+              advice%20and%20consultation."
+                className={`gc360_text_link ${styles.note_link}`}
+              >
+                Undergraduate Degree Checklist
+              </a>
+              <> for more information</>
+            </Typography>
+          </li>
+          <li>
+            <Typography>
               For all other changes or to partially/fully prevent your data from displaying, please
               contact the{' '}
               <a
@@ -751,12 +773,9 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
         title="Graduation Information:"
         contentText={
           graduationInfo ? (
-            graduationInfo.GraduationFlag === 'Y' ? (
+            graduationInfo.GraduationFlag !== null ? (
               // If the intent to graduate form has been submitted
               <>
-                <Typography>
-                  <b>Planned Graduation Year:</b> {profPlannedGradYear || 'Not Set'}
-                </Typography>
                 <Typography>
                   <b>Flagged Graduation Date:</b> {graduationInfo.WhenGraduated || 'Not Set'}
                 </Typography>
@@ -765,15 +784,16 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
               // If the intent to graduate form has not been submitted
               <>
                 <Typography>
-                  <b>Planned Graduation Year:</b> {profPlannedGradYear || 'Not Set'}
-                </Typography>
-                <Typography>
+                  {console.log(graduationInfo.GraduationFlag)}
                   <b>Warning:</b>{' '}
                   {profPlannedGradYear
-                    ? `Please submit the intent to graduate form by the year before ${profPlannedGradYear}.`
+                    ? `Please submit the intent to graduate form 8-12 months months before ${profPlannedGradYear}.`
                     : graduationInfo.WhenGraduated
-                      ? `Please submit the intent to graduate form by the year before ${graduationInfo.WhenGraduated}.`
-                      : 'Please submit the intent to graduate form as soon as possible.'}
+                      ? `Please submit the intent to graduate form 8-12 months months before ${graduationInfo.WhenGraduated}.`
+                      : 'Please submit the intent to graduate form as soon as possible.  '}
+                  <a href="https://my.gordon.edu" className={`gc360_text_link ${styles.note_link}`}>
+                    <> Click here</>
+                  </a>
                 </Typography>
               </>
             )

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -164,7 +164,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
 
         if (plannedGradDate && differenceInYears(plannedGradDate, currentDate) < 1) {
           createSnackbar(
-            `Please submit the Graduation Application 8-12 months before ${
+            `Please submit the Graduation Application 8-12 months before May ${
               profPlannedGradYear || graduationInfo.WhenGraduated
             }.`,
             'info',
@@ -793,7 +793,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
                     <Typography>
                       <b>Warning:</b>{' '}
                       {profPlannedGradYear
-                        ? `Please submit the Graduation Application 8-12 months before ${profPlannedGradYear}.`
+                        ? `Please submit the Graduation Application 8-12 months before May ${profPlannedGradYear}.`
                         : graduationInfo.WhenGraduated
                           ? `Please submit the Graduation Application 8-12 months before ${graduationInfo.WhenGraduated}.`
                           : 'Please submit the Graduation Application as soon as possible.'}

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -787,20 +787,26 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
                 if (setPlannedGradDate()) {
                   return (
                     <Typography>
-                      <b>Warning:</b>{' '}
-                      {profPlannedGradYear
-                        ? `Please submit the Graduation Application 8-12 months before May ${profPlannedGradYear}.`
-                        : graduationInfo.WhenGraduated
-                          ? `Please submit the Graduation Application 8-12 months before ${graduationInfo.WhenGraduated}.`
-                          : 'Please submit the Graduation Application as soon as possible.'}
-                      <a
-                        href="https://my.gordon.edu"
-                        className={`gc360_text_link ${styles.note_link}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <> Click here</>
-                      </a>
+                      <b>Warning: </b>
+                      {myProf ? (
+                        <>
+                          {profPlannedGradYear
+                            ? `Please submit the Graduation Application 8-12 months before May ${profPlannedGradYear}.`
+                            : graduationInfo.WhenGraduated
+                              ? `Please submit the Graduation Application 8-12 months before ${graduationInfo.WhenGraduated}.`
+                              : 'Please submit the Graduation Application as soon as possible.'}
+                          <a
+                            href="https://my.gordon.edu"
+                            className={`gc360_text_link ${styles.note_link}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            <> Click here</>
+                          </a>
+                        </>
+                      ) : (
+                        'The student has not yet submitted their Graduation Application.'
+                      )}
                     </Typography>
                   );
                 } else {

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -136,7 +136,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
   // Get a student's graduation information
   useEffect(() => {
     async function loadPersonalInfo() {
-      if (isStudent && (canViewAcademicInfo || myProf)) {
+      if (isStudent && myProf) {
         userService
           .getGraduation(profile.AD_Username)
           .then(setGraduationInfo)
@@ -153,22 +153,24 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
   };
 
   useEffect(() => {
-    if (graduationInfo && graduationInfo.GraduationFlag === null) {
-      const currentDate = new Date();
-      const plannedGradDate = profPlannedGradYear
-        ? new Date(`${profPlannedGradYear}-05-01`) // Assuming graduation is in May
-        : graduationInfo.WhenGraduated
-          ? parseGraduationDate(graduationInfo.WhenGraduated)
-          : null;
+    if (isStudent && myProf) {
+      if (graduationInfo && graduationInfo.GraduationFlag === null) {
+        const currentDate = new Date();
+        const plannedGradDate = profPlannedGradYear
+          ? new Date(`${profPlannedGradYear}-05-01`) // Assuming graduation is in May
+          : graduationInfo.WhenGraduated
+            ? parseGraduationDate(graduationInfo.WhenGraduated)
+            : null;
 
-      if (plannedGradDate && differenceInYears(plannedGradDate, currentDate) < 1) {
-        createSnackbar(
-          `Please submit the Graduation Application 8-12 months before ${
-            profPlannedGradYear || graduationInfo.WhenGraduated
-          }.`,
-          'info',
-          'https://my.gordon.edu',
-        );
+        if (plannedGradDate && differenceInYears(plannedGradDate, currentDate) < 1) {
+          createSnackbar(
+            `Please submit the Graduation Application 8-12 months before ${
+              profPlannedGradYear || graduationInfo.WhenGraduated
+            }.`,
+            'info',
+            'https://my.gordon.edu',
+          );
+        }
       }
     }
   }, [graduationInfo, profPlannedGradYear, createSnackbar]);

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -163,7 +163,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
 
       if (plannedGradDate && differenceInYears(plannedGradDate, currentDate) < 1) {
         createSnackbar(
-          `Please submit the Graduation Application form 8-12 months months before ${
+          `Please submit the Graduation Application 8-12 months before ${
             profPlannedGradYear || graduationInfo.WhenGraduated
           }.`,
           'info',
@@ -791,10 +791,10 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
                     <Typography>
                       <b>Warning:</b>{' '}
                       {profPlannedGradYear
-                        ? `Please submit the Graduation Application form 8-12 months before ${profPlannedGradYear}.`
+                        ? `Please submit the Graduation Application 8-12 months before ${profPlannedGradYear}.`
                         : graduationInfo.WhenGraduated
-                          ? `Please submit the Graduation Application form 8-12 months before ${graduationInfo.WhenGraduated}.`
-                          : 'Please submit the Graduation Application form as soon as possible.'}
+                          ? `Please submit the Graduation Application 8-12 months before ${graduationInfo.WhenGraduated}.`
+                          : 'Please submit the Graduation Application as soon as possible.'}
                       <a
                         href="https://my.gordon.edu"
                         className={`gc360_text_link ${styles.note_link}`}

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -54,7 +54,7 @@ type Props = {
   myProf: boolean;
   profile: profileType;
   isOnline: boolean;
-  createSnackbar: (message: string, severity: AlertColor, link?: string) => void;
+  createSnackbar: (message: string, severity: AlertColor, link?: string, linkText?: string) => void;
 };
 
 const parseGraduationDate = (whenGraduated: string) => {
@@ -172,6 +172,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
             }.`,
             'info',
             'https://my.gordon.edu',
+            'my.gordon.edu',
           );
         }
       }
@@ -801,7 +802,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
                             target="_blank"
                             rel="noopener noreferrer"
                           >
-                            <> Click here</>
+                            <> my.gordon.edu</>
                           </a>
                         </>
                       ) : (

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -869,6 +869,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
             {majors}
             {minors}
             {plannedGraduationYear}
+            {graduationYear}
             {graduationDetails}
             {cliftonStrengths}
             {advisors}

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -728,9 +728,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
             <Typography>
               <>Check the </>
               <a
-                href="https://www.gordon.edu/academics/resources/registrar/undergraduate/degree
-              -checklist#:~:text=Apply%20for%20graduation%20(application%20on,available%20for%20
-              advice%20and%20consultation."
+                href="https://www.gordon.edu/academics/resources/registrar/undergraduate/degree-checklist#:~:text=Apply%20for%20graduation%20(application%20on,available%20for%20advice%20and%20consultation."
                 className={`gc360_text_link ${styles.note_link}`}
               >
                 Undergraduate Degree Checklist

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -810,7 +810,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
                 } else {
                   return (
                     <Typography>
-                      <b>Estimated Graduation Date:</b> {graduationInfo.WhenGraduated || 'Not Set'}
+                      <b>Expected Graduation Date:</b> {graduationInfo.WhenGraduated || 'Not Set'}
                     </Typography>
                   );
                 }

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -136,7 +136,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
   // Get a student's graduation information
   useEffect(() => {
     async function loadPersonalInfo() {
-      if (isStudent && myProf) {
+      if (isStudent && (myProf || canViewAcademicInfo)) {
         userService
           .getGraduation(profile.AD_Username)
           .then(setGraduationInfo)
@@ -768,7 +768,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
     ) : null;
 
   const graduationDetails =
-    myProf && checkIsStudent(profile) ? (
+    (myProf || canViewAcademicInfo) && checkIsStudent(profile) ? (
       <ProfileInfoListItem
         title="Graduation Information:"
         contentText={

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -153,7 +153,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
   };
 
   useEffect(() => {
-    if (graduationInfo && graduationInfo.GraduationFlag !== 'Y') {
+    if (graduationInfo && graduationInfo.GraduationFlag === null) {
       const currentDate = new Date();
       const plannedGradDate = profPlannedGradYear
         ? new Date(`${profPlannedGradYear}-05-01`) // Assuming graduation is in May
@@ -161,9 +161,9 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
           ? parseGraduationDate(graduationInfo.WhenGraduated)
           : null;
 
-      if (plannedGradDate && differenceInYears(plannedGradDate, currentDate) <= 1) {
+      if (plannedGradDate && differenceInYears(plannedGradDate, currentDate) < 1) {
         createSnackbar(
-          `Please submit the intent to graduate form 8-12 months months before ${
+          `Please submit the Graduation Application form 8-12 months months before ${
             profPlannedGradYear || graduationInfo.WhenGraduated
           }.`,
           'info',
@@ -773,27 +773,46 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
           graduationInfo ? (
             graduationInfo.GraduationFlag !== null ? (
               // If the intent to graduate form has been submitted
-              <>
-                <Typography>
-                  <b>Flagged Graduation Date:</b> {graduationInfo.WhenGraduated || 'Not Set'}
-                </Typography>
-              </>
+              <Typography>
+                <b>Flagged Graduation Date:</b> {graduationInfo.WhenGraduated || 'Not Set'}
+              </Typography>
             ) : (
               // If the intent to graduate form has not been submitted
-              <>
-                <Typography>
-                  {console.log(graduationInfo.GraduationFlag)}
-                  <b>Warning:</b>{' '}
-                  {profPlannedGradYear
-                    ? `Please submit the intent to graduate form 8-12 months months before ${profPlannedGradYear}.`
-                    : graduationInfo.WhenGraduated
-                      ? `Please submit the intent to graduate form 8-12 months months before ${graduationInfo.WhenGraduated}.`
-                      : 'Please submit the intent to graduate form as soon as possible.  '}
-                  <a href="https://my.gordon.edu" className={`gc360_text_link ${styles.note_link}`}>
-                    <> Click here</>
-                  </a>
-                </Typography>
-              </>
+              (() => {
+                const currentDate = new Date();
+                const plannedGradDate = profPlannedGradYear
+                  ? new Date(`${profPlannedGradYear}-05-01`) // Assuming graduation is in May
+                  : graduationInfo.WhenGraduated
+                    ? parseGraduationDate(graduationInfo.WhenGraduated)
+                    : null;
+
+                if (plannedGradDate && differenceInYears(plannedGradDate, currentDate) < 1) {
+                  return (
+                    <Typography>
+                      <b>Warning:</b>{' '}
+                      {profPlannedGradYear
+                        ? `Please submit the Graduation Application form 8-12 months before ${profPlannedGradYear}.`
+                        : graduationInfo.WhenGraduated
+                          ? `Please submit the Graduation Application form 8-12 months before ${graduationInfo.WhenGraduated}.`
+                          : 'Please submit the Graduation Application form as soon as possible.'}
+                      <a
+                        href="https://my.gordon.edu"
+                        className={`gc360_text_link ${styles.note_link}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <> Click here</>
+                      </a>
+                    </Typography>
+                  );
+                } else {
+                  return (
+                    <Typography>
+                      <b>Estimated Graduation Date:</b> {graduationInfo.WhenGraduated || 'Not Set'}
+                    </Typography>
+                  );
+                }
+              })()
             )
           ) : (
             // If no graduation information is available

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -176,7 +176,7 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
         }
       }
     }
-  }, [graduationInfo, profPlannedGradYear, createSnackbar]);
+  }, [isStudent, myProf, graduationInfo, profPlannedGradYear, createSnackbar]);
 
   const handleChangeMobilePhonePrivacy = async () => {
     try {

--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -144,7 +144,33 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
       }
     }
     loadPersonalInfo();
-  }, [myProf, profile, createSnackbar]);
+  }, [myProf, isStudent, canViewAcademicInfo, profile.AD_Username, createSnackbar]);
+
+  const parseGraduationDate = (whenGraduated: string) => {
+    const [month, year] = whenGraduated.split(' '); // Split into "Month" and "Year"
+    const monthIndex = new Date(`${month} 1`).getMonth(); // Get the month index (0-11)
+    return new Date(Number(year), monthIndex, 1); // Create a new Date object (1st day of the month)
+  };
+
+  useEffect(() => {
+    if (graduationInfo && graduationInfo.GraduationFlag !== 'Y') {
+      const currentDate = new Date();
+      const plannedGradDate = profPlannedGradYear
+        ? new Date(`${profPlannedGradYear}-05-01`) // Assuming graduation is in May
+        : graduationInfo.WhenGraduated
+          ? parseGraduationDate(graduationInfo.WhenGraduated)
+          : null;
+
+      if (plannedGradDate && differenceInYears(plannedGradDate, currentDate) <= 1) {
+        createSnackbar(
+          `Please submit the intent to graduate form by the year before ${
+            profPlannedGradYear || graduationInfo.WhenGraduated
+          }.`,
+          'info',
+        );
+      }
+    }
+  }, [graduationInfo, profPlannedGradYear, createSnackbar]);
 
   const handleChangeMobilePhonePrivacy = async () => {
     try {

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -25,7 +25,8 @@ type SnackbarState = {
   message: string;
   severity: string;
   open: boolean;
-  link?: string; // Add the optional link property
+  link?: string;
+  linkText?: string; // Add the optional link property
 };
 
 const Profile = ({ profile, myProf }: Props) => {
@@ -40,9 +41,12 @@ const Profile = ({ profile, myProf }: Props) => {
   const [canReadStudentSchedules, setCanReadStudentSchedules] = useState<boolean>();
   const profileIsStudent = profile.PersonType?.includes('stu');
 
-  const createSnackbar = useCallback((message: string, severity: AlertColor, link?: string) => {
-    setSnackbar({ message, severity, open: true, link }); // Include the link property
-  }, []);
+  const createSnackbar = useCallback(
+    (message: string, severity: AlertColor, link?: string, linkText?: string) => {
+      setSnackbar({ message, severity, open: true, link, linkText }); // Include the link property
+    },
+    [],
+  );
 
   useEffect(() => {
     scheduleService.getCanReadStudentSchedules().then(setCanReadStudentSchedules);
@@ -112,7 +116,8 @@ const Profile = ({ profile, myProf }: Props) => {
         text={snackbar.message}
         severity={snackbar.severity as AlertColor}
         onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
-        link={snackbar.link} // Pass the link property to the snackbar
+        link={snackbar.link}
+        linkText={snackbar.linkText} // Pass the link property to the snackbar
       />
     </Grid>
   );

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -21,15 +21,27 @@ type Props = {
   myProf: boolean;
 };
 
+type SnackbarState = {
+  message: string;
+  severity: string;
+  open: boolean;
+  link?: string; // Add the optional link property
+};
+
 const Profile = ({ profile, myProf }: Props) => {
-  const [snackbar, setSnackbar] = useState({ message: '', severity: '', open: false });
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    message: '',
+    severity: '',
+    open: false,
+  });
+
   const isOnline = useNetworkStatus();
   const viewerIsPolice = useAuthGroups(AuthGroup.Police);
   const [canReadStudentSchedules, setCanReadStudentSchedules] = useState<boolean>();
   const profileIsStudent = profile.PersonType?.includes('stu');
 
-  const createSnackbar = useCallback((message: string, severity: AlertColor) => {
-    setSnackbar({ message, severity, open: true });
+  const createSnackbar = useCallback((message: string, severity: AlertColor, link?: string) => {
+    setSnackbar({ message, severity, open: true, link }); // Include the link property
   }, []);
 
   useEffect(() => {
@@ -100,6 +112,7 @@ const Profile = ({ profile, myProf }: Props) => {
         text={snackbar.message}
         severity={snackbar.severity as AlertColor}
         onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+        link={snackbar.link} // Pass the link property to the snackbar
       />
     </Grid>
   );

--- a/src/components/Snackbar/index.tsx
+++ b/src/components/Snackbar/index.tsx
@@ -14,6 +14,7 @@ type Props = SnackbarProps &
     duration?: number;
     onClose: () => void;
     link?: string; // Add a link prop
+    linkText?: string;
   };
 
 const SimpleSnackbar = ({
@@ -24,6 +25,7 @@ const SimpleSnackbar = ({
   duration = 10000,
   onClose,
   link,
+  linkText,
   ...otherProps
 }: Props) => {
   return (
@@ -45,9 +47,9 @@ const SimpleSnackbar = ({
             href={link}
             target="_blank"
             rel="noopener noreferrer"
-            style={{ color: 'white', textDecoration: 'underline' }}
+            style={{ color: 'inherit', textDecoration: 'underline' }}
           >
-            Click here
+            {linkText || 'Click here'}
           </a>
         )}
       </Alert>

--- a/src/components/Snackbar/index.tsx
+++ b/src/components/Snackbar/index.tsx
@@ -13,6 +13,7 @@ type Props = SnackbarProps &
     severity?: AlertColor;
     duration?: number;
     onClose: () => void;
+    link?: string; // Add a link prop
   };
 
 const SimpleSnackbar = ({
@@ -22,6 +23,7 @@ const SimpleSnackbar = ({
   severity,
   duration = 10000,
   onClose,
+  link,
   ...otherProps
 }: Props) => {
   return (
@@ -37,7 +39,17 @@ const SimpleSnackbar = ({
           error: <ErrorOutline />,
         }}
       >
-        {text}
+        {text}{' '}
+        {link && (
+          <a
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'white', textDecoration: 'underline' }}
+          >
+            Click here
+          </a>
+        )}
       </Alert>
     </Snackbar>
   );

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -391,8 +391,17 @@ export type MembershipHistorySession = {
   Participation: Participation;
 };
 
+export type Graduation = {
+  WhenGraduated: string;
+  HasGradated: boolean;
+  GraduationFlag: string;
+};
+
 const getMembershipHistory = (username: string): Promise<MembershipHistory[]> =>
   http.get(`profiles/${username}/memberships-history`);
+
+const getGraduation = (username: string): Promise<Graduation> =>
+  http.get(`profiles/${username}/graduation`);
 
 const userService = {
   setMobilePhonePrivacy,
@@ -410,6 +419,7 @@ const userService = {
   getAdvisors,
   getMailboxInformation,
   getMembershipHistory,
+  getGraduation,
   resetImage,
   postImage,
   postIDImage,


### PR DESCRIPTION
Fix #2107 

Shows registrar's official intent to graduate term as private information if Graduation Application is submitted, otherwise displays estimated graduation term or a warning to fill in their graduation application if it is less than a year before their planned/estimated graduation date.

Displays a snackbar warning when entering their own profile page to fill in their graduation application if it is less than a year before their planned/estimated graduation date.

Notes on the bottom of the profile page has also been updated to guide students in their graduation process.

Requires https://github.com/gordon-cs/gordon-360-api/pull/1206 to obtain graduation data from the database.