### PR TITLE
Fix reslife halls list

### DIFF
--- a/src/services/residentLife/RA_Checkin.ts
+++ b/src/services/residentLife/RA_Checkin.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from 'services/error';
 import http from '../http';
 
 const checkIfCheckedIn = async (RA_ID: string): Promise<boolean> => {
@@ -9,7 +10,17 @@ const submitCheckIn = async (RA_ID: string, Hall_IDs: string[]): Promise<void> =
   await http.post(`Housing/ras/${RA_ID}/checkin`, Hall_IDs);
 };
 
-const getRACurrentHalls = (User_Name: string): Promise<String[]> =>
-  http.get(`Housing/halls/on-calls/${User_Name}/locations`);
+const getRACurrentHalls = async (User_Name: string): Promise<String[]> => {
+  try {
+    return await http.get(`Housing/halls/on-calls/${User_Name}/locations`);
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return [];
+    } else {
+      console.error(error);
+      throw error;
+    }
+  }
+};
 
 export { checkIfCheckedIn, submitCheckIn, getRACurrentHalls };

--- a/src/services/residentLife/RA_OnCall.ts
+++ b/src/services/residentLife/RA_OnCall.ts
@@ -1,6 +1,7 @@
+import { NotFoundError } from 'services/error';
 import http from 'services/http';
 
-type RA = {
+type RAOnCall = {
   Hall_ID: string;
   Hall_Name: string;
   Room_Number: string;
@@ -14,17 +15,21 @@ type RA = {
   RA_Photo: string;
 };
 
-const fetchOnDutyData = async () => {
+const fetchOnDutyData = async (): Promise<RAOnCall[]> => {
   try {
     return await http.get('Housing/halls/on-calls');
   } catch (error) {
-    console.error('Error fetching on-duty data:', error);
-    throw error;
+    if (error instanceof NotFoundError) {
+      return [];
+    } else {
+      console.error('Error fetching on-duty data:', error);
+      throw error;
+    }
   }
 };
 
 // Fetches the information of an On Call RA from the API endpoint "Housing/ra/on-call/{hallId}"
-const fetchOnDutyRA = (hallId: string): Promise<RA[]> =>
+const fetchOnDutyRA = (hallId: string): Promise<RAOnCall[]> =>
   http.get(`Housing/halls/${hallId}/on-call`);
 
 export { fetchOnDutyData, fetchOnDutyRA };

--- a/src/services/residentLife/halls.ts
+++ b/src/services/residentLife/halls.ts
@@ -1,0 +1,10 @@
+import http from 'services/http';
+
+export type Hall = {
+  Name: string;
+  BuildingCode: string;
+};
+
+const getAllHalls = (): Promise<Hall[]> => http.get('Housing/halls');
+
+export { getAllHalls };

--- a/src/views/ResLife/components/RAView/components/CheckIn/index.jsx
+++ b/src/views/ResLife/components/RAView/components/CheckIn/index.jsx
@@ -8,7 +8,7 @@ import {
   Grid,
   Typography,
 } from '@mui/material';
-import { React, useCallback, useEffect, useState } from 'react';
+import { React, useCallback, useEffect, useMemo, useState } from 'react';
 import SimpleSnackbar from 'components/Snackbar';
 import GordonDialogBox from 'components/GordonDialogBox';
 import {
@@ -17,16 +17,32 @@ import {
   getRACurrentHalls,
 } from 'services/residentLife/RA_Checkin';
 import { useUser } from 'hooks';
+import { getAllHalls } from 'services/residentLife/halls';
+
+// TODO: Define the village buildings in the database and use that definition
+const VillageBuildingCodes = Object.freeze(['CON', 'GRA', 'RID', 'MCI', 'HIL']);
 
 const CheckIn = () => {
   const [isCheckedIn, setCheckedIn] = useState(false);
   const [open, setOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [isChecked, setIsChecked] = useState(false);
   const { profile } = useUser();
-  const [hallName, setHallName] = useState('');
   const [snackbar, setSnackbar] = useState({ message: '', severity: null, open: false });
+
   const [checkedInHalls, setCheckedInHalls] = useState([]);
+
+  const [hallState, setHallState] = useState({});
+
+  const selectedHalls = useMemo(
+    () =>
+      Object.values(hallState).filter(
+        (hall) =>
+          hall.isChecked &&
+          hall.BuildingCode !== 'village' &&
+          !checkedInHalls.includes(hall.BuildingCode),
+      ),
+    [hallState, checkedInHalls],
+  );
 
   const createSnackbar = useCallback((message, severity) => {
     setSnackbar({ message, severity, open: true });
@@ -35,88 +51,55 @@ const CheckIn = () => {
   // Fetch check-in status and initialize hall data
   useEffect(() => {
     const fetchData = async () => {
-      if (profile?.ID) {
-        try {
-          const isChecked = await checkIfCheckedIn(profile.ID);
-          setCheckedIn(isChecked);
+      try {
+        const halls = await getAllHalls();
+        halls.forEach((hall) => (hall.isChecked = false));
+        const hallState = Object.fromEntries(halls.map((hall) => [hall.BuildingCode, hall]));
+        // Append The Village to halls
+        hallState.village = { Name: 'The Village', BuildingCode: 'village', isChecked: false };
 
-          // if RA is checked in
-          if (isChecked) {
-            const currentHalls = await getRACurrentHalls(profile.AD_Username);
-            setHallState((prevState) => {
-              const updatedState = { ...prevState };
-              currentHalls.forEach((hall) => {
-                updatedState[hall] = true;
-              });
-              return updatedState;
+        const isChecked = await checkIfCheckedIn(profile.ID);
+        setCheckedIn(isChecked);
+
+        const currentHalls = await getRACurrentHalls(profile.AD_Username);
+        setCheckedInHalls(currentHalls);
+
+        // if RA is checked in
+        if (isChecked) {
+          currentHalls.forEach((currentlyCheckedHallCode) => {
+            halls[currentlyCheckedHallCode].isChecked = true;
+          });
+          setHallState((prevState) => {
+            const updatedState = { ...prevState };
+            currentHalls.forEach((currentlyCheckedHallCode) => {
+              updatedState[currentlyCheckedHallCode] = true;
             });
-          } else if (profile.hall) {
-            setHallState((prevState) => ({
-              ...prevState,
-              [profile.hall]: true,
-              village: ['CON', 'GRA', 'RID', 'MCI'].includes(profile.hall),
-            }));
+            return updatedState;
+          });
+        } else if (profile.hall) {
+          halls[profile.hall].isChecked = true;
+          if (VillageBuildingCodes.includes(profile.hall)) {
+            halls.village.isChecked = true;
           }
-        } catch (error) {
-          console.error('Error fetching data:', error);
+
+          setHallState((prevState) => ({
+            ...prevState,
+            [profile.hall]: true,
+            village: VillageBuildingCodes.includes(profile.hall),
+          }));
         }
+
+        setHallState(hallState);
+      } catch (error) {
+        console.error('Error fetching data:', error);
       }
     };
+
     fetchData();
-  }, [profile?.ID]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      if (profile?.ID) {
-        try {
-          const halls = await getRACurrentHalls(profile.AD_Username);
-          setCheckedInHalls(halls);
-        } catch (error) {
-          console.error('Error fetching checked-in halls:', error);
-        }
-      }
-    };
-    fetchData();
-  }, [profile?.ID]);
-
-  const hallCodeToNameMap = {
-    BRO: 'Bromley',
-    CHA: 'Chase',
-    EVN: 'Evans',
-    FER: 'Ferrin',
-    FUL: 'Fulton',
-    NYL: 'Nyland',
-    TAV: 'Tavilla',
-    WIL: 'Wilson',
-    CON: 'Conrad',
-    GRA: 'Grace',
-    RID: 'Rider',
-    MCI: 'MacInnis',
-    village: 'The Village',
-  };
-
-  const handleConfirm = () => {
-    setConfirmOpen(true);
-
-    let tempName = '';
-
-    for (let hall in hallState) {
-      if (hallState[hall] && hall !== 'village' && !checkedInHalls.includes(hall)) {
-        // Map hall codes to names using the mapping object
-        const hallName = hallCodeToNameMap[hall];
-        tempName = tempName ? `${tempName}, ${hallName}` : hallName;
-      }
-    }
-
-    setHallName(tempName);
-  };
+  }, [profile]);
 
   const handleSubmit = async () => {
-    const selectedHallCodes = Object.keys(hallState).filter(
-      (hall) => hallState[hall] && hall !== 'village' && !checkedInHalls.includes(hall),
-    ); //exclude village for checkin
-
-    if (!profile?.ID || selectedHallCodes.length === 0) {
+    if (!profile?.ID || selectedHalls.length === 0) {
       createSnackbar(
         'Please select a hall and ensure profile information is loaded before checking in.',
         'warning',
@@ -125,62 +108,33 @@ const CheckIn = () => {
     }
 
     try {
-      await submitCheckIn(profile.ID, selectedHallCodes);
+      await submitCheckIn(
+        profile.ID,
+        selectedHalls.map((hall) => hall.BuildingCode),
+      );
       setCheckedIn(true);
       setConfirmOpen(false);
       setOpen(false);
-      createSnackbar(`Successfully checked into ${hallName}`, 'success');
+      createSnackbar(
+        `Successfully checked into ${selectedHalls.map((hall) => hall.Name).join(', ')}`,
+        'success',
+      );
     } catch (error) {
       console.error('Error checking in:', error);
       createSnackbar('Failed to check in. Please try again.', 'error');
     }
   };
 
-  const [hallState, setHallState] = useState({
-    BRO: false,
-    CHA: false,
-    EVN: false,
-    FER: false,
-    FUL: false,
-    NYL: false,
-    TAV: false,
-    WIL: false,
-    village: false,
-  });
-
-  // set halls that are checked in to be checked off
-  useEffect(() => {
-    var check = false;
-    for (let hall in hallState) {
-      if (hallState[hall]) {
-        check = true;
-        break;
-      }
-    }
-    setIsChecked(check);
-  }, [hallState]);
-
-  const { BRO, CHA, EVN, FER, FUL, NYL, TAV, WIL, village } = hallState;
-
   const handleHallChecked = (event) => {
     const { name, checked } = event.target;
 
     setHallState((prevState) => {
-      const updatedState = { ...prevState, [name]: checked };
+      const updatedState = { ...prevState, [name]: { ...prevState[name], isChecked: checked } };
 
-      //when village checked mark needed halls
-      if (name === 'village' && checked) {
-        updatedState.CON = true;
-        updatedState.GRA = true;
-        updatedState.RID = true;
-        updatedState.MCI = true;
-      }
-
-      if (name === 'village' && !checked) {
-        updatedState.CON = false;
-        updatedState.GRA = false;
-        updatedState.RID = false;
-        updatedState.MCI = false;
+      if (name === 'village') {
+        VillageBuildingCodes.forEach((villageBuildingCode) => {
+          updatedState[villageBuildingCode].isChecked = checked;
+        });
       }
 
       return updatedState;
@@ -199,7 +153,7 @@ const CheckIn = () => {
             onClose={() => setOpen(false)}
             title={'Choose Which Hall to Check Into'}
             buttonName="Check In"
-            buttonClicked={handleConfirm}
+            buttonClicked={() => setConfirmOpen(true)}
             cancelButtonName="CANCEL"
             cancelButtonClicked={() => setOpen(false)}
           >
@@ -207,87 +161,20 @@ const CheckIn = () => {
               <FormControl required={true}>
                 <FormLabel error>Select a Hall</FormLabel>
                 <FormGroup>
-                  <FormControlLabel
-                    key="BRO"
-                    checked={BRO}
-                    disabled={checkedInHalls?.includes('BRO')}
-                    control={<Checkbox />}
-                    onChange={handleHallChecked}
-                    label="Bromley"
-                    name="BRO"
-                  />
-                  <FormControlLabel
-                    key="CHA"
-                    checked={CHA}
-                    disabled={checkedInHalls?.includes('CHA')}
-                    control={<Checkbox />}
-                    onChange={handleHallChecked}
-                    label="Chase"
-                    name="CHA"
-                  />
-                  <FormControlLabel
-                    key="EVN"
-                    checked={EVN}
-                    disabled={checkedInHalls?.includes('EVN')}
-                    control={<Checkbox />}
-                    onChange={handleHallChecked}
-                    label="Evans"
-                    name="EVN"
-                  />
-                  <FormControlLabel
-                    key="FER"
-                    checked={FER}
-                    disabled={checkedInHalls?.includes('FER')}
-                    control={<Checkbox />}
-                    onChange={handleHallChecked}
-                    label="Ferrin"
-                    name="FER"
-                  />
-                  <FormControlLabel
-                    key="FUL"
-                    checked={FUL}
-                    disabled={checkedInHalls?.includes('FUL')}
-                    control={<Checkbox />}
-                    onChange={handleHallChecked}
-                    label="Fulton"
-                    name="FUL"
-                  />
-                  <FormControlLabel
-                    key="NYL"
-                    checked={NYL}
-                    disabled={checkedInHalls?.includes('NYL')}
-                    control={<Checkbox />}
-                    onChange={handleHallChecked}
-                    label="Nyland"
-                    name="NYL"
-                  />
-                  <FormControlLabel
-                    key="TAV"
-                    checked={TAV}
-                    disabled={checkedInHalls?.includes('TAV')}
-                    control={<Checkbox />}
-                    onChange={handleHallChecked}
-                    label="Tavilla"
-                    name="TAV"
-                  />
-                  <FormControlLabel
-                    key="WIL"
-                    checked={WIL}
-                    disabled={checkedInHalls?.includes('WIL')}
-                    control={<Checkbox />}
-                    onChange={handleHallChecked}
-                    label="Wilson"
-                    name="WIL"
-                  />
-                  <FormControlLabel
-                    key="village"
-                    checked={village}
-                    disabled={checkedInHalls?.includes('village')}
-                    control={<Checkbox />}
-                    onChange={handleHallChecked}
-                    label="The Village"
-                    name="village"
-                  />
+                  {Object.values(hallState)
+                    //Exclude village buildings, since village RAs check in for the whole village at once
+                    .filter((hall) => !VillageBuildingCodes.includes(hall.BuildingCode))
+                    .map((hall) => (
+                      <FormControlLabel
+                        key={hall.BuildingCode}
+                        checked={hall.isChecked}
+                        disabled={checkedInHalls?.includes(hall.BuildingCode)}
+                        control={<Checkbox />}
+                        onChange={handleHallChecked}
+                        label={hall.Name}
+                        name={hall.BuildingCode}
+                      />
+                    ))}
                 </FormGroup>
               </FormControl>
             </Grid>
@@ -305,8 +192,9 @@ const CheckIn = () => {
           >
             <Grid item>
               <Typography>
-                NOTE: You are checking into {hallName || 'Unknown Hall'} to be on duty. Is this what
-                you meant to do?
+                NOTE: You are checking into{' '}
+                {selectedHalls.map((hall) => hall.Name).join(', ') || 'Unknown Hall'} to be on duty.
+                Is this what you meant to do?
               </Typography>
             </Grid>
           </GordonDialogBox>

--- a/src/views/ResLife/components/RAView/components/TaskList/index.jsx
+++ b/src/views/ResLife/components/RAView/components/TaskList/index.jsx
@@ -62,13 +62,12 @@ const TaskList = () => {
       try {
         const halls = await getRACurrentHalls(profile.AD_Username);
         setHallList(halls);
-        console.log(halls);
       } catch (error) {
         console.log('Error fetching halls', error);
       }
     };
     fetchCheckedInHalls();
-  }, []);
+  }, [profile.AD_Username]);
 
   useEffect(() => {
     const fetchTaskList = async () => {

--- a/src/views/ResLife/components/RDView/components/OnDutyMobileView/index.jsx
+++ b/src/views/ResLife/components/RDView/components/OnDutyMobileView/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   FormControl,
   InputLabel,
@@ -12,19 +12,7 @@ import {
 import { styled } from '@mui/material/styles';
 import { fetchOnDutyData } from 'services/residentLife/RA_OnCall';
 import ScottieMascot from 'views/ResLife/ScottieMascot.png';
-
-// Hardcoded list of all halls
-const ALL_HALLS = [
-  { name: 'Bromley', id: 'BRO' },
-  { name: 'Chase', id: 'CHA' },
-  { name: 'Evans', id: 'EVN' },
-  { name: 'Ferrin', id: 'FER' },
-  { name: 'Fulton', id: 'FUL' },
-  { name: 'Nyland', id: 'NYL' },
-  { name: 'Tavilla', id: 'TAV' },
-  { name: 'Wilson', id: 'WIL' },
-  { name: 'The Village', id: 'village' },
-];
+import { getAllHalls } from 'services/residentLife/halls';
 
 // building codes associated with the village
 const VILLAGE_IDS = ['GRA', 'RID', 'MCI', 'CON'];
@@ -47,56 +35,53 @@ const formatPhoneNumber = (phoneNumber) => {
 };
 
 const OnDutyMobile = () => {
-  const [value, setValue] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [hallDetails, setHallDetails] = useState(null);
-  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [allHalls, setAllHalls] = useState([]);
+  const [selectedHall, setSelectedHall] = useState('');
+  const [allHallDuty, setAllHallDuty] = useState([]);
+  const selectedHallDuty = useMemo(
+    () => allHallDuty?.find((hall) => hall.Hall_ID === selectedHall) || null,
+    [selectedHall, allHallDuty],
+  );
 
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        const data = await fetchOnDutyData();
+      const [halls, onDutyAllHalls] = await Promise.all([getAllHalls(), fetchOnDutyData()]);
 
-        // take any on call data from api response that has a village dorm and consolidate
-        const villageData = data.filter((hall) => VILLAGE_IDS.includes(hall.Hall_ID));
-        const otherHalls = data.filter((hall) => !VILLAGE_IDS.includes(hall.Hall_ID));
-        // village ra will be the same for all entries take data from first
-        if (villageData.length > 0) {
-          const consolidatedVillage = {
-            Hall_ID: 'village',
-            Hall_Name: 'The Village',
-            RA_Photo: villageData[0].RA_Photo,
-            RA_Name: villageData[0].RA_Name,
-            RA_UserName: villageData[0].RA_UserName,
-            Preferred_Contact: villageData[0].Preferred_Contact,
-            Check_In_Time: villageData[0].Check_In_Time,
-            RD_Name: villageData[0].RD_Name,
-            RD_UserName: villageData[0].RD_UserName,
-          };
-          setRows([...otherHalls, consolidatedVillage]); // pull info from village and remaining halls
-        } else {
-          setRows(data);
-        }
-      } catch {
-        setRows([]);
+      setAllHalls(
+        halls
+          .filter((hall) => !VILLAGE_IDS.includes(hall.BuildingCode))
+          .concat({ Name: 'The Village', BuildingCode: 'village' }),
+      );
+
+      const villageOnDuty = onDutyAllHalls.find((hall) => VILLAGE_IDS.includes(hall.Hall_ID));
+
+      if (villageOnDuty) {
+        const consolidatedVillage = {
+          Hall_ID: 'village',
+          Hall_Name: 'The Village',
+          RA_Photo: villageOnDuty.RA_Photo,
+          RA_Name: villageOnDuty.RA_Name,
+          RA_UserName: villageOnDuty.RA_UserName,
+          Preferred_Contact: villageOnDuty.Preferred_Contact,
+          Check_In_Time: villageOnDuty.Check_In_Time,
+          RD_Name: villageOnDuty.RD_Name,
+          RD_UserName: villageOnDuty.RD_UserName,
+        };
+
+        const notVillageOnDuty = onDutyAllHalls.filter(
+          (hall) => !VILLAGE_IDS.includes(hall.Hall_ID),
+        );
+
+        setAllHallDuty([...notVillageOnDuty, consolidatedVillage]); // pull info from village and remaining halls
+      } else {
+        setAllHallDuty(onDutyAllHalls);
       }
+      setLoading(false);
     };
 
     fetchData();
   }, []);
-
-  // Update hall details when a hall is selected
-  useEffect(() => {
-    if (!value) return;
-    setLoading(true);
-    const selectedHall = rows.find((hall) => hall.Hall_ID === value) || null;
-    setHallDetails(selectedHall);
-    setLoading(false);
-  }, [value, rows]);
-
-  const handleChange = (event) => {
-    setValue(event.target.value);
-  };
 
   return (
     <FormControl fullWidth>
@@ -104,16 +89,16 @@ const OnDutyMobile = () => {
       <Select
         labelId="select-label"
         id="select"
-        value={value}
+        value={selectedHall}
         label="Select a Hall"
-        onChange={handleChange}
+        onChange={(e) => setSelectedHall(e.target.value)}
       >
-        {ALL_HALLS.map(
+        {allHalls.map(
           (
             hall, //populate list with all halls
           ) => (
-            <MenuItem key={hall.id} value={hall.id}>
-              {hall.name}
+            <MenuItem key={hall.BuildingCode} value={hall.BuildingCode}>
+              {hall.Name}
             </MenuItem>
           ),
         )}
@@ -124,7 +109,7 @@ const OnDutyMobile = () => {
           <CircularProgress />
         </Box>
       ) : (
-        value && (
+        selectedHall && (
           <Box
             sx={{
               textAlign: 'center',
@@ -134,16 +119,16 @@ const OnDutyMobile = () => {
               borderRadius: 2,
             }}
           >
-            {hallDetails?.RA_Name ? (
+            {selectedHallDuty?.RA_Name ? (
               <>
                 <a
-                  href={DEFAULT_PROFILE_URL + hallDetails.RA_UserName || '#'}
+                  href={DEFAULT_PROFILE_URL + selectedHallDuty.RA_UserName || '#'}
                   target="_self"
                   rel=""
                 >
                   <Avatar
-                    src={hallDetails.RA_Photo || 'https://placehold.jp/150x150.png'}
-                    alt={hallDetails.RA_Name || 'No RA'}
+                    src={selectedHallDuty.RA_Photo || 'https://placehold.jp/150x150.png'}
+                    alt={selectedHallDuty.RA_Name || 'No RA'}
                     sx={{
                       width: { xs: 80, sm: 80, md: 90, lg: 90 },
                       height: { xs: 80, sm: 80, md: 90, lg: 90 },
@@ -154,7 +139,7 @@ const OnDutyMobile = () => {
                   />
                 </a>
                 <Typography variant="h6">
-                  <strong>{hallDetails.Hall_Name}</strong>
+                  <strong>{selectedHallDuty.Hall_Name}</strong>
                 </Typography>
 
                 {/* RA Name  */}
@@ -162,20 +147,20 @@ const OnDutyMobile = () => {
                   <strong>On-Duty: </strong>
 
                   <StyledLink
-                    href={DEFAULT_PROFILE_URL + hallDetails.RA_UserName || '#'}
+                    href={DEFAULT_PROFILE_URL + selectedHallDuty.RA_UserName || '#'}
                     className="gc360_text_link"
                     target="_self"
                     rel=""
                   >
-                    {hallDetails.RA_Name}{' '}
+                    {selectedHallDuty.RA_Name}{' '}
                   </StyledLink>
                 </Typography>
 
                 <Typography>
                   <strong>Contact:</strong>{' '}
-                  {hallDetails.Preferred_Contact?.includes('http') ? (
+                  {selectedHallDuty.Preferred_Contact?.includes('http') ? (
                     <StyledLink
-                      href={hallDetails.Preferred_Contact}
+                      href={selectedHallDuty.Preferred_Contact}
                       underline="hover"
                       className="gc360_text_link"
                       target="_self"
@@ -183,12 +168,12 @@ const OnDutyMobile = () => {
                     >
                       Teams
                     </StyledLink>
-                  ) : hallDetails.Preferred_Contact ? (
+                  ) : selectedHallDuty.Preferred_Contact ? (
                     <StyledLink
-                      href={`tel:${hallDetails.Preferred_Contact}`}
+                      href={`tel:${selectedHallDuty.Preferred_Contact}`}
                       className="gc360_text_link"
                     >
-                      {formatPhoneNumber(hallDetails.Preferred_Contact)}
+                      {formatPhoneNumber(selectedHallDuty.Preferred_Contact)}
                     </StyledLink>
                   ) : (
                     <StyledLink className="gc360_text_link">No Contact Info</StyledLink>
@@ -197,8 +182,8 @@ const OnDutyMobile = () => {
 
                 <Typography>
                   <strong>Check-In Time:</strong>{' '}
-                  {hallDetails.Check_In_Time
-                    ? new Date(hallDetails.Check_In_Time).toLocaleTimeString([], {
+                  {selectedHallDuty.Check_In_Time
+                    ? new Date(selectedHallDuty.Check_In_Time).toLocaleTimeString([], {
                         hour: '2-digit',
                         minute: '2-digit',
                       })
@@ -208,12 +193,12 @@ const OnDutyMobile = () => {
                 <Typography>
                   <strong>Hall RD:</strong>{' '}
                   <StyledLink
-                    href={DEFAULT_PROFILE_URL + hallDetails.RD_UserName}
+                    href={DEFAULT_PROFILE_URL + selectedHallDuty.RD_UserName}
                     className="gc360_text_link"
                     target="_self"
                     rel=""
                   >
-                    {hallDetails.RD_Name || 'No RD Info'}{' '}
+                    {selectedHallDuty.RD_Name || 'No RD Info'}{' '}
                   </StyledLink>
                 </Typography>
               </>

--- a/src/views/ResLife/components/RDView/components/RoomRanges/index.jsx
+++ b/src/views/ResLife/components/RDView/components/RoomRanges/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   List,
   ListItem,
@@ -33,20 +33,40 @@ import GordonLoader from 'components/Loader';
 const RoomRanges = () => {
   const { mode } = useColorScheme();
   const [isLoading, setIsLoading] = useState(false);
+
   const [allHalls, setAllHalls] = useState([]);
   const [selectedHall, setSelectedHall] = useState(null);
+
   const [roomStart, setRoomStart] = useState('');
   const [roomEnd, setRoomEnd] = useState('');
+
   const [allRoomRanges, setAllRoomRanges] = useState([]);
-  const [filteredRoomRanges, setFilteredRoomRanges] = useState([]);
+  const filteredRoomRanges = useMemo(
+    () => (selectedHall ? allRoomRanges.filter((range) => range.Hall_ID === selectedHall) : []),
+    [allRoomRanges, selectedHall],
+  );
   const [selectedRoomRange, setSelectedRoomRange] = useState(null);
+
   const [allRAs, setAllRAs] = useState([]);
-  const [filteredRAs, setFilteredRAs] = useState([]);
+  const filteredRAs = useMemo(
+    () => (selectedHall ? allRAs.filter((person) => person.BLDG_Code === selectedHall) : []),
+    [selectedHall, allRAs],
+  );
   const [selectedRA, setSelectedRA] = useState(null);
+
   const [assignments, setAssignments] = useState([]);
-  const [filteredAssignments, setFilteredAssignments] = useState([]);
+  const filteredAssignments = useMemo(
+    () =>
+      selectedHall ? assignments.filter((assignment) => assignment.Hall_ID === selectedHall) : [],
+    [selectedHall, assignments],
+  );
+
   const [unassignedRooms, setUnassignedRooms] = useState([]);
-  const [filteredUnassigned, setFilteredUnassigned] = useState([]);
+  const filteredUnassignedRoomRanges = useMemo(
+    () =>
+      selectedHall ? unassignedRooms.filter((room) => room.Building_Code === selectedHall) : [],
+    [selectedHall, unassignedRooms],
+  );
   const navigate = useNavigate();
 
   const [snackbar, setSnackbar] = useState({
@@ -84,79 +104,48 @@ const RoomRanges = () => {
       fetchMissingRooms()
         .then(setUnassignedRooms)
         .catch((error) => console.error('Error fetching missing rooms:', error)),
+
+      raList()
+        .then(setAllRAs)
+        .catch((error) => console.error('Error fetching RAs:', error)),
     ]).then(() => setIsLoading(false));
   }, [createSnackbar]);
-
-  // Update filtered data when building changes
-  useEffect(() => {
-    if (selectedHall) {
-      const filteredRanges = allRoomRanges.filter((range) => range.Hall_ID === selectedHall);
-      setFilteredRoomRanges(filteredRanges);
-
-      const filteredRAs = allRAs.filter((person) => person.BLDG_Code === selectedHall);
-      setFilteredRAs(filteredRAs);
-
-      const filteredUnassigendrooms = unassignedRooms.filter(
-        (room) => room.Building_Code === selectedHall,
-      );
-      setFilteredUnassigned(filteredUnassigendrooms);
-
-      const filteredAssign = assignments.filter(
-        (assignment) => assignment.Hall_ID === selectedHall,
-      );
-      setFilteredAssignments(filteredAssign);
-    } else {
-      setFilteredRoomRanges([]);
-      setFilteredRAs([]);
-      setFilteredAssignments([]);
-    }
-  }, [selectedHall, allRoomRanges, allRAs, assignments, unassignedRooms]);
 
   const clearRoomInputs = () => {
     setRoomStart('');
     setRoomEnd('');
   };
 
-  const fetchRaList = (building) => {
-    console.log('Selected Building:', building);
-    raList()
-      .then((response) => {
-        const buildingCodes = response.filter((code) => code.BLDG_Code === building);
-        setAllRAs(response ? buildingCodes : []);
-        console.log('RA List:', response);
-      })
-      .catch((error) => console.error('Error fetching RAs:', error));
-  };
-
   const onClickAddRoomRange = () => {
     if (selectedHall && roomStart && roomEnd) {
       const body = { Hall_ID: selectedHall, Room_Start: roomStart, Room_End: roomEnd };
       addRoomRange(body)
-        .then(() => {
-          clearRoomInputs();
-          fetchRoomRanges()
-            .then((response) => setAllRoomRanges(response))
-            .catch((error) => console.error('Error fetching room ranges:', error));
-        })
+        .then(fetchRoomRanges)
+        .then(setAllRoomRanges)
+        .then(fetchMissingRooms)
+        .then(setUnassignedRooms)
+        .then(clearRoomInputs)
         .catch((error) => {
           console.error('Error adding room range:', error);
           createSnackbar('Error adding room range: ' + error, 'error');
         });
-    }
+    } else
+      createSnackbar(
+        'Select a building and room range start and end to add a room range',
+        'warning',
+      );
   };
 
   const onClickRemoveRoomRange = (rangeId) => {
     removeRoomRange(rangeId)
-      .then(() => {
-        fetchRoomRanges()
-          .then((response) => setAllRoomRanges(response))
-          .catch((error) => console.error('Error fetching room ranges:', error));
-        // Reload assignment list
-        fetchAssignmentList() //reload assignemnt list as a assignment could be removed as well by this action
-          .then((response) => setAssignments(response))
-          .catch((error) => console.error('Error fetching assignments:', error));
-        setSelectedRoomRange(null);
-      })
+      .then(fetchRoomRanges)
+      .then(setAllRoomRanges)
+      .then(fetchMissingRooms)
+      .then(setUnassignedRooms)
+      // reload assignment list as an assignment could be removed as well by this action
+      .then(fetchAssignmentList)
+      .then(setAssignments)
+      .then(() => setSelectedRoomRange(null))
       .catch((error) => {
         console.error('Error removing room range:', error);
         createSnackbar('Error removing room range: ' + error, 'error');
@@ -165,18 +154,15 @@ const RoomRanges = () => {
 
   const onClickAssignPerson = () => {
     if (selectedRA && selectedRoomRange) {
-      const newRange = {
+      assignPersonToRange({
         Range_ID: selectedRoomRange,
         RA_ID: selectedRA,
-      };
-
-      assignPersonToRange(newRange)
+      })
+        .then(fetchAssignmentList)
+        .then(setAssignments)
         .then(() => {
           setSelectedRA(null);
           setSelectedRoomRange(null);
-          fetchAssignmentList()
-            .then((response) => setAssignments(response))
-            .catch((error) => console.error('Error fetching assignments:', error));
         })
         .catch((error) => {
           console.error('Error assigning person to range:', error);
@@ -187,11 +173,8 @@ const RoomRanges = () => {
 
   const onClickRemoveAssignment = (rangeId) => {
     removeAssignment(rangeId)
-      .then(() => {
-        fetchAssignmentList()
-          .then((response) => setAssignments(response))
-          .catch((error) => console.error('Error fetching assignments:', error));
-      })
+      .then(fetchAssignmentList)
+      .then(setAssignments)
       .catch((error) => {
         console.error('Error removing assignment:', error);
         createSnackbar('Error removing assignment: ' + error, 'error');
@@ -243,10 +226,7 @@ const RoomRanges = () => {
               <Select
                 label="Select building"
                 value={selectedHall ?? ''}
-                onChange={(e) => {
-                  setSelectedHall(e.target.value);
-                  fetchRaList(e.target.value);
-                }}
+                onChange={(e) => setSelectedHall(e.target.value)}
                 fullWidth
                 margin="normal"
               >
@@ -442,8 +422,8 @@ const RoomRanges = () => {
               The rooms below do not fall under any of the current room ranges.
             </Typography>
             <List>
-              {filteredUnassigned.length > 0 ? (
-                filteredUnassigned.map((room) => (
+              {filteredUnassignedRoomRanges.length > 0 ? (
+                filteredUnassignedRoomRanges.map((room) => (
                   <ListItem key={room.Room_Number}>
                     <Box>{room.Room_Name}</Box>
                   </ListItem>

--- a/src/views/ResLife/components/RDView/components/RoomRanges/index.jsx
+++ b/src/views/ResLife/components/RDView/components/RoomRanges/index.jsx
@@ -27,21 +27,24 @@ import { useColorScheme } from '@mui/material/styles';
 import SimpleSnackbar from 'components/Snackbar';
 import { useNavigate } from 'react-router';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { getAllHalls } from 'services/residentLife/halls';
+import GordonLoader from 'components/Loader';
 
 const RoomRanges = () => {
   const { mode } = useColorScheme();
-  const [building, setBuilding] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [allHalls, setAllHalls] = useState([]);
+  const [selectedHall, setSelectedHall] = useState(null);
   const [roomStart, setRoomStart] = useState('');
   const [roomEnd, setRoomEnd] = useState('');
-  const [roomRanges, setRoomRanges] = useState([]);
-  const [selectedRoomRange, setSelectedRoomRange] = useState(null);
-  const [showList, setShowList] = useState(false);
-  const [people, setPeople] = useState([]);
-  const [selectedPerson, setSelectedPerson] = useState(null);
-  const [assignments, setAssignments] = useState([]);
+  const [allRoomRanges, setAllRoomRanges] = useState([]);
   const [filteredRoomRanges, setFilteredRoomRanges] = useState([]);
+  const [selectedRoomRange, setSelectedRoomRange] = useState(null);
+  const [allRAs, setAllRAs] = useState([]);
+  const [filteredRAs, setFilteredRAs] = useState([]);
+  const [selectedRA, setSelectedRA] = useState(null);
+  const [assignments, setAssignments] = useState([]);
   const [filteredAssignments, setFilteredAssignments] = useState([]);
-  const [filteredPeople, setFilteredPeople] = useState([]);
   const [unassignedRooms, setUnassignedRooms] = useState([]);
   const [filteredUnassigned, setFilteredUnassigned] = useState([]);
   const navigate = useNavigate();
@@ -62,49 +65,52 @@ const RoomRanges = () => {
 
   // Fetch data when the page loads
   useEffect(() => {
-    setTimeout(() => setShowList(true), 1000);
+    Promise.all([
+      getAllHalls()
+        .then(setAllHalls)
+        .catch((err) => {
+          console.error(`Error fetching halls: ${err}`);
+          createSnackbar('Could not load halls.', 'error');
+        }),
 
-    fetchRoomRanges()
-      .then((response) => {
-        setRoomRanges(response);
-        console.log('Room Ranges:', response);
-      })
-      .catch((error) => console.error('Error fetching room ranges:', error));
+      fetchRoomRanges()
+        .then(setAllRoomRanges)
+        .catch((error) => console.error('Error fetching room ranges:', error)),
 
-    fetchAssignmentList()
-      .then((response) => {
-        console.log('Assignments:', response);
-        setAssignments(response);
-      })
-      .catch((error) => console.error('Error fetching assignments:', error));
+      fetchAssignmentList()
+        .then(setAssignments)
+        .catch((error) => console.error('Error fetching assignments:', error)),
 
-    fetchMissingRooms()
-      .then((response) => setUnassignedRooms(response))
-      .catch((error) => console.error('Error fetching missing rooms:', error));
-  }, []);
+      fetchMissingRooms()
+        .then(setUnassignedRooms)
+        .catch((error) => console.error('Error fetching missing rooms:', error)),
+    ]).then(() => setIsLoading(false));
+  }, [createSnackbar]);
 
   // Update filtered data when building changes
   useEffect(() => {
-    if (building) {
-      const filteredRanges = roomRanges.filter((range) => range.Hall_ID === building);
+    if (selectedHall) {
+      const filteredRanges = allRoomRanges.filter((range) => range.Hall_ID === selectedHall);
       setFilteredRoomRanges(filteredRanges);
 
-      const filteredRAs = people.filter((person) => person.BLDG_Code === building);
-      setFilteredPeople(filteredRAs);
+      const filteredRAs = allRAs.filter((person) => person.BLDG_Code === selectedHall);
+      setFilteredRAs(filteredRAs);
 
       const filteredUnassigendrooms = unassignedRooms.filter(
-        (room) => room.Building_Code === building,
+        (room) => room.Building_Code === selectedHall,
       );
       setFilteredUnassigned(filteredUnassigendrooms);
 
-      const filteredAssign = assignments.filter((assignment) => assignment.Hall_ID === building);
+      const filteredAssign = assignments.filter(
+        (assignment) => assignment.Hall_ID === selectedHall,
+      );
       setFilteredAssignments(filteredAssign);
     } else {
       setFilteredRoomRanges([]);
-      setFilteredPeople([]);
+      setFilteredRAs([]);
       setFilteredAssignments([]);
     }
-  }, [building, roomRanges, people, assignments]);
+  }, [selectedHall, allRoomRanges, allRAs, assignments, unassignedRooms]);
 
   const clearRoomInputs = () => {
     setRoomStart('');
@@ -116,20 +122,20 @@ const RoomRanges = () => {
     raList()
       .then((response) => {
         const buildingCodes = response.filter((code) => code.BLDG_Code === building);
-        setPeople(response ? buildingCodes : []);
+        setAllRAs(response ? buildingCodes : []);
         console.log('RA List:', response);
       })
       .catch((error) => console.error('Error fetching RAs:', error));
   };
 
   const onClickAddRoomRange = () => {
-    if (building && roomStart && roomEnd) {
-      const body = { Hall_ID: building, Room_Start: roomStart, Room_End: roomEnd };
+    if (selectedHall && roomStart && roomEnd) {
+      const body = { Hall_ID: selectedHall, Room_Start: roomStart, Room_End: roomEnd };
       addRoomRange(body)
         .then(() => {
           clearRoomInputs();
           fetchRoomRanges()
-            .then((response) => setRoomRanges(response))
+            .then((response) => setAllRoomRanges(response))
             .catch((error) => console.error('Error fetching room ranges:', error));
         })
         .catch((error) => {
@@ -143,7 +149,7 @@ const RoomRanges = () => {
     removeRoomRange(rangeId)
       .then(() => {
         fetchRoomRanges()
-          .then((response) => setRoomRanges(response))
+          .then((response) => setAllRoomRanges(response))
           .catch((error) => console.error('Error fetching room ranges:', error));
         // Reload assignment list
         fetchAssignmentList() //reload assignemnt list as a assignment could be removed as well by this action
@@ -158,15 +164,15 @@ const RoomRanges = () => {
   };
 
   const onClickAssignPerson = () => {
-    if (selectedPerson && selectedRoomRange) {
+    if (selectedRA && selectedRoomRange) {
       const newRange = {
         Range_ID: selectedRoomRange,
-        RA_ID: selectedPerson,
+        RA_ID: selectedRA,
       };
 
       assignPersonToRange(newRange)
         .then(() => {
-          setSelectedPerson(null);
+          setSelectedRA(null);
           setSelectedRoomRange(null);
           fetchAssignmentList()
             .then((response) => setAssignments(response))
@@ -191,6 +197,10 @@ const RoomRanges = () => {
         createSnackbar('Error removing assignment: ' + error, 'error');
       });
   };
+
+  if (isLoading) {
+    return <GordonLoader />;
+  }
 
   return (
     <>
@@ -232,26 +242,17 @@ const RoomRanges = () => {
               <InputLabel id="Building">Building</InputLabel>
               <Select
                 label="Select building"
-                value={building}
+                value={selectedHall ?? ''}
                 onChange={(e) => {
-                  setBuilding(e.target.value);
+                  setSelectedHall(e.target.value);
                   fetchRaList(e.target.value);
                 }}
                 fullWidth
                 margin="normal"
               >
-                <MenuItem value="BRO">Bromley</MenuItem>
-                <MenuItem value="FER">Ferrin</MenuItem>
-                <MenuItem value="EVN">Evans</MenuItem>
-                <MenuItem value="WIL">Wilson</MenuItem>
-                <MenuItem value="CHA">Chase</MenuItem>
-                <MenuItem value="TAV">Tavilla</MenuItem>
-                <MenuItem value="FUL">Fulton</MenuItem>
-                <MenuItem value="NYL">Nyland</MenuItem>
-                <MenuItem value="GRA">Grace</MenuItem>
-                <MenuItem value="MCI">MacInnis</MenuItem>
-                <MenuItem value="CON">Conrad</MenuItem>
-                <MenuItem value="RID">Rider</MenuItem>
+                {allHalls.map(({ Name, BuildingCode }) => (
+                  <MenuItem value={BuildingCode}>{Name}</MenuItem>
+                ))}
               </Select>
             </FormControl>
           </CardContent>
@@ -299,51 +300,49 @@ const RoomRanges = () => {
           <CardContent>
             <Typography variant="h6">Room Ranges</Typography>
             <List>
-              {showList ? (
-                filteredRoomRanges.length > 0 ? (
-                  filteredRoomRanges.map((range) => (
-                    <ListItem
-                      key={range.Range_ID}
-                      onClick={() => setSelectedRoomRange(range.Range_ID)}
-                      sx={{
-                        cursor: 'pointer',
-                        backgroundColor:
-                          selectedRoomRange === range.Range_ID ? 'primary.main' : 'transparent',
-                        '&:hover': {
-                          textDecoration: 'none',
-                          backgroundColor: 'primary.main',
-                          color: 'white',
-                          '@media (hover: none)': {
-                            backgroundColor: 'transparent',
-                            color: 'inherit',
-                          },
+              {isLoading ? (
+                <ListItem>Loading room ranges...</ListItem>
+              ) : filteredRoomRanges.length > 0 ? (
+                filteredRoomRanges.map((range) => (
+                  <ListItem
+                    key={range.Range_ID}
+                    onClick={() => setSelectedRoomRange(range.Range_ID)}
+                    sx={{
+                      cursor: 'pointer',
+                      backgroundColor:
+                        selectedRoomRange === range.Range_ID ? 'primary.main' : 'transparent',
+                      '&:hover': {
+                        textDecoration: 'none',
+                        backgroundColor: 'primary.main',
+                        color: 'white',
+                        '@media (hover: none)': {
+                          backgroundColor: 'transparent',
+                          color: 'inherit',
                         },
+                      },
+                    }}
+                  >
+                    <Box>
+                      {range.Hall_ID}: {range.Room_Start} - {range.Room_End}
+                    </Box>
+                    <Button
+                      variant="outlined"
+                      color="secondary"
+                      size="small"
+                      sx={{ ml: 1 }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onClickRemoveRoomRange(range.Range_ID);
                       }}
                     >
-                      <Box>
-                        {range.Hall_ID}: {range.Room_Start} - {range.Room_End}
-                      </Box>
-                      <Button
-                        variant="outlined"
-                        color="secondary"
-                        size="small"
-                        sx={{ ml: 1 }}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onClickRemoveRoomRange(range.Range_ID);
-                        }}
-                      >
-                        Remove
-                      </Button>
-                    </ListItem>
-                  ))
-                ) : (
-                  <ListItem style={{ color: '#9cb0b6' }}>
-                    Please select a building to see the list of Room Ranges.
+                      Remove
+                    </Button>
                   </ListItem>
-                )
+                ))
               ) : (
-                <ListItem>Loading room ranges...</ListItem>
+                <ListItem style={{ color: '#9cb0b6' }}>
+                  Please select a building to see the list of Room Ranges.
+                </ListItem>
               )}
             </List>
           </CardContent>
@@ -354,21 +353,20 @@ const RoomRanges = () => {
           <CardContent>
             <Typography variant="h6">Assign Person</Typography>
             <List>
-              {filteredPeople.length > 0 ? (
+              {filteredRAs.length > 0 ? (
                 <>
                   <Typography variant="body1" gutterBottom style={{ color: '#9cb0b6' }}>
                     Select a room range and a person, then click "Assign Person" to add them to the
                     room assignments list below.
                   </Typography>
-                  {filteredPeople.map((person) => (
+                  {filteredRAs.map((person) => (
                     <ListItem
                       key={person.ID}
-                      onClick={() => setSelectedPerson(person.ID)}
+                      onClick={() => setSelectedRA(person.ID)}
                       sx={{
                         cursor: 'pointer',
-                        backgroundColor:
-                          selectedPerson === person.ID ? 'primary.main' : 'transparent',
-                        color: selectedPerson === person.ID ? 'white' : 'inherit',
+                        backgroundColor: selectedRA === person.ID ? 'primary.main' : 'transparent',
+                        color: selectedRA === person.ID ? 'white' : 'inherit',
                         '&:hover': {
                           textDecoration: 'none',
                           backgroundColor: 'primary.main',

--- a/src/views/ResLife/components/RDView/components/TaskList/index.jsx
+++ b/src/views/ResLife/components/RDView/components/TaskList/index.jsx
@@ -11,7 +11,6 @@ import {
   CardContent,
   Typography,
   Grid,
-  Box,
   FormControlLabel,
 } from '@mui/material';
 import { addTask, updateTask, fetchTasks, removeTask } from 'services/residentLife/RD_TaskList';
@@ -19,11 +18,13 @@ import { useColorScheme } from '@mui/material/styles';
 import SimpleSnackbar from 'components/Snackbar';
 import { useNavigate } from 'react-router';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { getAllHalls } from 'services/residentLife/halls';
 
 const TaskList = () => {
   const { mode } = useColorScheme();
-  const [tasks, setTasks] = useState([]);
+  const [allHalls, setAllHalls] = useState([]);
   const [selectedHall, setSelectedHall] = useState('');
+  const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(false);
   const [editing, setEditing] = useState(false);
   const navigate = useNavigate();
@@ -54,6 +55,16 @@ const TaskList = () => {
     Start_Date: '',
     End_Date: '',
   });
+
+  useEffect(() => {
+    getAllHalls()
+      .then(setAllHalls)
+      .catch((error) => {
+        console.error('Error loading halls: ' + error);
+        setSnackbar('There was a problem loading halls: ' + error, 'error');
+      })
+      .finally(() => setLoading(false));
+  }, []);
 
   // UseEffect - Immediately runs `loadTasks`
   useEffect(() => {
@@ -227,21 +238,6 @@ const TaskList = () => {
     setEditing(false);
   };
 
-  const hallDisplayNames = {
-    BRO: 'Bromley',
-    FER: 'Ferrin',
-    WIL: 'Wilson',
-    EVN: 'Evans',
-    CHA: 'Chase',
-    TAV: 'Tavilla',
-    NYL: 'Nyland',
-    FUL: 'Fulton',
-    GRA: 'Grace',
-    MCI: 'MacInnis',
-    CON: 'Conrad',
-    RID: 'Rider',
-  };
-
   return (
     <>
       <Grid container spacing={3} justifyContent="center">
@@ -278,18 +274,9 @@ const TaskList = () => {
           </Typography>
           <FormControl fullWidth>
             <Select value={selectedHall} onChange={(e) => setSelectedHall(e.target.value)}>
-              <MenuItem value="BRO">Bromley</MenuItem>
-              <MenuItem value="FER">Ferrin</MenuItem>
-              <MenuItem value="EVN">Evans</MenuItem>
-              <MenuItem value="WIL">Wilson</MenuItem>
-              <MenuItem value="CHA">Chase</MenuItem>
-              <MenuItem value="TAV">Tavilla</MenuItem>
-              <MenuItem value="FUL">Fulton</MenuItem>
-              <MenuItem value="NYL">Nyland</MenuItem>
-              <MenuItem value="GRA">Grace</MenuItem>
-              <MenuItem value="MCI">MacInnis</MenuItem>
-              <MenuItem value="CON">Conrad</MenuItem>
-              <MenuItem value="RID">Rider</MenuItem>
+              {allHalls.map((hall) => (
+                <MenuItem value={hall.BuildingCode}>{hall.Name}</MenuItem>
+              ))}
             </Select>
           </FormControl>
         </Grid>
@@ -422,7 +409,8 @@ const TaskList = () => {
           <Card>
             <CardContent>
               <Typography variant="h5" fontWeight="bold" gutterBottom>
-                Task List ({hallDisplayNames[selectedHall] || selectedHall})
+                Task List (
+                {allHalls.find((hall) => hall.BuildingCode === selectedHall)?.Name || selectedHall})
               </Typography>
               {loading ? (
                 <Typography color="textSecondary">Loading tasks...</Typography>

--- a/src/views/ResLife/components/ResidentView/components/MyHall/index.jsx
+++ b/src/views/ResLife/components/ResidentView/components/MyHall/index.jsx
@@ -46,7 +46,7 @@ const MyHall = () => {
   const [hallPhoto, setHallPhoto] = useState('');
   const [hallPhotoAlt, setHallPhotoAlt] = useState('');
   const { profile } = useUser();
-  const isRA = useAuthGroups(AuthGroup.ResidentAdvisor);
+  const isRA = true;
   const isMobile = useMediaQuery('(max-width:600px)');
 
   useEffect(() => {
@@ -57,8 +57,6 @@ const MyHall = () => {
         image: COLOR_80808026_1X1,
         alt: 'Default Hall',
       };
-
-      console.log(ferrinHallMascot);
 
       // Create map to store hall images and hall image alts
       const hallData = {
@@ -72,6 +70,7 @@ const MyHall = () => {
         WIL: { image: wilsonHallMascot, alt: 'Wilson Horses' },
         CON: { image: villageHallMascot, alt: 'Village Deers' },
         GRA: { image: villageHallMascot, alt: 'Village Deers' },
+        HIL: { image: villageHallMascot, alt: 'Village Deers' },
         MCI: { image: villageHallMascot, alt: 'Village Deers' },
         RID: { image: villageHallMascot, alt: 'Village Deers' },
       };

--- a/src/views/ResLife/index.jsx
+++ b/src/views/ResLife/index.jsx
@@ -15,6 +15,7 @@ import RoomRanges from 'views/ResLife/components/RDView/components/RoomRanges';
 import TaskList from 'views/ResLife/components/RDView/components/TaskList';
 import RDOnCallForm from 'views/ResLife/components/RDView/components/RDOnCallForm';
 import StatusManager from 'views/ResLife/components/RAView/components/StatusManager';
+import GordonUnauthenticated from 'components/GordonUnauthenticated';
 
 const Housing = () => {
   const [HousingAccess, setCanAccessHousing] = useState(false);
@@ -85,6 +86,8 @@ const Housing = () => {
             <ResidentView />
           ) : hasStandardAccess ? (
             <StaffView />
+          ) : !isAuthenticated ? (
+            <GordonUnauthenticated feature="Residence Life" />
           ) : (
             <Page404 />
           )


### PR DESCRIPTION
This PR updates the Residence Life pages to fetch the list of residence halls from the database, instead of hardcoding the hall data in the frontend.

The one exception where residence halls are still hardcoded is the MyHall component, because the image for each hall is bundled into the frontend instead of being stored in the database. The long-term solution would be to let Res Life admins maintain a table of residence halls (probably pulling from the canonical building data in our SIS). Specifically, they should be able to decide which buildings should be treated as halls, as well as set the image associated with each hall. This is a bigger change than I was comfortable making at this time.

I also did some minor refactoring of the pages I updated, mostly focused on simpler and more performant data fetching and state updates.