### PR TITLE
fix profile reload issue

### DIFF
--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -51,7 +51,8 @@ const Profile = ({ profile: propsProfile, myProf }: Props) => {
   );
 
   const fetchProfile = async () => {
-    const updatedProfile = await user.getProfileInfo(profile.AD_Username);
+    let username = myProf ? '' : propsProfile.AD_Username;
+    const updatedProfile = await user.getProfileInfo(username);
     if (updatedProfile) setProfile(updatedProfile);
   };
 


### PR DESCRIPTION
The myprofile page was using the public profile endpoint to populate itself. This caused some private information to be missing, e.g., Gordon ID. 