### PR TITLE
Hotfix: Fix erroneous privacy "enforcement"

### DIFF
--- a/src/components/Profile/components/PersonalInfoList/index.tsx
+++ b/src/components/Profile/components/PersonalInfoList/index.tsx
@@ -252,43 +252,42 @@ const PersonalInfoList = ({ myProf, profile, isOnline, createSnackbar }: Props) 
     setMobilePhoneNumber(profile.MobilePhone);
   }, [profile.MobilePhone]);
 
-  const mobilePhoneListItem =
-    (myProf || !isMobilePhonePrivate) && mobilePhone ? (
-      <ProfileInfoListItem
-        title="Mobile Phone:"
-        contentText={
-          <>
-            {myProf || !isMobilePhonePrivate ? formatPhone(mobilePhone) : 'Private'}
-            {myProf && (
-              <UpdatePhone
-                currentPhone={mobilePhone}
-                onUpdateSuccess={(newPhone) => {
-                  setMobilePhoneNumber(newPhone);
-                }}
-              />
-            )}
-          </>
-        }
-        ContentIcon={
-          myProf && (
-            <FormControlLabel
-              control={
-                <Switch
-                  onChange={handleChangeMobilePhonePrivacy}
-                  color="secondary"
-                  checked={!isMobilePhonePrivate}
-                />
-              }
-              label={isMobilePhonePrivate ? 'Private' : 'Public'}
-              labelPlacement="bottom"
-              disabled={!isOnline}
+  const mobilePhoneListItem = mobilePhone ? (
+    <ProfileInfoListItem
+      title="Mobile Phone:"
+      contentText={
+        <>
+          {mobilePhone === PRIVATE_INFO ? mobilePhone : formatPhone(mobilePhone)}
+          {myProf && (
+            <UpdatePhone
+              currentPhone={mobilePhone}
+              onUpdateSuccess={(newPhone) => {
+                setMobilePhoneNumber(newPhone);
+              }}
             />
-          )
-        }
-        privateInfo={isMobilePhonePrivate}
-        myProf={myProf}
-      />
-    ) : null;
+          )}
+        </>
+      }
+      ContentIcon={
+        myProf && (
+          <FormControlLabel
+            control={
+              <Switch
+                onChange={handleChangeMobilePhonePrivacy}
+                color="secondary"
+                checked={!isMobilePhonePrivate}
+              />
+            }
+            label={isMobilePhonePrivate ? 'Private' : 'Public'}
+            labelPlacement="bottom"
+            disabled={!isOnline}
+          />
+        )
+      }
+      privateInfo={isMobilePhonePrivate}
+      myProf={myProf}
+    />
+  ) : null;
 
   let streetAddr = profile.HomeStreet2 ? <span>{profile.HomeStreet2},&nbsp;</span> : null;
 


### PR DESCRIPTION
A summer practicum student tried to enforce privacy for mobile phones in an unrelated PR this summer. Firstly, the front end can never enforce privacy because the data has already been delivered to the user by that point. Secondly, the backend was already enforcing privacy for mobile phones as designed, but the student broke that and hid the mobile phone from staff members (e.g. RDs) who need access to it to perform their jobs.

This fixes CTS Case #00079425.