### PR TITLE
Build deployment artifacts with NODE_ENV=prodcuction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: npm run lint
 
       - name: Build
+        env:
+          NODE_ENV: production
         run: npm run build
 
         # Uncomment when ready to run tests

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -19,7 +19,7 @@ const Providers = ({
 }) => {
   useEffect(() => {
     // Only use analytics in production
-    if (import.meta.env.NODE_ENV === 'production') {
+    if (import.meta.env.PROD) {
       analytics.initialize();
     }
   }, []);


### PR DESCRIPTION
This is an attempt to get our Google Analytics integration working again. It seems like Google Analytics is not being initialized in production because we are not building with `NODE_ENV=production`, so the condition to initialize analytics is always false.