### PR TITLE
Adds an effect for hovering over the tabs in Gordon360

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -16,6 +16,24 @@
   min-width: 55px;
   max-width: 125px;
   flex-grow: 1;
+  position: relative;
+  transition:
+    transform 0.2s ease,
+    z-index 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &:hover {
+    transform: translateY(-4px);
+    z-index: 10;
+  }
+
+  :global(svg) {
+    transition: transform 0.2s ease;
+  }
+
+  &:hover :global(svg) {
+    transform: translateY(-2px);
+  }
 
   &.disabled_tab {
     color: var(--mui-palette-neutral-400);


### PR DESCRIPTION
Small change that I think adds an immersive level to Gordon360... When the cursor is hovered over the tabs on the top, the tab lifts up a little bit. In the screenshot below, the cursor is hovered over the people tab.

![Screenshot 2025-06-06 at 9 15 26 AM](https://github.com/user-attachments/assets/57a3d7ae-1568-4042-80c3-bafc5efc807a)

This makes the UI for the header a little bit more interactive and immersive, and I think it spices things up nicely. 