### PR TITLE
S25 show current or next term

### DIFF
--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -72,12 +72,13 @@ const Profile = ({ profile, myProf }: Props) => {
         <Grid item xs={12} lg={10}>
           <Grid container spacing={2}>
             <OfficeInfoList profile={profile} myProf={myProf} />
-            {viewerIsPolice && <EmergencyInfoList username={profile.AD_Username} />}
+            {viewerIsPolice ? <EmergencyInfoList username={profile.AD_Username} /> : null}
           </Grid>
         </Grid>
       )}
 
       <Grid item xs={12} lg={10}>
+        {/* Pass profile and myProf as before */}
         <SchedulePanel profile={profile} myProf={myProf} />
       </Grid>
 
@@ -89,7 +90,7 @@ const Profile = ({ profile, myProf }: Props) => {
             isOnline={isOnline}
             createSnackbar={createSnackbar}
           />
-          {viewerIsPolice && <EmergencyInfoList username={profile.AD_Username} />}
+          {viewerIsPolice ? <EmergencyInfoList username={profile.AD_Username} /> : null}
         </Grid>
       </Grid>
 

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -3,9 +3,8 @@ import GordonSnackbar from 'components/Snackbar';
 import { Profile as profileType, isFacStaff as checkIsFacStaff } from 'services/user';
 import { useAuthGroups } from 'hooks';
 import useNetworkStatus from 'hooks/useNetworkStatus';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { AuthGroup } from 'services/auth';
-import scheduleService from 'services/schedule';
 import {
   EmergencyInfoList,
   Identification,
@@ -26,7 +25,7 @@ type SnackbarState = {
   severity: string;
   open: boolean;
   link?: string;
-  linkText?: string; // Add the optional link property
+  linkText?: string;
 };
 
 const Profile = ({ profile, myProf }: Props) => {
@@ -42,7 +41,7 @@ const Profile = ({ profile, myProf }: Props) => {
 
   const createSnackbar = useCallback(
     (message: string, severity: AlertColor, link?: string, linkText?: string) => {
-      setSnackbar({ message, severity, open: true, link, linkText }); // Include the link property
+      setSnackbar({ message, severity, open: true, link, linkText });
     },
     [],
   );
@@ -73,8 +72,7 @@ const Profile = ({ profile, myProf }: Props) => {
         <Grid item xs={12} lg={10}>
           <Grid container spacing={2}>
             <OfficeInfoList profile={profile} myProf={myProf} />
-
-            {viewerIsPolice ? <EmergencyInfoList username={profile.AD_Username} /> : null}
+            {viewerIsPolice && <EmergencyInfoList username={profile.AD_Username} />}
           </Grid>
         </Grid>
       )}
@@ -91,7 +89,7 @@ const Profile = ({ profile, myProf }: Props) => {
             isOnline={isOnline}
             createSnackbar={createSnackbar}
           />
-          {viewerIsPolice ? <EmergencyInfoList username={profile.AD_Username} /> : null}
+          {viewerIsPolice && <EmergencyInfoList username={profile.AD_Username} />}
         </Grid>
       </Grid>
 
@@ -110,7 +108,7 @@ const Profile = ({ profile, myProf }: Props) => {
         severity={snackbar.severity as AlertColor}
         onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
         link={snackbar.link}
-        linkText={snackbar.linkText} // Pass the link property to the snackbar
+        linkText={snackbar.linkText}
       />
     </Grid>
   );


### PR DESCRIPTION
This update changes the schedule panel to show the current term’s schedule if the student is enrolled and the term is still in progress. If the student has no courses in the current term or the session end date has passed, it will instead show the next upcoming term where the student has courses.