### PR TITLE
Full images are shown in MarketplacePopup

### DIFF
--- a/src/views/MarketPlace/components/MarketPlacePopup/index.jsx
+++ b/src/views/MarketPlace/components/MarketPlacePopup/index.jsx
@@ -314,7 +314,7 @@ Thank you
                       paddingTop: '100%',
                       position: 'relative',
                       borderRadius: 2,
-                      backgroundColor: '#000',
+                      backgroundColor: 'contrastText.main',
                     }}
                   >
                     <img
@@ -326,7 +326,7 @@ Thank you
                         left: 0,
                         width: '100%',
                         height: '100%',
-                        objectFit: 'cover',
+                        objectFit: 'contain',
                         borderRadius: 8,
                       }}
                     />


### PR DESCRIPTION
Make it so that on MarketPlacePopup, the full image is shown instead of the cropped image on the Card in Marketplace