### PR TITLE
Fix http service type error

### DIFF
--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -2,15 +2,6 @@ import { getToken, isAuthenticated } from './auth';
 import { createError } from './error';
 import { getEnvVar } from 'envVar';
 
-type HttpRequestBody =
-  | string
-  | FormData
-  | URLSearchParams
-  | Blob
-  | File
-  | ArrayBuffer
-  | ArrayBufferView;
-
 const get = <TResponse>(endpoint: string): Promise<TResponse> => makeRequest(endpoint, 'get');
 
 const put = <TResponse>(
@@ -74,7 +65,7 @@ const apiBaseURL = getEnvVar('PROD') === 'development' ? '/' : getEnvVar('VITE_A
 const makeRequest = async <TResponse>(
   endpoint: string,
   method: string,
-  body?: HttpRequestBody,
+  body?: BodyInit,
   headers?: Headers,
 ): Promise<TResponse> => {
   console.log(`${method} request to endpoint ${endpoint}`);


### PR DESCRIPTION
Right now we define body as `body?: HttpRequestBody`, a type defined at the top of the file and used only here.
It looks like the builtin type `BodyInit` is meant to do the exact same thing as `HttpRequestBody`. 

This PR replaces `HttpRequestBody` with `BodyInit`.