### PR TITLE
Tab Spacing Fixed!!

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -48,7 +48,7 @@
   display: none;
 }
 
-@media (min-width: $break-md) {
+@media (min-width: $break-lg) {
   .center_container {
     display: initial;
     flex-grow: 1;


### PR DESCRIPTION
This is the smallest window it could be before the tabs up top disappeared before and after...


Before:
<img width="894" height="846" alt="Screenshot 2025-07-18 at 2 36 01 PM" src="https://github.com/user-attachments/assets/7ee72fd7-caf4-4420-a90c-3e89f4fcd277" />


After:

<img width="1080" height="829" alt="Screenshot 2025-07-18 at 2 36 41 PM" src="https://github.com/user-attachments/assets/101663f8-0c49-419f-a5e8-f4a7da9f5fb3" />


Now the spacing is better so that we can read all the tabs right before they would disappear