### PR TITLE
Res-Life-Tabbing Works!!

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -232,6 +232,7 @@ const GordonHeader = ({ onDrawerToggle }: Props) => {
                 label="Res-Life"
                 component={NavLink}
                 to="/reslife"
+                tabIndex={0}
               />
             )}
         </Tabs>


### PR DESCRIPTION
Quick fix to #2727 that allows the Res-Life tab to be reached by cycling through tab, as shown below:


https://github.com/user-attachments/assets/198910c0-f0eb-4120-8e3a-33c3b7eb3ef3

