### PR TITLE
S25 add senior projects to about page

### DIFF
--- a/src/views/About/contributors.json
+++ b/src/views/About/contributors.json
@@ -36,13 +36,12 @@
     "body": "Ben Abbett '21, Addison Abbot '20, Nathaniel Rudenberg '20, Jessica Guan '21, and Joshua Rogers '21 (Directors: Chris Hansen, Jason Whitehouse '99, Information Systems Group)"
   },
   {
-    "title": "Senior Project: Timecard Manager",
+    "title": "Senior Project: Timecard Manager, 2019-20",
     "body": "Jacob Bradley '20, Nathaniel Rudenberg '20, and Adam Princiotta '20"
   },
   {
     "title": "Summer Practicum, 2020",
-    "body": "Ari Dospassos '21, Caleb Chang '20, Cameron Abbot '23, Gahngnin Kim '21, Jahnuel Dorelus '21, Marilyn Stoltzfus '21, Matheus Ramos '21, Nick Noormand '21, and Shouwang Zhu '21 (Directors: Jonathan Senning
-, Ph.D. '85 and Russ Tuck, Ph.D.)"
+    "body": "Ari Dospassos '21, Caleb Chang '20, Cameron Abbot '23, Gahngnin Kim '21, Jahnuel Dorelus '21, Marilyn Stoltzfus '21, Matheus Ramos '21, Nick Noormand '21, and Shouwang Zhu '21 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.)"
   },
   {
     "title": "GoCo Tech Labs, 2020-21",

--- a/src/views/About/contributors.json
+++ b/src/views/About/contributors.json
@@ -36,6 +36,10 @@
     "body": "Ben Abbett '21, Addison Abbot '20, Nathaniel Rudenberg '20, Jessica Guan '21, and Joshua Rogers '21 (Directors: Chris Hansen, Jason Whitehouse '99, Information Systems Group)"
   },
   {
+    "title": "Senior Project: Timecard Manager",
+    "body": "Jacob Bradley '20, Natou Rudenberg '20, and Adam Princiotta '20"
+  },
+  {
     "title": "Summer Practicum, 2020",
     "body": "Ari Dospassos '21, Caleb Chang '20, Cameron Abbot '23, Gahngnin Kim '21, Jahnuel Dorelus '21, Marilyn Stoltzfus '21, Matheus Ramos '21, Nick Noormand '21, and Shouwang Zhu '21 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.)"
   },
@@ -52,7 +56,7 @@
     "body": "Bethany Ruggerio '23, Cameron Abbot '23, Kaiwen Chu '23, Hyungyu Park '22, Silas White '23 (Directors: Evan Platzer '20, Bennett Forkner, Information Systems Group)"
   },
   {
-    "title": "Senior Project: Apartemnt Applications, 2021-22",
+    "title": "Senior Project: Apartment Applications, 2021-22",
     "body": "Gahngnin Kim '21, Christian Kunis '21, Nick Noormand '21, Joshua Rogers '21"
   },
   {
@@ -61,15 +65,15 @@
   },
   {
     "title": "Senior Project: Rec-IM, 2022-23",
-    "body": "Cameron Abbot '24, Amos Cha '24, Kaiwen Chu '23, Silas White '23"
+    "body": "Cameron Abbot '23, Amos Cha '23, Kaiwen Chu '23, Silas White '23"
   },
   {
     "title": "Summer Practicum, 2023",
-    "body": "Andrew Wang '24, Antônia Vontobel '25, Arabella Ji '24, Eric Mo '24, Gideon Kim '24, Jack Hammond, Jae Min Lee '24, Matt Jones '25 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20, Amos Cha '24, and Bennett Forkner)"
+    "body": "Andrew Wang '24, Antônia Vontobel '25, Arabella Ji '24, Eric Mo '24, Gideon Kim '24, Jack Hammond, Jae Min Lee '24, Matt Jones '25 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20, Amos Cha '23, and Bennett Forkner)"
   },
   {
     "title": "Summer Practicum, 2024",
-    "body": "Collin Williams '26, Danya Li '25, Hunter Simpson '26, Isaiah Diaz '26, Luke Hart '25, Tsion Tezera '26, Yushin Jo '26 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20 and Amos Cha '24)"
+    "body": "Collin Williams '26, Danya Li '25, Hunter Simpson '26, Isaiah Diaz '26, Luke Hart '25, Tsion Tezera '26, Yushin Jo '26 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20 and Amos Cha '23)"
   },
   {
     "title": "Senior Project: Campus Safety/Lost & Found, 2024-25",
@@ -77,7 +81,7 @@
   },
   {
     "title": "Senior Project: Where's My RA?, 2024-25",
-    "body": "Danya Li '25, Ross Clark '25, Jason Asonye '25, Maya Randolph '25"
+    "body": "Danya Li '25, Ross Clark '25, Jason Asonye '25, Mya Randolph '25"
   }
 
 ]

--- a/src/views/About/contributors.json
+++ b/src/views/About/contributors.json
@@ -77,7 +77,7 @@
   },
   {
     "title": "Senior Project: Where's My RA?, 2024-25",
-    "body": "Danya Li '25, Ross Clark '25, Jason Asonye '25, Maya Randolph '25"   
+    "body": "Danya Li '25, Ross Clark '25, Jason Asonye '25, Maya Randolph '25"
   }
 
 ]

--- a/src/views/About/contributors.json
+++ b/src/views/About/contributors.json
@@ -37,11 +37,12 @@
   },
   {
     "title": "Senior Project: Timecard Manager",
-    "body": "Jacob Bradley '20, Natou Rudenberg '20, and Adam Princiotta '20"
+    "body": "Jacob Bradley '20, Nathaniel Rudenberg '20, and Adam Princiotta '20"
   },
   {
     "title": "Summer Practicum, 2020",
-    "body": "Ari Dospassos '21, Caleb Chang '20, Cameron Abbot '23, Gahngnin Kim '21, Jahnuel Dorelus '21, Marilyn Stoltzfus '21, Matheus Ramos '21, Nick Noormand '21, and Shouwang Zhu '21 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.)"
+    "body": "Ari Dospassos '21, Caleb Chang '20, Cameron Abbot '23, Gahngnin Kim '21, Jahnuel Dorelus '21, Marilyn Stoltzfus '21, Matheus Ramos '21, Nick Noormand '21, and Shouwang Zhu '21 (Directors: Jonathan Senning
+, Ph.D. '85 and Russ Tuck, Ph.D.)"
   },
   {
     "title": "GoCo Tech Labs, 2020-21",

--- a/src/views/About/contributors.json
+++ b/src/views/About/contributors.json
@@ -52,15 +52,32 @@
     "body": "Bethany Ruggerio '23, Cameron Abbot '23, Kaiwen Chu '23, Hyungyu Park '22, Silas White '23 (Directors: Evan Platzer '20, Bennett Forkner, Information Systems Group)"
   },
   {
+    "title": "Senior Project: Apartemnt Applications, 2021-22",
+    "body": "Gahngnin Kim '21, Christian Kunis '21, Nick Noormand '21, Joshua Rogers '21"
+  },
+  {
     "title": "GoCo Tech Labs, 2022-23",
     "body": "Arabella Ji '24, Charlie Lee '23, Jake Colbert '23, Kaiwen Chu '23, Sharon Patta '24, Sofi Stonehouse '25 (Directors: Evan Platzer '20, Bennett Forkner, Information Systems Group)"
   },
   {
+    "title": "Senior Project: Rec-IM, 2022-23",
+    "body": "Cameron Abbot '24, Amos Cha '24, Kaiwen Chu '23, Silas White '23"
+  },
+  {
     "title": "Summer Practicum, 2023",
-    "body": "Andrew Wang '24, Antônia Vontobel '25, Arabella Ji '24, Eric Mo '24, Gideon Kim '24, Jack Hammond, Jae Min Lee '24, Matt Jones '25 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20, Amos Cha '23, and Bennett Forkner)"
+    "body": "Andrew Wang '24, Antônia Vontobel '25, Arabella Ji '24, Eric Mo '24, Gideon Kim '24, Jack Hammond, Jae Min Lee '24, Matt Jones '25 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20, Amos Cha '24, and Bennett Forkner)"
   },
   {
     "title": "Summer Practicum, 2024",
-    "body": "Collin Williams '26, Danya Li '25, Hunter Simpson '26, Isaiah Diaz '26, Luke Hart '25, Tsion Tezera '26, Yushin Jo '26 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20 and Amos Cha '23)"
+    "body": "Collin Williams '26, Danya Li '25, Hunter Simpson '26, Isaiah Diaz '26, Luke Hart '25, Tsion Tezera '26, Yushin Jo '26 (Directors: Jonathan Senning, Ph.D. '85 and Russ Tuck, Ph.D.; Additional code reviews and mentoring: Evan Platzer '20 and Amos Cha '24)"
+  },
+  {
+    "title": "Senior Project: Campus Safety/Lost & Found, 2024-25",
+    "body": "Erik Andersen '25, Luke Hart '25, Matthew Jones '25, Benjamin Myers '25, Richmond Obeng '25"
+  },
+  {
+    "title": "Senior Project: Where's My RA?, 2024-25",
+    "body": "Danya Li '25, Ross Clark '25, Jason Asonye '25, Maya Randolph '25"   
   }
+
 ]


### PR DESCRIPTION
Several recent senior projects have contributed features to 360 but these were not included in the list of contributors.  This PR adds (most of) them.