### PR TITLE
Change GetCurrentPosters sort logic

### DIFF
--- a/src/services/poster.ts
+++ b/src/services/poster.ts
@@ -76,7 +76,8 @@ const createPoster = (newPoster: UploadPoster): Promise<CreatedPoster> =>
 
 const getPosters = (): Promise<Poster[]> => http.get(`posters/all`);
 
-const getCurrentPosters = (): Promise<Poster[]> => http.get(`posters`);
+const getCurrentPosters = (username: string): Promise<Poster[]> =>
+  http.get(`posters/current/${username}`);
 
 const getCurrentPostersByActivityCode = (activityCode: string): Promise<Poster[]> =>
   http.get(`posters/activity/${activityCode}`);

--- a/src/views/Home/components/PosterSwiper/index.jsx
+++ b/src/views/Home/components/PosterSwiper/index.jsx
@@ -9,13 +9,18 @@ import { Autoplay, Pagination, Navigation, Keyboard, EffectCoverflow } from 'swi
 import './PosterSwiper.scss';
 import { Link } from 'react-router-dom';
 import { Card, CardMedia, Grid, Typography } from '@mui/material';
+import { useMsal } from '@azure/msal-react';
 
 const PosterSwiper = () => {
+  const { accounts } = useMsal();
+  const currentUsername = accounts.length > 0 ? accounts[0].username : null;
+  const currentUsernameShort = currentUsername?.split('@')[0];
+  console.log('currentUsername: ', currentUsername);
   const [currentPosters, setCurrentPosters] = useState([]);
 
   useEffect(() => {
-    getCurrentPosters().then(setCurrentPosters);
-  }, []);
+    getCurrentPosters(currentUsernameShort).then(setCurrentPosters);
+  }, [currentUsernameShort]);
 
   return (
     <Grid sx={{ mb: 4 }}>

--- a/src/views/Posters/index.jsx
+++ b/src/views/Posters/index.jsx
@@ -25,6 +25,7 @@ import { AuthGroup } from 'services/auth';
 import { useAuthGroups, useNetworkStatus, useUser } from 'hooks';
 import FileUploadedRoundIcon from '@mui/icons-material/FileUploadRounded';
 import GordonLoader from 'components/Loader';
+import { useMsal } from '@azure/msal-react';
 const LOADER_SIZE = 50;
 
 const Posters = () => {
@@ -44,6 +45,9 @@ const Posters = () => {
   const isSiteAdmin = useAuthGroups(AuthGroup.SiteAdmin);
   const [openEditDialog, setOpenEditDialog] = useState(false);
   const [posterToEdit, setPosterToEdit] = useState(null);
+  const { accounts } = useMsal();
+  const currentUsername = accounts.length > 0 ? accounts[0].username : null;
+  const currentUsernameShort = currentUsername?.split('@')[0];
 
   const [snackbar, setSnackbar] = useState({
     message: '',
@@ -80,11 +84,11 @@ const Posters = () => {
 
   useEffect(() => {
     const loadPosters = async () => {
-      const posters = await getCurrentPosters();
+      const posters = await getCurrentPosters(currentUsernameShort);
       setAllPosters(posters);
     };
     loadPosters();
-  }, []);
+  }, [currentUsernameShort]);
 
   useEffect(() => {
     const loadButton = async () => {


### PR DESCRIPTION
Backend here: https://github.com/gordon-cs/gordon-360-api/pull/1252

Changed frontend to fit for Backend changes for getCurrentPoster. Now PosterSwiper sorts by Priority first (CEC), then all the clubs the user is involved in, and finally all the other clubs, not just by expiration date.

WARNING! DO NOT MERGE ONE AT A TIME!! This is based upon a change from the backend, and merging one without the other will break the system!!!