### PR TITLE
Got rid of box shadow on the home page

### DIFF
--- a/src/views/Home/components/PosterSwiper/index.jsx
+++ b/src/views/Home/components/PosterSwiper/index.jsx
@@ -19,7 +19,7 @@ const PosterSwiper = () => {
 
   return (
     <Grid sx={{ mb: 4 }}>
-      <Card sx={{ padding: 0 }}>
+      <Card sx={{ padding: 0, boxShadow: 'none' }}>
         <CardContent sx={{ padding: 0 }} class="posterSwiperCardContent">
           <div style={{ width: '100%', overflow: 'visible' }}>
             <Swiper


### PR DESCRIPTION
![Screenshot 2025-07-08 at 10 27 28 AM](https://github.com/user-attachments/assets/30bec492-df4b-4c6e-82d9-e09d281714b1)

There is a shadow for the box that contains the posters, even though the box is designed to be invisible. I fix this with my pull request, which changes it to this:

![Screenshot 2025-07-08 at 10 28 17 AM](https://github.com/user-attachments/assets/6535208d-8d71-4598-83c3-d68ad965c5ff)
